### PR TITLE
security: fix py/path-injection in reliability-service ML model paths + postcss override

### DIFF
--- a/api/reliability-service/ml/anomaly_model.py
+++ b/api/reliability-service/ml/anomaly_model.py
@@ -75,8 +75,15 @@ class AnomalyDetectionModel:
     
     def save(self, filepath: str) -> None:
         """Persist the trained model to disk."""
-        os.makedirs(os.path.dirname(filepath), exist_ok=True)
-        with open(filepath, "wb") as f:
+        # Guard against path traversal: ``filepath`` is derived from a
+        # user-provided monitor id upstream, so the resolved path must stay
+        # inside the fixed model directory.
+        base_dir = os.path.realpath("ml/models")
+        real_path = os.path.realpath(filepath)
+        if not real_path.startswith(base_dir + os.sep):
+            raise ValueError(f"Refusing to save model outside {base_dir}: {filepath!r}")
+        os.makedirs(os.path.dirname(real_path), exist_ok=True)
+        with open(real_path, "wb") as f:
             pickle.dump(self.model, f)
         logger.info(f"Model saved to {filepath}")
     

--- a/api/reliability-service/ml/model_manager.py
+++ b/api/reliability-service/ml/model_manager.py
@@ -7,6 +7,7 @@ historical data or fall back to heuristic detection.
 
 import logging
 import os
+import re
 from pathlib import Path
 from typing import Optional
 
@@ -15,6 +16,38 @@ from ml.feature_transformer import FeatureTransformer
 from ml.anomaly_model import AnomalyDetectionModel
 
 logger = logging.getLogger(__name__)
+
+# Model artifacts live under this fixed directory. Monitor IDs are used to build
+# file names inside it, so they must be validated to prevent path traversal.
+MODEL_DIR = Path("ml/models")
+_MONITOR_ID_RE = re.compile(r"[A-Za-z0-9_-]+")
+
+
+def resolve_model_paths(monitor_id: str) -> tuple[Path, Path]:
+    """
+    Validate ``monitor_id`` and return safe (model_path, transformer_path)
+    located inside :data:`MODEL_DIR`.
+
+    ``monitor_id`` originates from a user-controlled request value, so it is
+    restricted to ``[A-Za-z0-9_-]`` and the resolved paths are verified to stay
+    within ``MODEL_DIR`` to defend against path traversal.
+
+    Raises:
+        ValueError: if ``monitor_id`` is not a safe identifier or the resulting
+            path would escape ``MODEL_DIR``.
+    """
+    if not isinstance(monitor_id, str) or not _MONITOR_ID_RE.fullmatch(monitor_id):
+        raise ValueError(f"Invalid monitor_id: {monitor_id!r}")
+
+    model_path = MODEL_DIR / f"{monitor_id}_anomaly_model.pkl"
+    transformer_path = MODEL_DIR / f"{monitor_id}_transformer.pkl"
+
+    base = os.path.realpath(MODEL_DIR)
+    for path in (model_path, transformer_path):
+        if not os.path.realpath(path).startswith(base + os.sep):
+            raise ValueError(f"Invalid monitor_id path: {monitor_id!r}")
+
+    return model_path, transformer_path
 
 
 def ensure_model_exists(monitor_id: str) -> bool:
@@ -26,9 +59,12 @@ def ensure_model_exists(monitor_id: str) -> bool:
         True if model exists or was successfully trained
         False if no training data available
     """
-    model_dir = Path("ml/models")
-    model_path = model_dir / f"{monitor_id}_anomaly_model.pkl"
-    transformer_path = model_dir / f"{monitor_id}_transformer.pkl"
+    try:
+        model_path, transformer_path = resolve_model_paths(monitor_id)
+    except ValueError as e:
+        logger.error(f"Refusing to build model path for monitor: {e}")
+        return False
+    model_dir = model_path.parent
     
     # Model already exists
     if model_path.exists() and transformer_path.exists():
@@ -86,9 +122,16 @@ def model_status(monitor_id: str) -> dict:
             "message": str
         }
     """
-    model_dir = Path("ml/models")
-    model_path = model_dir / f"{monitor_id}_anomaly_model.pkl"
-    transformer_path = model_dir / f"{monitor_id}_transformer.pkl"
+    try:
+        model_path, transformer_path = resolve_model_paths(monitor_id)
+    except ValueError as e:
+        logger.error(f"Refusing to build model path for monitor: {e}")
+        return {
+            "monitor_id": monitor_id,
+            "model_exists": False,
+            "can_infer": False,
+            "message": "Invalid monitor_id",
+        }
     
     model_exists = model_path.exists() and transformer_path.exists()
     

--- a/api/reliability-service/services/ml_anomaly_detector.py
+++ b/api/reliability-service/services/ml_anomaly_detector.py
@@ -1,11 +1,10 @@
 import os
 import pickle
 import logging
-from pathlib import Path
 import numpy as np
 from dataclasses import asdict, is_dataclass
 
-from ml.model_manager import ensure_model_exists
+from ml.model_manager import ensure_model_exists, resolve_model_paths
 
 logger = logging.getLogger(__name__)
 
@@ -29,9 +28,11 @@ class MLAnomalyDetector:
     
     def _load_model(self):
         """Load model and transformer from disk, if they exist. Attempt to train if missing."""
-        model_dir = Path("ml/models")
-        model_path = model_dir / f"{self.monitor_id}_anomaly_model.pkl"
-        transformer_path = model_dir / f"{self.monitor_id}_transformer.pkl"
+        try:
+            model_path, transformer_path = resolve_model_paths(self.monitor_id)
+        except ValueError as e:
+            logger.error(f"Refusing to load model: {e}")
+            return False
         
         # Try to ensure model exists (train if necessary)
         if not ensure_model_exists(self.monitor_id):

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -5098,34 +5098,6 @@
         }
       }
     },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "node_modules/node-exports-info": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
@@ -5416,10 +5388,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
-      "dev": true,
+      "version": "8.5.17",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.17.tgz",
+      "integrity": "sha512-J7EF+8X+CzRPaJPOv9Ck2wNWJvGnnl3PcNPAdGg6GTLjyVpyQ0yATMSXRFRV01BviT/9Gwuc3rjEyJbDJG9a4w==",
       "funding": [
         {
           "type": "opencollective",

--- a/web/package.json
+++ b/web/package.json
@@ -22,5 +22,8 @@
     "eslint-config-next": "16.2.6",
     "tailwindcss": "^4",
     "typescript": "^5"
+  },
+  "overrides": {
+    "postcss": "^8.5.10"
   }
 }


### PR DESCRIPTION
## Summary

Fixes CodeQL **py/path-injection** alerts in the Python reliability service and remediates the live **postcss** Dependabot alert in `web/`. All changes are minimal and behavior-preserving for legitimate inputs.

### Path injection (path traversal + arbitrary file R/W; pickle is also an RCE sink)

`monitor_id` reaches the model-file sinks from user-controlled sources — FastAPI path params (`/insights/{monitor_id}`, `/analyze/{monitor_id}`) and the gRPC `request.monitor_id` field — and was interpolated straight into `ml/models/{monitor_id}_*.pkl` paths that are then `open()`ed / `pickle`-loaded / written.

**Fix pattern:** validate the id against a strict allowlist and confirm the resolved real path stays inside the fixed `ml/models` base dir.

| File | Site(s) | Change |
|------|---------|--------|
| `api/reliability-service/ml/model_manager.py` | :34 (x2), :66 | New `resolve_model_paths()` helper: rejects any id not matching `re.fullmatch(r"[A-Za-z0-9_-]+")` and verifies `os.path.realpath(path)` starts with `realpath(ml/models) + os.sep`. Used in `ensure_model_exists()` and `model_status()`. |
| `api/reliability-service/services/ml_anomaly_detector.py` | :45, :47 | `_load_model()` builds paths via `resolve_model_paths()`, so invalid ids are rejected before any pickle file is opened (falls back gracefully). |
| `api/reliability-service/ml/anomaly_model.py` | :78, :79 | `AnomalyDetectionModel.save()` verifies the resolved path is inside `ml/models` before `makedirs`/`open`. |

Legitimate ids (e.g. Mongo ObjectIDs like `6a2c342367d7434a69e89a63`) are unaffected; traversal/invalid ids (`../`, `/`, `.`, embedded newlines, non-str, etc.) are rejected. Validated with a standalone test of the exact sanitizer logic. Every edited file passes `python3 -m py_compile`.

### postcss (Dependabot: GHSA-qx2v-qp2m-jg93, moderate)

`next@16.2.9` bundled a nested `node_modules/next/node_modules/postcss@8.4.31` (`<8.5.10`, XSS via unescaped `</style>`). Added an `overrides.postcss: ^8.5.10` to `web/package.json` and regenerated `web/package-lock.json` (`--package-lock-only --legacy-peer-deps`). The nested vulnerable copy is gone and `npm audit --package-lock-only` now reports **0 vulnerabilities**. `web/.deprecated/` was not touched.

## Notes
- upstat has no working CI, so this was verified locally: `py_compile` on all 3 Python files, a standalone unit test of the sanitizer logic, and `npm audit` (0 vulns).

🤖 Generated with [Claude Code](https://claude.com/claude-code)