### PR TITLE
chore: finish observability rename in app code

### DIFF
--- a/api/common/cmd/make_service_token/main.go
+++ b/api/common/cmd/make_service_token/main.go
@@ -8,8 +8,8 @@ import (
 )
 
 func main() {
-    userId := "service-reliability"
-    email := "reliability-service@local"
+    userId := "service-observability"
+    email := "observability@local"
     if len(os.Args) >= 2 {
         userId = os.Args[1]
     }

--- a/api/observability/main.py
+++ b/api/observability/main.py
@@ -11,7 +11,7 @@ logging.basicConfig(
     level=logging.INFO,
     format="[%(asctime)s] %(levelname)s %(name)s: %(message)s",
 )
-logger = logging.getLogger("reliability-service")
+logger = logging.getLogger("observability")
 
 load_env_file()
 
@@ -27,7 +27,7 @@ def _grpc_enabled() -> bool:
 
 @app.on_event("startup")
 def startup_event():
-    logger.info("Starting reliability-service")
+    logger.info("Starting observability")
     logger.info(f"UPSTAT_GRPC_ADDRESS={os.getenv('UPSTAT_GRPC_ADDRESS', '<unset>')}")
     logger.info(f"UPSTAT_GRPC_AUTH_TOKEN set={bool(os.getenv('UPSTAT_GRPC_AUTH_TOKEN'))}")
 


### PR DESCRIPTION
Updates the last two `reliability-service` leftovers (service-token identity default + FastAPI logger name) to `observability`. Safe — the token email is a non-validated claim; the logger name is cosmetic.