### PR TITLE
docs: PRD breakdown — requirements, target architecture, data model, API, roadmap

### DIFF
--- a/docs/analytics-math.md
+++ b/docs/analytics-math.md
@@ -1,0 +1,88 @@
+# Upstat — Analytics Math Contract (events → rollups → stats)
+
+> The exact math behind the events layer (M2/M3, decisions U-2/U-3/U-6):
+> visitor hashing, sessionization, rollups, uniques, and the honesty rules
+> for what the UI may claim. Complements flows/monitor.md (uptime math lives
+> there) and query-grammar.md.
+
+## 1. Visitor hash (U-3, normative)
+
+```
+visitor_hash = hex( SHA-256( daily_salt ‖ property_id ‖ ip ‖ user_agent ) )[:32]
+```
+
+- `daily_salt`: 32 random bytes, rotated at 00:00 UTC, **previous salts
+  destroyed** — cross-day linkage is cryptographically dead, which is the
+  privacy guarantee UPS-005 publishes.
+- `ip` is used pre-hash only; never stored. Proxied requests use the
+  left-most public address in `X-Forwarded-For` as seen by our LB.
+- Consequences (documented, not hidden): the same person counts anew each
+  day; shared NAT + identical UA under-counts; UA changes over-count.
+  That's the cookieless trade and we say so.
+
+## 2. Sessionization (derived, not stored per-event)
+
+A *visit* = consecutive events with the same `visitor_hash` on one property
+with gaps < 30 min (industry-standard heuristic). Computed inside the rollup
+job, producing per-bucket: `visits`, `bounce_visits` (single-page-view
+visits), `total_visit_seconds` (sum of last-event − first-event per visit;
+zero for bounces). Derived UI metrics:
+
+| Metric | Formula | Honesty note |
+| --- | --- | --- |
+| Bounce rate | bounce_visits ÷ visits | undefined (—) when visits = 0 |
+| Avg. visit duration | total_visit_seconds ÷ (visits − bounce_visits) | bounces excluded; label says "engaged visits" |
+| Pages / visit | page_view count ÷ visits | |
+
+## 3. Rollups
+
+Hourly job (observability service) aggregates raw events into `ROLLUP` rows
+keyed `(property, period, bucket, name, dims)`:
+
+- `count` = exact event count.
+- `uniques` = **exact** `COUNT(DISTINCT visitor_hash)` within the bucket
+  (volumes make exact feasible; no sketches in v1).
+- Daily rollups aggregate from raw events (not from hourly rollups) so daily
+  uniques are exact for the day.
+- Idempotent upserts: the job recomputes the trailing 48h of buckets every
+  run — late events (batched beacons, clock skew ≤ ingest-time bounding)
+  self-heal; buckets older than 48h are immutable.
+
+## 4. Uniques across ranges (the non-additivity rule)
+
+`Σ uniques(day)` over-counts multi-day visitors — but cross-day linkage is
+deliberately impossible (§1), so **cross-day "unique visitors" does not
+exist in this product**. Normative UI rules:
+
+| Range | What "uniques" shows |
+| --- | --- |
+| ≤ 1 day | the day's exact uniques |
+| Multi-day | *daily-average uniques* (labeled exactly that) + the per-day series; never a summed "total uniques" |
+
+Any chart or API consumer summing uniques across buckets is wrong by
+specification — `/v1/stats` returns `uniques_additive: false` in range
+metadata to make the contract machine-visible.
+
+## 5. Ingest-time bounding
+
+Events accept client `ts` within `[now − 48h, now + 5min]`; outside →
+rejected (`422 ts-out-of-range`, counted in the property's rejected
+counter). The 48h floor matches the rollup self-heal window — nothing
+accepted can land in an immutable bucket.
+
+## 6. Rate limits & rejection accounting
+
+Per property key: 600 events/min sustained, burst 1,200 **[Decided
+defaults]**; over-limit → `429` with `Retry-After`. All rejections
+(schema, origin, rate, ts) increment per-property `rejected{reason}`
+counters visible in property settings — silent data loss is not acceptable
+even for rejected data.
+
+## 7. Acceptance
+
+- [ ] Salt rotation proven: same visitor, consecutive days → different hashes; same day → stable
+- [ ] Raw IP/UA absent from every stored row and log line (grep-proven)
+- [ ] Rollup idempotency: re-running the job changes nothing for settled buckets
+- [ ] Late event within 48h lands correctly; outside window rejected + counted
+- [ ] Multi-day stats responses carry `uniques_additive: false`; UI shows daily-average labeling
+- [ ] Bounce/duration formulas match fixtures incl. zero-visit buckets

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,117 @@
+# Upstat — API Surface
+
+> Current surface verified against `internal/proto/*.proto` and the web app.
+> The full gRPC reference lives in
+> [api/common/docs/grpc-api.md](../api/common/docs/grpc-api.md) — this file
+> maps it to the PRD and defines the target additions. Markers: **[Current]**,
+> **[PRD]**, **[Proposed]**.
+
+## 1. Current surface **[Current]**
+
+### gRPC (api/common :8080, h2c; browsers via Envoy gRPC-Web :8082)
+
+| Service | RPCs | Auth |
+| --- | --- | --- |
+| `UserService` | GetUser, GoogleAuth, CreateUser, UpdateUser, DeleteUser, GetAllUsers | CreateUser/GetUser/GoogleAuth public; rest JWT |
+| `MonitorService` | CreateMonitor, UpdateMonitor, GetMonitor, ListMonitors, DeleteMonitor, GetStatusPage, GetRecentChecks | GetStatusPage + GetRecentChecks public; rest JWT (owner from token) |
+| `InsightService` (served by api/observability :50051, consumed by api/common) | GetMonitorInsight | service-token |
+
+### HTTP
+
+| Endpoint | Notes |
+| --- | --- |
+| `GET /health`, `GET /ready` (both services) | probes |
+| `GET /insights/{monitor_id}`, `POST /analyze/{monitor_id}` (observability :8081) | insight read/trigger |
+| `web /api/dashboard/stats`, `/api/dashboard/total-users` | **mock data** — scaffolding to be replaced (ANA-002), not product surface |
+
+## 2. Target surface — monitors & alerts **[Proposed]**
+
+Monitors stay gRPC (working, typed, already browser-reachable via Envoy).
+Additions:
+
+| Service / RPC | Purpose |
+| --- | --- |
+| `AlertService.CreateChannel / ListChannels / VerifyChannel / DeleteChannel` | email/webhook channels (MON-001) |
+| `AlertService.SetRules / GetRules` | per-monitor rules (on: down/recovered, cooldown) |
+
+## 3. Target surface — events & stats (M2/M3, the ecosystem "D2" contract) **[Proposed]**
+
+Plain HTTP/JSON — browser beacons can't speak gRPC and sibling servers
+shouldn't need proto toolchains for two counters.
+
+### 3.1 Ingestion
+
+```
+POST /v1/events
+Authorization: Bearer <property_public_key>     (write-only key)
+Origin: enforced against the property allowlist  (browser calls)
+
+{
+  "events": [
+    {
+      "name": "page_view" | "demo_start" | "github_click"
+              | "upload_success" | "report_generation" | <registered name>,
+      "ts": "2026-07-15T12:00:00Z",          // optional, server default now()
+      "dims": {                               // closed vocabulary, all optional
+        "path": "/pricing",
+        "referrer_host": "google.com",
+        "device_class": "mobile" | "desktop" | "tablet",
+        "country": "NG"
+      }
+    }
+  ]
+}
+→ 202 {accepted: n, rejected: m}
+```
+
+Rules: batch ≤ 100; unknown `dims` keys → event rejected (privacy by schema);
+per-key rate limits; `visitor_hash` computed server-side (cookieless).
+
+### 3.2 The tracking script (UPS-003 install surface)
+
+```html
+<script defer src="https://upstat.cuesoft.io/upstat.js"
+        data-property="pk_live_…"></script>
+<script>upstat("event", "demo_start")</script>
+```
+
+Auto page-views (incl. SPA history changes) + manual custom events.
+
+### 3.3 Stats query (dashboards + sibling products' own metric reads)
+
+```
+GET /v1/stats?property=…&name=page_view&period=day&from=…&to=…&dim=path
+Authorization: user JWT (owner) — not the public key
+→ {series: [{bucket, count, uniques}], totals: {…}}
+```
+
+### 3.4 Consumer registry (who sends what)
+
+| Consumer | Events | Constraint |
+| --- | --- | --- |
+| apparule web | `demo_start`, `github_click` | counters only |
+| expendit api | `upload_success`, `report_generation` | counters + `file_type`/`kind` dim only — never amounts/descriptions |
+| upstat itself | `page_view` on upstat.cuesoft.io | dogfooding (§5 reliability showcase) |
+
+New event names are registered per property (no free-form names) — keeps the
+schema-as-privacy-boundary enforceable.
+
+## 4. Gap analysis — requirement → current → needed
+
+| Requirement | Current | Gap |
+| --- | --- | --- |
+| UPS-001 landing | `/` exists; Figma design available | apply design + demo cards (web only) |
+| UPS-002 app entry | auth + dashboard work | CTAs; D1 later |
+| UPS-003 setup docs | self-host docs only | user guides for monitors/script/alerts/retention — after those features exist |
+| UPS-004 example cards | components exist | landing embed with demo data |
+| UPS-005 privacy | nothing | privacy page + D3 clause |
+| MON-001 alerts | status flips silently | AlertService + worker dispatch + channels |
+| ANA-001 ingestion + script | nothing | §3.1–3.2 |
+| ANA-002 real dashboards | mock routes | `/v1/stats` + traffic page rewire |
+| ECO-TRACK (D2) | nothing | §3 shipped = apparule/expendit unblocked |
+
+## 5. Conventions
+
+Shared ecosystem conventions (error envelope, pagination, idempotency) apply
+to the new HTTP surfaces exactly as written in apparule's api.md §4; gRPC
+error semantics stay as documented in grpc-api.md. **[Proposed]**

--- a/docs/api.md
+++ b/docs/api.md
@@ -115,3 +115,22 @@ schema-as-privacy-boundary enforceable.
 Shared ecosystem conventions (error envelope, pagination, idempotency) apply
 to the new HTTP surfaces exactly as written in apparule's api.md §4; gRPC
 error semantics stay as documented in grpc-api.md. **[Proposed]**
+
+---
+
+## 6. Observability platform surface (2026-07-16) **[Proposed]** — deltas
+
+| Group | Surface |
+| --- | --- |
+| Ingestion | OTLP/gRPC + OTLP/HTTP (`/v1/otlp/{traces,metrics,logs}`), authn `Upstat-Ingest-Key`; StatsD UDP/TCP shim; existing `/v1/events` + vitals payloads (RUM SDK) |
+| Query | `POST /v1/query` (shared grammar → timeseries/log/trace results; powers explorers, dashboards, monitor evaluator) |
+| Dashboards | CRUD + portable JSON import/export |
+| Monitors | rule CRUD (signal-generic), `POST /v1/monitors/{id}/test` (24h replay), triggered-feed |
+| Incidents | declare/update/resolve, timeline entries, postmortem attach |
+| SLOs | CRUD + status/burn endpoints |
+| Service catalog | CRUD + telemetry-presence summary |
+| Keys | ingest-key CRUD with scopes/quotas |
+
+gRPC remains for the existing user/monitor control plane; all new surfaces
+are HTTP/JSON (ecosystem conventions). RUM/browser SDK (`upstat.js`) extends
+the Phase-1 script with web-vitals + error capture — same property keys.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -113,3 +113,114 @@ flowchart LR
 - The Go backend owns monitor state and check execution, making it the authoritative source for recent monitor health.
 - The Python service owns analytics and machine learning, consuming the Go service via a clear gRPC interface.
 - The system separates operational monitoring from analysis, which is the key architectural boundary.
+
+---
+
+# Target architecture (PRD phase)
+
+> Everything above documents the system as it exists. This section adds the
+> PRD-driven target design. Markers: **[PRD]** = stated requirement,
+> **[Proposed]** = design decision for ratification. See [prd.md](prd.md) for
+> the requirement register (M1 monitoring / M2 analytics / M3 ecosystem
+> tracking).
+
+## Target context
+
+```mermaid
+flowchart LR
+    subgraph Monitored & tracked
+        SITE[Customer websites<br/>tracking script]
+        SIB[Sibling products<br/>apparule, expendit servers]
+        TGT[Monitored targets<br/>HTTP endpoints]
+    end
+
+    subgraph upstat.cuesoft.io
+        LAND[Landing<br/>Figma design, demo cards]
+        DASH[Dashboard<br/>monitors + real analytics]
+        STATUS[Public status pages]
+    end
+
+    subgraph Backend
+        ING[Event ingestion<br/>HTTP, property-key authed]
+        GO[api/common Go<br/>monitors, users, alerts]
+        OBS[api/observability Python<br/>insights, rollup worker]
+        MG[(MongoDB<br/>+ TTL retention)]
+        CH[Alert channels<br/>email, webhook]
+    end
+
+    SITE -->|page_view beacons| ING
+    SIB -->|server-side events| ING
+    GO -->|scheduled checks| TGT
+    ING --> MG
+    OBS -->|hourly/daily rollups| MG
+    GO -->|state change| CH
+    DASH --> GO
+    DASH -->|stats queries| ING
+    STATUS --> GO
+```
+
+## The events layer (M2 + M3) **[Proposed]**
+
+This is the design for what sibling roadmaps call **dependency D2** — Upstat
+as the ecosystem's standardized event tracker **[PRD §4.2]**.
+
+- **Ingestion**: `POST /v1/events` — plain HTTP/JSON (browser `sendBeacon`
+  compatible), authenticated by a *write-only property key* + origin
+  allowlist + rate limiting. Payloads validate against a closed schema
+  (name + coarse dims only) so sensitive data is rejected structurally
+  (data-model.md §2).
+- **Tracking script**: `upstat.js` — a few KB, cookieless; auto page-views on
+  history changes + `upstat("event", "demo_start")` for custom events.
+- **Aggregation**: the observability service gains a rollup worker (hour/day
+  buckets, approximate uniques via the daily-rotating `visitor_hash`).
+  Dashboards and the stats API read rollups, never raw events.
+- **Dashboards**: the existing traffic page moves from mock
+  `/api/dashboard/*` routes onto `GET /v1/stats` (ANA-002); bounce/SEO/
+  page-load pages follow only where honest data exists (prd.md §4).
+
+```mermaid
+sequenceDiagram
+    participant B as Browser (customer site)
+    participant I as POST /v1/events
+    participant M as MongoDB
+    participant R as Rollup worker (observability)
+    participant D as Dashboard
+
+    B->>I: sendBeacon {property_key, name: page_view, dims}
+    I->>I: key + origin + schema + rate checks
+    I->>M: insert EVENT (TTL 90d)
+    R->>M: hourly: aggregate events → ROLLUP upserts
+    D->>I: GET /v1/stats?property&period&name
+    I->>M: read ROLLUP
+    I-->>D: series + uniques
+```
+
+## Alerting (MON-001) **[Proposed]**
+
+The monitor worker already tracks `consecutiveFailures` vs `failureThreshold`
+and flips `status` — alerting hooks that transition:
+
+```mermaid
+sequenceDiagram
+    participant W as Monitor worker (Go)
+    participant M as MongoDB
+    participant CH as Channel (email/webhook)
+
+    W->>W: check fails, threshold crossed → status: down
+    W->>M: load ALERT_RULEs for monitor (+cooldown state)
+    alt rule matches "down" and not cooling down
+        W->>CH: dispatch (template: monitor, target, since, last error)
+        W->>M: record dispatch time (cooldown)
+    end
+    W->>W: later: recovery → status: up
+    W->>CH: "recovered" per rule
+```
+
+Email provider is an open decision (prd.md §8.2); webhooks are
+provider-independent and may ship first if the email decision stalls.
+
+## Non-goals guardrail
+
+Per PRD §5, the target explicitly excludes APM/tracing/log aggregation and
+session replay. Any feature request in those directions re-opens the PRD
+rather than growing scope silently.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -224,3 +224,66 @@ provider-independent and may ship first if the email decision stalls.
 Per PRD §5, the target explicitly excludes APM/tracing/log aggregation and
 session replay. Any feature request in those directions re-opens the PRD
 rather than growing scope silently.
+
+---
+
+# Observability platform expansion (2026-07-16) **[Directive]**
+
+> Supersedes the "Non-goals guardrail" above and the PRD §5 restraint: Upstat
+> now targets a **full observability & SRE platform** (Datadog-class) —
+> pillars in [pages.md](pages.md). The events layer and alerting designed
+> above stand unchanged; they become the RUM pillar's foundation and the
+> monitor engine respectively.
+
+## Ingestion architecture **[Proposed]**
+
+**OpenTelemetry-native**: OTLP (gRPC + HTTP) is the single first-party intake
+for traces, metrics, and logs — customers use standard OTel SDKs/collectors,
+no proprietary agent to build or maintain. Complements: the existing HTTP
+events API + `upstat.js` (RUM), StatsD-compat shim (metrics), uptime checker
+(synthetics).
+
+```mermaid
+flowchart LR
+    subgraph Customer
+        SDK[OTel SDKs] --> COL[OTel Collector]
+        JS[upstat.js RUM]
+        AGENTLESS[StatsD apps]
+    end
+    COL -->|OTLP| GW[Ingestion gateway<br/>authn: org ingest keys,<br/>rate/quota, schema guard]
+    JS -->|/v1/events + vitals| GW
+    AGENTLESS -->|statsd shim| GW
+    GW --> BUF[[Buffer/queue]]
+    BUF --> TS[(Timeseries store<br/>metrics)]
+    BUF --> LS[(Column/log store<br/>logs + traces)]
+    BUF --> MG[(MongoDB<br/>control plane: orgs, monitors,<br/>dashboards, incidents, SLOs)]
+    TS --> Q[Query layer]
+    LS --> Q
+    MG --> Q
+    Q --> APP[Dashboards / explorers / monitors]
+```
+
+## The storage decision (gating, R2)
+
+MongoDB cannot serve high-cardinality timeseries or log search at platform
+scale. **Proposal: ClickHouse as the unified telemetry store** (metrics,
+logs, traces in columnar tables — the Signoz/HyperDX-proven pattern), with
+MongoDB retained solely as the control plane. Alternative split
+(VictoriaMetrics + OpenSearch) rejected for operational surface. Self-host
+compose gains one ClickHouse container; helm adds a StatefulSet or external
+endpoint — mirrors the existing "chart deploys no DB" stance. **[Ratify
+before OBS-001 implementation.]**
+
+## Query layer
+
+One internal query service translating the shared QueryBar grammar
+(design.md §3) to store-specific queries; all pillars and the monitor
+evaluator consume it — monitors are "saved queries + thresholds on a
+schedule", nothing pillar-specific.
+
+## Honesty stance for the build-out
+
+Pillars ship behind org-level feature flags; a pillar is not "available"
+until its explorer, retention, and monitor support all work. Marketing may
+list pillars as "early access" but the in-app empty states (MI-16) never
+pretend data exists. Sequencing in roadmap.md revision.

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -1,0 +1,163 @@
+# Upstat — Data Model
+
+> Companion to [prd.md](prd.md) / [architecture.md](architecture.md).
+> Markers: **[Current]**, **[PRD]**, **[Proposed]**.
+
+## 1. Current entities **[Current]** (MongoDB, database `Upstat`)
+
+```mermaid
+erDiagram
+    USER ||--o{ MONITOR : owns
+    MONITOR ||--o{ CHECK_RESULT : produces
+    MONITOR ||--o{ INCIDENT : "opens/closes"
+    MONITOR ||--o{ MONITOR_INSIGHT : "analyzed into"
+    SERVICE_TOKEN }o--|| USER : "issued for s2s"
+
+    USER {
+        objectid _id PK
+        string name
+        string email
+        string password_hash
+        datetime created_at
+    }
+    MONITOR {
+        objectid _id PK
+        string ownerId
+        string name
+        string target "URL"
+        string type "website | server | api | blog"
+        bool active
+        string status "up | down | ..."
+        int intervalSeconds
+        int timeoutSeconds
+        int failureThreshold
+        int consecutiveFailures
+        datetime lastCheckedAt
+        int lastResponseTimeMs
+        int lastStatusCode
+    }
+    CHECK_RESULT {
+        objectid _id PK
+        objectid monitor_id FK
+        bool up
+        int status_code
+        int response_time_ms
+        datetime checked_at
+    }
+    INCIDENT {
+        objectid _id PK
+        objectid monitor_id FK
+        datetime started_at
+        datetime resolved_at "null while open"
+        string cause
+    }
+    MONITOR_INSIGHT {
+        objectid _id PK
+        string monitor_id
+        float risk_score
+        string severity
+        json signals "failure/latency/trend analyses"
+        string narrative "LLM-rendered (Groq)"
+        datetime generated_at
+    }
+    SERVICE_TOKEN {
+        objectid _id PK
+        string name "e.g. observability"
+        string token_hash
+        datetime created_at
+    }
+```
+
+(Field lists are representative of `internal/model/*.go` + repository structs;
+insight shape comes from the observability service's generator.)
+
+## 2. Target additions **[Proposed]** — the analytics/events layer (M2/M3)
+
+```mermaid
+erDiagram
+    USER ||--o{ PROPERTY : owns
+    PROPERTY ||--o{ EVENT : receives
+    PROPERTY ||--o{ ROLLUP : "aggregated into"
+    MONITOR ||--o{ ALERT_RULE : "guarded by"
+    ALERT_RULE }o--o{ ALERT_CHANNEL : notifies
+
+    PROPERTY {
+        objectid _id PK
+        string ownerId
+        string name "e.g. apparule.cuesoft.io"
+        string public_key "write-only ingest key, rotatable"
+        json allowed_origins "CORS allowlist for beacons"
+        datetime created_at
+    }
+    EVENT {
+        objectid _id PK
+        objectid property_id FK
+        string name "page_view | demo_start | upload_success | ..."
+        json dims "coarse dimensions only: path, referrer_host, country, device_class"
+        datetime ts
+        string visitor_hash "daily-rotating anonymous hash, no cookie"
+    }
+    ROLLUP {
+        objectid _id PK
+        objectid property_id FK
+        string period "hour | day"
+        datetime bucket
+        string name
+        json dims
+        int count
+        int uniques "approx, from visitor_hash"
+    }
+    ALERT_RULE {
+        objectid _id PK
+        objectid monitor_id FK
+        string on "down | recovered | both"
+        int cooldown_minutes
+    }
+    ALERT_CHANNEL {
+        objectid _id PK
+        string ownerId
+        string kind "email | webhook"
+        json config "address / url + secret"
+        bool verified
+    }
+```
+
+Modeling notes:
+
+- **`EVENT.dims` is a closed, validated vocabulary** — the schema is the
+  privacy boundary (prd.md §6): free-form payloads are rejected at ingest so
+  sibling products *cannot* leak financial/measurement data into analytics
+  even by accident.
+- **`visitor_hash`**: cookieless uniques via
+  `hash(daily_salt, property, ip, user_agent)`; the salt rotates daily and raw
+  IPs are never stored. **[Proposed — the privacy-defining choice, ratify]**
+- **Rollups are the query surface**; raw `EVENT` rows exist to rebuild rollups
+  and are the first thing retention deletes.
+- **Alerting is monitor-scoped** with owner-scoped reusable channels; email
+  requires a provider decision (prd.md §8.2 — old SMTP plumbing was
+  deliberately removed and should return via one well-chosen provider).
+
+## 3. Storage mapping
+
+| Concern | Choice | Rationale |
+| --- | --- | --- |
+| Everything current | MongoDB (`Upstat` db) **[Current]** | as-is |
+| Events + rollups | MongoDB collections with TTL indexes **[Proposed]** | "lightweight architecture" (§5): no new datastore; TTL indexes give free retention enforcement; revisit only if volume demands it |
+| Alert dispatch state | Mongo (rule cooldown timestamps) | avoids a queue dependency at this scale |
+
+## 4. Retention & privacy **[Proposed defaults, to ratify + publish per UPS-003/005]**
+
+| Data | Retention | Notes |
+| --- | --- | --- |
+| Raw events | 90 days (TTL) | rollups carry the history |
+| Rollups (hour) | 90 days | day rollups cover longer horizons |
+| Rollups (day) | 13 months | year-over-year comparisons |
+| Check results | 90 days | insights summarize older history |
+| Incidents | indefinite | they are the historical record |
+| Visitor identifiers | never stored raw | `visitor_hash` only, daily-rotating |
+
+| Class | Data | Rules |
+| --- | --- | --- |
+| Visitor data | events, visitor_hash | cookieless, anonymized, no cross-property joins; disclosed on the privacy page (UPS-005) |
+| Customer data | monitors, targets, alert configs | targets may embed internal hostnames — treat as confidential |
+| Operational | checks, rollups, insights | safe for internal metrics |

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -141,9 +141,9 @@ Modeling notes:
 
 | Concern | Choice | Rationale |
 | --- | --- | --- |
-| Everything current | MongoDB (`Upstat` db) **[Current]** | as-is |
-| Events + rollups | MongoDB collections with TTL indexes **[Proposed]** | "lightweight architecture" (§5): no new datastore; TTL indexes give free retention enforcement; revisit only if volume demands it |
-| Alert dispatch state | Mongo (rule cooldown timestamps) | avoids a queue dependency at this scale |
+| Everything current | MongoDB (`Upstat` db) **[Current]** | as-is until the control-plane→**Postgres** migration (X-5, with the monitors-v2/OBS work) |
+| Events + rollups | Phase 1: control-plane store (**Postgres** partitioned tables + scheduled retention job, per X-5) | folds into **ClickHouse** when OBS-001 lands (U-1); the TTL-index shortcut died with the Mongo control plane |
+| Alert dispatch state | control-plane store (rule cooldown timestamps) | avoids a queue dependency at this scale |
 
 ## 4. Retention & privacy **[Proposed defaults, to ratify + publish per UPS-003/005]**
 

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -161,3 +161,68 @@ Modeling notes:
 | Visitor data | events, visitor_hash | cookieless, anonymized, no cross-property joins; disclosed on the privacy page (UPS-005) |
 | Customer data | monitors, targets, alert configs | targets may embed internal hostnames — treat as confidential |
 | Operational | checks, rollups, insights | safe for internal metrics |
+
+---
+
+## 5. Observability platform entities (2026-07-16) **[Proposed]**
+
+Control plane (MongoDB) additions:
+
+```mermaid
+erDiagram
+    ORG ||--o{ INGEST_KEY : issues
+    ORG ||--o{ DASHBOARD : owns
+    DASHBOARD ||--o{ WIDGET : arranges
+    ORG ||--o{ MONITOR_RULE : defines
+    MONITOR_RULE }o--o{ ALERT_CHANNEL : notifies
+    ORG ||--o{ SLO : tracks
+    ORG ||--o{ INCIDENT_V2 : manages
+    INCIDENT_V2 ||--o{ TIMELINE_ENTRY : logs
+    ORG ||--o{ SERVICE_ENTRY : catalogs
+
+    INGEST_KEY { objectid _id PK
+        objectid org_id FK
+        string scope "otlp|rum|statsd|all"
+        string key_hash
+        json quotas }
+    DASHBOARD { objectid _id PK
+        objectid org_id FK
+        string name
+        json layout "12-col grid"
+        json template_vars }
+    WIDGET { objectid _id PK
+        objectid dashboard_id FK
+        string type "timeseries|query_value|toplist|table|heatmap|logstream|slo|status|servicemap|markdown"
+        json query "shared grammar"
+        json viz_options }
+    MONITOR_RULE { objectid _id PK
+        objectid org_id FK
+        string signal "uptime|metric|log|trace|slo_burn"
+        json query
+        json thresholds "warn/crit + window"
+        json notify "channels, renotify, mute_windows" }
+    SLO { objectid _id PK
+        objectid org_id FK
+        string sli_source "check|metric_ratio|latency"
+        float target "e.g. 99.9"
+        string window "30d rolling" }
+    INCIDENT_V2 { objectid _id PK
+        objectid org_id FK
+        int sev "1..4"
+        string status "declared|mitigated|resolved"
+        json roles "commander, responders"
+        string postmortem_key }
+    SERVICE_ENTRY { objectid _id PK
+        objectid org_id FK
+        string name
+        string owner
+        json links "repo, runbook"
+        json environments }
+```
+
+Telemetry plane (ClickHouse, pending R2): `metrics_points`
+(series-hash, ts, value, tags), `logs` (ts, org, service, level, message,
+attrs map, trace_id), `spans` (trace_id, span_id, parent, service, name,
+start, duration, status, attrs) — schemas finalized during OBS-001 design.
+Retention defaults extend §4's table: metrics 13mo (rollup-thinned), logs
+15d hot (+archive later), traces 7d sampled **[Proposed]**.

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -81,7 +81,12 @@ Effectively already true — ratifying makes it official.
   sign-in/sign-up screens **in-app** (own UI per its design system,
   Firebase Auth underneath: Google sign-in + email/password flows). The
   central facade fronts the same Firebase project later without contract
-  changes; in-app screens then become optional, not obsolete. Environment/secrets live in **Doppler**
+  changes; in-app screens then become optional, not obsolete. **HARDENED
+  2026-07-16: Google sign-in is the ONLY method — no username/password
+  signup or login, product-wide.** Email/Password provider disabled at
+  the Firebase project; backends reject non-Google-provider tokens
+  (`provider-not-allowed`); UI ships exactly one auth CTA. Full contract:
+  [flows/auth.md](flows/auth.md). Environment/secrets live in **Doppler**
   (`cueprise/cuesoft_stg`; see also the `cuesoft-iac` project) — CLI token
   currently expired (`doppler login` to refresh); config names to be mirrored
   into docs once readable. ☑

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -127,3 +127,11 @@ observability-service touch, not as its own phase.
   `sandbox-e306a` (per-product prefixes `upstat/<env>/…`) for capture
   media, exports, and artifacts. Self-host compose keeps its bundled
   stores. ☑
+- **X-6 Environments & deploy gating (RATIFIED 2026-07-16, deliberate
+  deviation from the cueprise norm)**: `stg` = **sandbox** and is the ONLY
+  environment — no production deployment exists for these products. Secrets
+  live in Doppler `<project>/stg`. Because these repos are **open source**,
+  merge-to-main must NOT deploy: main-merge runs build+test only. **Deploys
+  happen exclusively on tag creation (`v*`)**, treated as production-grade:
+  a GitHub tag ruleset restricts `v*` creation to owner-level access, and the
+  deploy workflow additionally runs in a protected GitHub environment. ☑

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -77,8 +77,11 @@ Effectively already true — ratifying makes it official.
 - **X-1 account.cuesoft.io / identity (RATIFIED)**: interim + sandbox identity
   is **Firebase Authentication on GCP project `sandbox-e306a`** ("sandbox") —
   Google sign-in + email flows come from Firebase; services verify Firebase ID
-  tokens (OIDC-compatible). The `account.cuesoft.io` facade fronts this later
-  without contract changes. Environment/secrets live in **Doppler**
+  tokens (OIDC-compatible). `account.cuesoft.io` **is not built yet** — each app replicates the
+  sign-in/sign-up screens **in-app** (own UI per its design system,
+  Firebase Auth underneath: Google sign-in + email/password flows). The
+  central facade fronts the same Firebase project later without contract
+  changes; in-app screens then become optional, not obsolete. Environment/secrets live in **Doppler**
   (`cueprise/cuesoft_stg`; see also the `cuesoft-iac` project) — CLI token
   currently expired (`doppler login` to refresh); config names to be mirrored
   into docs once readable. ☑

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -18,7 +18,9 @@
 **Also ratify with it:** self-host compose gains a `clickhouse` service; helm
 documents external-or-StatefulSet options (same stance as Mongo today).
 
-☑ Ratified: option (a) ClickHouse
+☑ Ratified: option (a) ClickHouse — **control-plane note revised by X-5:**
+the control plane migrates Mongo→**Aiven Postgres**; "Mongo stays" in the
+option text is superseded
 
 ## U-2 · Browser event auth (ANA-001) — gates Phase 1 (events layer, "D2")
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -84,3 +84,9 @@ Effectively already true — ratifying makes it official.
   into docs once readable. ☑
 - **X-2 Docs platform**: GitBook space per product, Git-synced; Scalar API
   refs. ☑
+- **X-3 Cloud deployment target (RATIFIED, directive)**: all backend
+  services run on **Google Cloud Run** (per-service containers — the same
+  `cuesoft/<repo>-<service>` images), following the cueprise pattern
+  (IaC precedent in `cuesoft-iac`); frontends deploy to **Firebase App
+  Hosting**. Helm + terraform in `deploy/` remain the **self-host** path —
+  cloud and self-host share images, not manifests. ☑

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -3,6 +3,10 @@
 > Ratify by checking a box; each decision flips its **[Proposed]** tags to
 > **[Decided]** and unblocks the listed phases. Status: ☐ open · ☑ ratified.
 
+> **RATIFIED 2026-07-16** — all recommendations approved wholesale ("decisions
+> look solid"). Where other docs still carry **[Proposed]** on these topics,
+> this sheet governs; tags flip to **[Decided]** as docs are next touched.
+
 ## U-1 · Unified telemetry store (R2) — gates Phases 3–7 (every pillar)
 
 | Option | For | Against |
@@ -14,7 +18,7 @@
 **Also ratify with it:** self-host compose gains a `clickhouse` service; helm
 documents external-or-StatefulSet options (same stance as Mongo today).
 
-☐ Ratified: option ___
+☑ Ratified: option (a) ClickHouse
 
 ## U-2 · Browser event auth (ANA-001) — gates Phase 1 (events layer, "D2")
 
@@ -23,7 +27,7 @@ per-key rate limits + closed event/dims schema; `visitor_hash` computed
 server-side. This is the standard cookieless-analytics posture
 (Plausible/Fathom-class). No cookies, no raw IPs at rest.
 
-☐ Ratified
+☑ Ratified
 
 ## U-3 · Cookieless visitor model — privacy-defining, published in UPS-005
 
@@ -31,7 +35,7 @@ server-side. This is the standard cookieless-analytics posture
 salt rotates daily; raw IP never stored; uniques are approximate and
 documented as such; no cross-property joins, ever.
 
-☐ Ratified
+☑ Ratified
 
 ## U-4 · Alert channels & email provider (MON-001) — gates Phase 2
 
@@ -40,7 +44,7 @@ immediately), **email via Resend** second (developer-grade DX, sane pricing;
 SES is the cost-optimization escape hatch later); Slack via webhook URL
 initially, native app later.
 
-☐ Ratified: email provider ___
+☑ Ratified: email provider Resend
 
 ## U-5 · Protocol split — gates all new surfaces
 
@@ -49,7 +53,7 @@ initially, native app later.
 (events, stats, query, OTLP/HTTP alongside OTLP/gRPC, dashboards, monitors-v2,
 incidents, SLOs). Browsers and sibling products never need proto toolchains.
 
-☐ Ratified
+☑ Ratified
 
 ## U-6 · Retention defaults per signal — published per UPS-003
 
@@ -57,7 +61,7 @@ incidents, SLOs). Browsers and sibling products never need proto toolchains.
 13mo · check results 90d · incidents indefinite · metrics 13mo
 (rollup-thinned) · logs 15d hot (archive later) · traces 7d sampled.
 
-☐ Ratified (or adjust: ___)
+☑ Ratified as recommended
 
 ## U-7 · Brand & theme (sampled 2026-07-16)
 
@@ -66,10 +70,17 @@ from the existing landing, now in `upstat/tokens`); dashboards **default
 dark**, light supported; `ok` green kept visually distinct from brand teal.
 Effectively already true — ratifying makes it official.
 
-☐ Ratified
+☑ Ratified
 
 ## Cross-cutting
 
-- **X-1 account.cuesoft.io**: OIDC target; local JWT interim. ☐
+- **X-1 account.cuesoft.io / identity (RATIFIED)**: interim + sandbox identity
+  is **Firebase Authentication on GCP project `sandbox-e306a`** ("sandbox") —
+  Google sign-in + email flows come from Firebase; services verify Firebase ID
+  tokens (OIDC-compatible). The `account.cuesoft.io` facade fronts this later
+  without contract changes. Environment/secrets live in **Doppler**
+  (`cueprise/cuesoft_stg`; see also the `cuesoft-iac` project) — CLI token
+  currently expired (`doppler login` to refresh); config names to be mirrored
+  into docs once readable. ☑
 - **X-2 Docs platform**: GitBook space per product, Git-synced; Scalar API
-  refs. ☐
+  refs. ☑

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -72,6 +72,15 @@ Effectively already true — ratifying makes it official.
 
 ☑ Ratified
 
+## U-8 · Insight narrative LLM (added 2026-07-16)
+
+**Ratified via X-4:** the observability insight renderer (currently Groq,
+`service/groq_renderer.py`) migrates to **Vertex AI** in cloud deployments;
+GROQ_API_KEY remains the self-host fallback. Scheduled with the next
+observability-service touch, not as its own phase.
+
+☑ Ratified
+
 ## Cross-cutting
 
 - **X-1 account.cuesoft.io / identity (RATIFIED)**: interim + sandbox identity
@@ -98,3 +107,10 @@ Effectively already true — ratifying makes it official.
   (IaC precedent in `cuesoft-iac`); frontends deploy to **Firebase App
   Hosting**. Helm + terraform in `deploy/` remain the **self-host** path —
   cloud and self-host share images, not manifests. ☑
+- **X-4 AI platform (RATIFIED, directive 2026-07-16)**: AI features use
+  **Vertex AI** (Gemini via `{region}-aiplatform.googleapis.com`, ADC from the
+  service account — the `cuesoft-iac/functions/cueprise-gemini-proxy` pattern;
+  reference model `gemini-2.5-flash-lite`, region `us-central1`). No
+  consumer-API keys to third-party AI vendors in cloud deployments — data
+  stays inside GCP, which strengthens every privacy disclosure. Self-host
+  fallback: bring-your-own Gemini/Groq key via env (existing code path). ☑

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1,0 +1,75 @@
+# Upstat — Decision Sheet
+
+> Ratify by checking a box; each decision flips its **[Proposed]** tags to
+> **[Decided]** and unblocks the listed phases. Status: ☐ open · ☑ ratified.
+
+## U-1 · Unified telemetry store (R2) — gates Phases 3–7 (every pillar)
+
+| Option | For | Against |
+| --- | --- | --- |
+| **(a) ClickHouse — one columnar store for metrics + logs + traces; Mongo stays control-plane** ⭐ | The Signoz/HyperDX-proven pattern; one system to operate; excellent compression + TTLs; self-host = one more container | New operational skill to build |
+| (b) VictoriaMetrics + OpenSearch split | Best-of-breed per signal | Two stateful systems to run + query-layer complexity |
+| (c) Stretch MongoDB | No new infra | Falls over on high-cardinality timeseries + log search; would poison every pillar |
+
+**Also ratify with it:** self-host compose gains a `clickhouse` service; helm
+documents external-or-StatefulSet options (same stance as Mongo today).
+
+☐ Ratified: option ___
+
+## U-2 · Browser event auth (ANA-001) — gates Phase 1 (events layer, "D2")
+
+**Recommendation ⭐:** public **write-only property key** + origin allowlist +
+per-key rate limits + closed event/dims schema; `visitor_hash` computed
+server-side. This is the standard cookieless-analytics posture
+(Plausible/Fathom-class). No cookies, no raw IPs at rest.
+
+☐ Ratified
+
+## U-3 · Cookieless visitor model — privacy-defining, published in UPS-005
+
+**Recommendation ⭐:** `visitor_hash = hash(daily_salt, property, ip, UA)`;
+salt rotates daily; raw IP never stored; uniques are approximate and
+documented as such; no cross-property joins, ever.
+
+☐ Ratified
+
+## U-4 · Alert channels & email provider (MON-001) — gates Phase 2
+
+**Recommendation ⭐:** **webhooks first** (provider-independent, ships
+immediately), **email via Resend** second (developer-grade DX, sane pricing;
+SES is the cost-optimization escape hatch later); Slack via webhook URL
+initially, native app later.
+
+☐ Ratified: email provider ___
+
+## U-5 · Protocol split — gates all new surfaces
+
+**Recommendation ⭐:** existing user/monitor control plane stays **gRPC**
+(works, typed, Envoy already wired); every new surface is **HTTP/JSON**
+(events, stats, query, OTLP/HTTP alongside OTLP/gRPC, dashboards, monitors-v2,
+incidents, SLOs). Browsers and sibling products never need proto toolchains.
+
+☐ Ratified
+
+## U-6 · Retention defaults per signal — published per UPS-003
+
+**Recommendation ⭐:** raw events 90d · hourly rollups 90d · daily rollups
+13mo · check results 90d · incidents indefinite · metrics 13mo
+(rollup-thinned) · logs 15d hot (archive later) · traces 7d sampled.
+
+☐ Ratified (or adjust: ___)
+
+## U-7 · Brand & theme (sampled 2026-07-16)
+
+**Recommendation ⭐:** brand **#00E09E** + `brand-deep` **#00A991** (sampled
+from the existing landing, now in `upstat/tokens`); dashboards **default
+dark**, light supported; `ok` green kept visually distinct from brand teal.
+Effectively already true — ratifying makes it official.
+
+☐ Ratified
+
+## Cross-cutting
+
+- **X-1 account.cuesoft.io**: OIDC target; local JWT interim. ☐
+- **X-2 Docs platform**: GitBook space per product, Git-synced; Scalar API
+  refs. ☐

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -114,3 +114,16 @@ observability-service touch, not as its own phase.
   consumer-API keys to third-party AI vendors in cloud deployments — data
   stays inside GCP, which strengthens every privacy disclosure. Self-host
   fallback: bring-your-own Gemini/Groq key via env (existing code path). ☑
+- **X-5 Data plane (RATIFIED 2026-07-16, per-product DB decided by delegation)**:
+  **Aiven Postgres** for the control plane (users, monitors, dashboards,
+  rules, incidents, SLOs) — migrating from Mongo with the monitors-v2/OBS
+  work; **ClickHouse** remains the telemetry store (U-1 unchanged).
+  **Shared Redis**: the sandbox **Aiven Redis** instance, tenancy by
+  **`REDIS_DB` index** (the irealty pattern: discrete `REDIS_HOST/PORT/
+  USERNAME/PASSWORD/TLS/DB` vars; e.g. irealty prd=0, stg/dev=1) — indices
+  per product/config assigned in Doppler by the owner. **Doppler is the env
+  source of truth**: project `upstat` with `dev / dev_personal / stg / prd`
+  configs (already created). **Object storage**: the **default Cloud Storage bucket** in
+  `sandbox-e306a` (per-product prefixes `upstat/<env>/…`) for capture
+  media, exports, and artifacts. Self-host compose keeps its bundled
+  stores. ☑

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,54 @@
+# Deployment — Cloud Contract
+
+> Implements decision X-3. Cloud deploys follow the proven cueprise/getpp
+> patterns (workflows verified 2026-07-16); provisioning goes through the
+> **cuesoft-iac** Pulumi ecosystem — never ad-hoc gcloud. Self-hosting via
+> `deploy/` (compose/helm/terraform) is unchanged and shares only images.
+
+## 1. Topology
+
+| Surface | Runs on | Provisioned by |
+| --- | --- | --- |
+| `api/common` (Go, gRPC/h2c) | Cloud Run (HTTP/2 enabled) | cuesoft-iac stack `upstat` |
+| `api/observability` (Python) | Cloud Run | cuesoft-iac stack `upstat` |
+| envoy gRPC-Web proxy | Cloud Run (or folded into gateway design at OBS-001) | cuesoft-iac stack `upstat` |
+| `web` (Next.js) | **Firebase App Hosting** | App Hosting backend |
+
+## 2. Provisioning (cuesoft-iac)
+
+- **Pulumi, bun runtime**; state in `gs://cuesoft-iac-pulumi-state-bucket`;
+  per-product stack (`Pulumi.<product>.yaml`) added alongside existing ones
+  (getpp, swaves, …).
+- Cloud Run services instantiate the shared module
+  `common/modules/gcp/cloud-run-service.ts`; the GitHub→GCP deploy identity
+  uses **Workload Identity Federation** (`common/helpers/wif.ts`) — no
+  service-account keys in GitHub.
+- Secrets/env flow from **Doppler** (`cueprise/cuesoft_stg` pattern) into
+  Cloud Run env; the repo's `.env.example` files document the variable
+  names, Doppler owns values.
+
+## 3. CI/CD (GitHub Actions, cueprise/getpp pattern)
+
+| Workflow | Trigger | Does |
+| --- | --- | --- |
+| `build-and-test.yml` | PRs | build + tests per service |
+| `build-push-and-release-staging.yml` | push to `main` | matrix over services: buildx (GHA cache) → push `cuesoft/upstat-<service>` (tags: `latest` + `sha`) → Cloud Run deploy **by image digest** via WIF |
+| `build-push-and-release-production.yml` | GitHub Release | same, pinned to the release commit; frontend rollout via `firebase-tools apphosting:rollouts:create --git-commit` |
+
+Two hard-won rules inherited from cueprise, non-negotiable:
+
+1. **Deploy by digest, never by tag** — Cloud Run pulls Docker Hub images
+   through the `mirror.gcr.io` cache, which has served stale manifests for
+   tags; the staging workflow threads `steps.build.outputs.digest` into the
+   deploy step.
+2. **WIF only** (`google-github-actions/auth@v3` with
+   `workload_identity_provider` + `service_account`) — no JSON keys.
+
+GitHub environments (`Staging <Project>`, `Production`) gate the deploy
+jobs and carry the URLs.
+
+## 4. Not in this phase
+
+Writing these workflows + the Pulumi stack is **implementation work**, out of
+scope for the docs phase — this document is the contract they'll be built
+against. Docker Hub repos already exist for every image name above.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -31,9 +31,14 @@
 
 | Workflow | Trigger | Does |
 | --- | --- | --- |
-| `build-and-test.yml` | PRs | build + tests per service |
-| `build-push-and-release-staging.yml` | push to `main` | matrix over services: buildx (GHA cache) → push `cuesoft/upstat-<service>` (tags: `latest` + `sha`) → Cloud Run deploy **by image digest** via WIF |
-| `build-push-and-release-production.yml` | GitHub Release | same, pinned to the release commit; frontend rollout via `firebase-tools apphosting:rollouts:create --git-commit` |
+| `build-and-test.yml` | PRs **and** push to `main` | build + tests per service — **no deploy, no image push** (X-6: open-source repos; merges must be inert) |
+| `release.yml` | **tag `v*` created** | matrix over services: buildx (GHA cache) → push `cuesoft/upstat-<service>` (tags: `latest`, `sha`, version) → Cloud Run deploy **by image digest** via WIF → App Hosting rollout pinned to the tag commit |
+
+**Gating (X-6):** `stg` (sandbox) is the only environment and is treated as
+production. Two independent gates: (1) a GitHub **tag ruleset** restricts
+creating `v*` tags to owner-level access; (2) the deploy job runs in a
+protected GitHub **environment** (`Sandbox`) with required reviewers. A merged
+PR never reaches the sandbox on its own.
 
 Two hard-won rules inherited from cueprise, non-negotiable:
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -29,8 +29,9 @@
 > **dark-first with a mint/teal accent** — that is Upstat's actual brand, and
 > it stays. "datadoghq.com look and feel" contributes the *data-UI patterns*
 > (density, pillar nav, synced graphs), not Datadog's purple. The `brand`
-> token below is teal; exact hex sampled from the Figma file into the
-> `upstat/tokens` variable collection (§7).
+> token below is teal, sampled from the file: **#00E09E** (primary, 63 uses)
+> with **#00A991** as `brand-deep` — both now live in the `upstat/tokens`
+> variable collection (§7).
 
 | Token | Light | Dark | Use |
 | --- | --- | --- | --- |
@@ -39,7 +40,8 @@
 | `border` | #E4E6EB | #262C30 | hairlines |
 | `text` | #1B1D22 | #EDEEF2 | primary |
 | `text-2` | #6B6F7B | #9BA0AC | secondary |
-| `brand` | teal (sampled from landing, ~#2AD8A4 family) | same | nav, CTAs, focus — final hex from the Figma sample |
+| `brand` | #00E09E | #00E09E | nav, CTAs, focus (sampled from the landing) |
+| `brand-deep` | #00A991 | #00A991 | hover/active brand states, secondary accents |
 | `ok` | #2E9950 | #3DCC70 | up / passing |
 | `warn` | #C77D00 | #FFB020 | degraded / warn thresholds |
 | `crit` | #D32F2F | #FF5C5C | down / alerting |
@@ -131,8 +133,7 @@ verified in both themes) — the one extra constraint the teal brand imposes.
 ## 7. Figma Style Guide (source of truth for tokens)
 
 The design system lives in the product's Figma file on a dedicated **Style
-Guide** page, backed by a variable collection **`upstat/tokens`** with
-**Light** and **Dark** modes. Every color token in §2 exists as a Figma
+Guide** page, backed by a variable collection **`upstat/tokens`**. The file's plan allows a single variable mode, so themes are expressed as **`light/` and `dark/` variable groups** (same token names in each) rather than modes — migrate to true modes if the plan changes. Every color token in §2 exists as a Figma
 variable (scopes: frame/shape/text fills + strokes) so designs bind to tokens,
 never raw hexes; the Style Guide page renders swatches (both modes), the type
 scale, and status/accent samples. Token changes happen in Figma first, then

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,0 +1,120 @@
+# Upstat — Design Language
+
+> Reference feel: **datadoghq.com** — dense, data-first observability UI with
+> a confident purple identity; marketing site clean and product-led. Markers:
+> **[Directive]** = user-stated direction (2026-07-16), **[Proposed]** =
+> ratifiable decision. Pages in [pages.md](pages.md) reference
+> microinteractions here as `MI-n`.
+
+## 1. Design principles
+
+1. **Time is the primary axis** — a global time picker governs every view;
+   all graphs share cursor, zoom, and range. Nothing renders without its
+   time context.
+2. **Density with hierarchy** — Datadog-class UIs win by showing a lot
+   without chaos: strict typographic scale, hairline dividers, color reserved
+   for signal (status, series), never decoration.
+3. **Every pixel is a pivot** — hover anything (point, log line, service
+   node) → rich context; click → filtered drill-down. Dead-end views are
+   defects.
+4. **Keyboard + query duality** — every UI filter state has a query-string
+   representation (shareable URLs); power users type, others click — same
+   result.
+
+## 2. Foundations
+
+### Color **[Proposed]**
+
+| Token | Light | Dark | Use |
+| --- | --- | --- | --- |
+| `bg` | #FFFFFF | #14151A | canvas (dashboards default dark **[Proposed]** — graphs read better; marketing light) |
+| `bg-elev` | #F7F8FA | #1D1F26 | panels, cells |
+| `border` | #E4E6EB | #2C2F38 | hairlines |
+| `text` | #1B1D22 | #EDEEF2 | primary |
+| `text-2` | #6B6F7B | #9BA0AC | secondary |
+| `brand` | #6C3FC5 | #8A5CF6 | the Upstat purple (Datadog-adjacent): nav, CTAs, focus |
+| `ok` | #2E9950 | #3DCC70 | up / passing |
+| `warn` | #C77D00 | #FFB020 | degraded / warn thresholds |
+| `crit` | #D32F2F | #FF5C5C | down / alerting |
+| `nodata` | #9AA0AA | #5C6270 | no data / muted monitors |
+| Series palette | 8-step categorical (colorblind-safe, starts purple) | — | charts; consistent series→color per view session |
+
+Status semantics are sacred: `ok/warn/crit/nodata` colors are reserved — never
+used decoratively anywhere in the product.
+
+### Type & numerals
+
+- UI: `Inter`; data/query/code: `JetBrains Mono` (log lines, queries, IDs).
+- Base 13px in data views (density), 14px in settings/forms; tabular figures
+  in all numeric contexts; fixed-precision latencies (`142 ms`, `1.24 s`).
+
+### Layout
+
+- Left product nav (Datadog pattern): icon rail 56px with flyout labels;
+  sections = pillars (§pages.md B). Top bar: org/env switcher · **global time
+  picker** · search (`/`) · incidents bell.
+- Views: filter bar (query pills) → visualization canvas → detail drawer
+  (right, 480px) for point/line/span inspection.
+- Grid dashboards: 12-col draggable/resizable widgets (react-grid-layout
+  class behavior), 8px gutters.
+- Radii 4px (denser than siblings); hairlines everywhere; elevation only for
+  drawers/palettes.
+
+## 3. Component inventory
+
+| Component | Anatomy | Notes |
+| --- | --- | --- |
+| `TimePicker` | presets (15m/1h/4h/1d/1w/custom) + absolute range + live toggle | global, URL-synced; "live" pulses a dot |
+| `QueryBar` | tokenized pills (`service:api-common` `status:error`) + free text; autocomplete from facets | shared grammar across logs/metrics/traces **[Proposed]** |
+| `TimeseriesPanel` | title · query chip · chart (line/area/bars) · legend with per-series toggle | crosshair synced across all panels in view (MI-2) |
+| `StatusPill` | dot + label (`ok/warn/crit/nodata`) | breathing animation only while state is `crit` (MI-8) |
+| `UptimeCard` | monitor name · 90-day bar strip · uptime % · latency sparkline | the classic status strip; bars tooltip per-day detail |
+| `LogLine` | ts · level chip · service · message (mono, truncated) | expand → JSON tree with copy-paths (MI-5) |
+| `TraceWaterfall` | span rows: name, service color, duration bar on time axis | hover span → mini-summary; click → span drawer |
+| `ServiceMapNode` | hexagon: service name + req/s + error % ring | force-layout map; edges animate flow direction |
+| `MonitorRow` | status pill · name · query summary · last triggered · muted toggle | |
+| `IncidentBanner` | sev chip · title · age · responders avatars | global banner while any sev1/2 open |
+| `SLOCard` | target vs actual · error-budget bar (burn colored) | budget bar depletes right-to-left |
+| `FacetSidebar` | checkbox facets with counts, top-N | logs/traces explorers |
+| `WidgetShell` | dashboard widget chrome: title, query, ⋯ menu (edit/duplicate/fullscreen/export) | drag handle appears on hover |
+
+## 4. Microinteraction catalog
+
+| ID | Interaction | Spec |
+| --- | --- | --- |
+| MI-1 | **Global time sync** | changing TimePicker animates all panels' x-domains 250ms; URL updates; back/forward restores |
+| MI-2 | **Synced crosshair** | hovering any chart draws vertical cursor + value dots on *every* panel in view; tooltip follows with per-series values; 0ms delay, rAF-throttled |
+| MI-3 | **Drag-to-zoom** | drag horizontal region on any chart → all panels zoom to range with 200ms ease; double-click resets; breadcrumb chip shows zoom stack |
+| MI-4 | **Live tail** | logs stream with 150ms batch flush; user scroll-up pauses (PAUSED pill + buffered count "▼ 128 new"); click resumes with smooth catch-up scroll |
+| MI-5 | **Log expand** | line expands accordion-style to JSON tree; keys hover → copy-path icon; `⌘click` a value → adds `key:value` pill to QueryBar (the signature pivot) |
+| MI-6 | **Facet filtering** | checking a facet animates result count + charts re-query with 120ms crossfade; pills appear in QueryBar |
+| MI-7 | **Span hover** | waterfall span highlights its service color across the map minimap; duration label pops 1.05× |
+| MI-8 | **Status transitions** | pill color crossfades 300ms + single pulse on worsening (never on recovery — recovery is calm); status strip bars fill on first render 400ms stagger |
+| MI-9 | **Monitor test** | "Test rule" replays last 24h against thresholds → chart overlays trigger bands + would-have-fired markers |
+| MI-10 | **Incident timeline composer** | timeline entries slide-in; slash-commands (`/status resolved`, `/sev 2`) autocomplete; posting an update optimistically prepends with clock-sync check |
+| MI-11 | **Dashboard editing** | drag ghost + snap guides; resize live-reflows neighbors; save pulses the Saved chip; `e` toggles edit mode |
+| MI-12 | **Widget fullscreen** | widget zooms to viewport 250ms (FLIP), ESC returns; keeps crosshair sync with origin dashboard |
+| MI-13 | **Query autocomplete** | facet suggestions ranked by cardinality; tab completes; syntax errors underline red with hover explanation |
+| MI-14 | **Alert flash** | new alert event flashes the nav bell + adds row to alert feed with 300ms slide; sev1 adds persistent IncidentBanner |
+| MI-15 | **SLO budget burn** | budget bar animates depletion on load; burn-rate > threshold ignites a subtle flame icon (calm UI otherwise) |
+| MI-16 | **Empty/onboarding states** | every pillar's empty state = 3-step inline setup (install snippet with copy ✓, "waiting for data…" radar sweep, docs link); radar sweep stops on first datapoint with a satisfying ping |
+| MI-17 | **Keyboard map** | `g d` dashboards, `g l` logs, `g m` monitors, `/` search, `?` overlay cheatsheet |
+| MI-18 | **Saved views** | saving a filter set morphs QueryBar into a named chip; org-shared views get avatar stack |
+
+## 5. Accessibility & motion
+
+- Status never color-only: pills carry labels/icons; charts offer pattern
+  fills in colorblind mode.
+- `prefers-reduced-motion`: no pulses/sweeps; state changes are instant
+  crossfades; live tail unaffected (data, not decoration).
+- All charts expose data-table toggle; log lines fully keyboard-navigable
+  (j/k, enter expands).
+- Contrast ≥4.5:1 both themes including series-on-dark validation.
+
+## 6. Platform parity map
+
+| Surface | Now | Target |
+| --- | --- | --- |
+| Home (public) | `/` page + Figma landing design | pages.md Part A (Datadog-style product-led marketing) |
+| Dashboard | monitor CRUD + mock analytics pages | pages.md Part B — pillar-based observability app |
+| Mobile | — | later: on-call/incident companion app sketch (pages.md Part C) — parity direction **[Directive]** |

--- a/docs/design.md
+++ b/docs/design.md
@@ -25,14 +25,21 @@
 
 ### Color **[Proposed]**
 
+> **Brand reconciliation (2026-07-16):** the existing Figma landing design is
+> **dark-first with a mint/teal accent** — that is Upstat's actual brand, and
+> it stays. "datadoghq.com look and feel" contributes the *data-UI patterns*
+> (density, pillar nav, synced graphs), not Datadog's purple. The `brand`
+> token below is teal; exact hex sampled from the Figma file into the
+> `upstat/tokens` variable collection (§7).
+
 | Token | Light | Dark | Use |
 | --- | --- | --- | --- |
-| `bg` | #FFFFFF | #14151A | canvas (dashboards default dark **[Proposed]** — graphs read better; marketing light) |
-| `bg-elev` | #F7F8FA | #1D1F26 | panels, cells |
-| `border` | #E4E6EB | #2C2F38 | hairlines |
+| `bg` | #FFFFFF | #0E1113 | canvas (dashboards + marketing default dark, per the existing landing; light mode supported) |
+| `bg-elev` | #F7F8FA | #171B1E | panels, cells |
+| `border` | #E4E6EB | #262C30 | hairlines |
 | `text` | #1B1D22 | #EDEEF2 | primary |
 | `text-2` | #6B6F7B | #9BA0AC | secondary |
-| `brand` | #6C3FC5 | #8A5CF6 | the Upstat purple (Datadog-adjacent): nav, CTAs, focus |
+| `brand` | teal (sampled from landing, ~#2AD8A4 family) | same | nav, CTAs, focus — final hex from the Figma sample |
 | `ok` | #2E9950 | #3DCC70 | up / passing |
 | `warn` | #C77D00 | #FFB020 | degraded / warn thresholds |
 | `crit` | #D32F2F | #FF5C5C | down / alerting |
@@ -40,7 +47,9 @@
 | Series palette | 8-step categorical (colorblind-safe, starts purple) | — | charts; consistent series→color per view session |
 
 Status semantics are sacred: `ok/warn/crit/nodata` colors are reserved — never
-used decoratively anywhere in the product.
+used decoratively anywhere in the product. Because the brand accent is teal,
+`ok` green must stay visually distinct from `brand` (bluer/deeper green;
+verified in both themes) — the one extra constraint the teal brand imposes.
 
 ### Type & numerals
 
@@ -118,3 +127,14 @@ used decoratively anywhere in the product.
 | Home (public) | `/` page + Figma landing design | pages.md Part A (Datadog-style product-led marketing) |
 | Dashboard | monitor CRUD + mock analytics pages | pages.md Part B — pillar-based observability app |
 | Mobile | — | later: on-call/incident companion app sketch (pages.md Part C) — parity direction **[Directive]** |
+
+## 7. Figma Style Guide (source of truth for tokens)
+
+The design system lives in the product's Figma file on a dedicated **Style
+Guide** page, backed by a variable collection **`upstat/tokens`** with
+**Light** and **Dark** modes. Every color token in §2 exists as a Figma
+variable (scopes: frame/shape/text fills + strokes) so designs bind to tokens,
+never raw hexes; the Style Guide page renders swatches (both modes), the type
+scale, and status/accent samples. Token changes happen in Figma first, then
+sync back into this document — the two must never diverge. Type styles and
+component samples are the next Style Guide iteration.

--- a/docs/engineering.md
+++ b/docs/engineering.md
@@ -1,0 +1,79 @@
+# Upstat — Engineering Contracts
+
+> Error catalog, authorization matrix, rate limits, testing strategy, logging
+> rules. Ecosystem envelope + conventions per apparule engineering.md §1;
+> gRPC surfaces map the same codes onto status codes
+> (`INVALID_ARGUMENT`/`UNAUTHENTICATED`/`PERMISSION_DENIED`/`NOT_FOUND`/
+> `ALREADY_EXISTS`/`RESOURCE_EXHAUSTED`/`FAILED_PRECONDITION`).
+
+## 1. Error catalog (product families)
+
+Flow-spec-owned codes: monitors (flows/monitor.md — `name_taken`,
+`timeout_gte_interval`), alerts (flows/alert.md — `channel_unverified`,
+`verification_expired`), events (analytics-math.md — `ts_out_of_range`,
+schema/origin rejections with per-reason counters), auth (flows/auth.md —
+`provider_not_allowed`, `migrate_to_firebase`), query
+(`invalid_query{position, hint}` — query-grammar.md §3's error-not-empty
+rule), ingest (`quota_exceeded`, `key_scope_mismatch` — OBS-001).
+
+## 2. Authorization matrix
+
+Current model: single-owner resources; org roles arrive with the OBS
+build-out (data-model.md §5 ORG). Matrix for the org era, applied to the
+owner-only model as "owner=everything, others=nothing" until then:
+
+| Resource / action | viewer | member | admin | owner |
+| --- | --- | --- | --- | --- |
+| Dashboards/explorers read | ✓ | ✓ | ✓ | ✓ |
+| Monitors create/edit/pause | — | ✓ | ✓ | ✓ |
+| Alert channels create/verify | — | ✓ | ✓ | ✓ |
+| Channel delete; rules bulk ops | — | — | ✓ | ✓ |
+| Properties + ingest keys | — | — | ✓ | ✓ |
+| Key rotation/revocation | — | — | ✓ | ✓ |
+| Incidents declare/update | — | ✓ | ✓ | ✓ |
+| SLOs define | — | — | ✓ | ✓ |
+| Org members, retention settings | — | — | — | ✓ |
+| Public status pages | world-readable by design | | | config: admin+ |
+
+Machine identities: `SERVICE_TOKEN` (observability↔common, fixed scope);
+property public keys (write-only ingest, U-2) — neither ever grants user-API
+access.
+
+## 3. Rate limits
+
+| Surface | Limit |
+| --- | --- |
+| Events ingest | 600/min sustained, 1200 burst per property key (analytics-math.md §6) |
+| Stats/query API | 60/min per user |
+| Monitor CRUD | 60/min per user |
+| Monitor test-replay (MI-9) | 6/min per user |
+| Channel verification sends | 5/hr per channel |
+| OTLP ingest (OBS-001) | per-key quotas (data-model.md `INGEST_KEY.quotas`) |
+
+## 4. Testing strategy
+
+| Layer | Scope | Non-negotiables |
+| --- | --- | --- |
+| Unit (Go/pytest) | worker, dispatcher, rollups, hash | **evaluation-semantics transition table** (flows/monitor.md §2 — every edge incl. `nodata`); dispatch ordering + cooldown fixtures (flows/alert.md §5); visitor-hash rotation vectors; rollup idempotency (analytics-math.md §7) |
+| Contract | error catalog + query grammar | grammar: valid/invalid corpus with position-accurate errors; `uniques_additive:false` metadata presence |
+| Integration (compose) | web → envoy → gRPC; events → rollup → stats | webhook signature fixture (documented recipe verifies) |
+| E2E smoke (release tag) | signin → create monitor → down-simulation → alert → recover | against sandbox in release.yml; uses a controllable target service |
+| Privacy invariants | events pipeline | raw IP/UA absent from storage + logs (grep + storage-scan test) |
+
+## 5. Logging & observability (dogfooding rule)
+
+Ecosystem conventions (request-id line, ids not emails). **Never-log list**
+(CI grep-gated): raw visitor IP/UA, channel secrets & webhook URLs' auth
+components, service tokens, ingest keys, monitor target credentials (if URL
+userinfo is ever supported: reject instead). Upstat monitors Upstat: its own
+services run the tracking script + uptime checks + (later) OTLP — every new
+pillar's first customer is this repo, and the public status page (Phase 0)
+is the standing proof.
+
+## 6. Acceptance
+
+- [ ] Transition-table test covers every state edge incl. worker-outage `nodata`
+- [ ] Grammar corpus: 30+ valid / 30+ invalid queries with exact error positions
+- [ ] Rollup re-run produces byte-identical settled buckets
+- [ ] Storage-scan test proves no raw IP/UA at rest
+- [ ] Release smoke drives a real down→alert→recover cycle in sandbox

--- a/docs/flows/alert.md
+++ b/docs/flows/alert.md
@@ -1,0 +1,91 @@
+# Flow: Alerting (channels → rules → dispatch)
+
+> Implements MON-001 with decisions U-4 (webhooks first, email via Resend).
+> Covers channel lifecycle, rule config, dispatch semantics, cooldown, and
+> the flapping guard. Data model: `ALERT_RULE`/`ALERT_CHANNEL`
+> (data-model.md §2).
+
+## 1. Channels
+
+| Kind | Config | Verification |
+| --- | --- | --- |
+| Webhook | URL (https only) + optional secret | "Verify" sends a signed test event; channel unusable until a 2xx returns (`verified: true`) |
+| Email (Resend) | address | 6-digit code mailed; entered in-app; 15min expiry, 3 attempts |
+
+- Channels are owner-scoped and reusable across monitors.
+- Webhook signing: `X-Upstat-Signature: hex(hmac-sha256(secret, body))` +
+  `X-Upstat-Timestamp`; consumers must reject >5min skew (documented in
+  UPS-003 setup docs).
+- Failing channels: 5 consecutive delivery failures → `degraded` badge +
+  email-to-owner (if any email channel works) + banner; deliveries keep
+  trying (no auto-disable — silent alert loss is worse than noise).
+- Deleting a channel detaches it from all rules; rules left with zero
+  channels show a "no destination" warning badge.
+
+## 2. Rules
+
+Per monitor: `on: down | recovered | nodata | all` **(nodata opt-in)**,
+`cooldown_minutes` (default 30, 0–1440). One rule may fan out to many
+channels. Defaults on first channel creation: a `down+recovered` rule is
+offered pre-filled for every existing monitor (bulk opt-in sheet) — empty
+alerting after setup is a product failure.
+
+## 3. Dispatch semantics
+
+```mermaid
+sequenceDiagram
+    participant W as Worker (state change)
+    participant D as Dispatcher
+    participant CH as Channels
+
+    W->>D: transition {monitor, from, to, at, cause}
+    D->>D: load rules; filter by "on"; check cooldown stamps
+    alt within cooldown
+        D->>D: drop (recorded as suppressed in alert feed)
+    else
+        D->>CH: deliver (parallel, per-channel retry ×3, backoff 1s/5s/25s)
+        D->>D: stamp cooldown per rule
+    end
+```
+
+- **At-least-once** per channel with the retry ladder; a channel's failure
+  never blocks the others.
+- **Ordering**: `recovered` dispatch always awaits the corresponding `down`
+  dispatch outcome (never out-of-order pairs on one channel).
+- **Cooldown** applies per rule per state-direction — a `down` at minute 0
+  suppresses re-`down` noise until cooldown lapses, but never suppresses the
+  `recovered`.
+- **Renotify** (delta, optional): `renotify_minutes` re-sends "still down"
+  while an incident stays open; off by default.
+- **Flapping guard** (with monitor.md §2): >6 transitions/30min → one
+  "Monitor X is flapping" alert; normal dispatch resumes after 30 quiet
+  minutes; suppressed transitions visible in the alert feed (MI-14).
+
+## 4. Payloads
+
+Webhook (versioned envelope):
+
+```json
+{
+  "version": 1,
+  "event": "monitor.down | monitor.recovered | monitor.nodata | monitor.flapping",
+  "monitor": {"id": "…", "name": "…", "target": "…"},
+  "transition": {"from": "up", "to": "down", "at": "2026-07-16T12:00:00Z",
+                  "cause": "timeout", "consecutive_failures": 3},
+  "incident": {"id": "…", "started_at": "…"}
+}
+```
+
+Email: subject `[Upstat] {name} is DOWN` / `RECOVERED — was down 14m`;
+body = status, cause, duration, per-monitor page link, unsubscribe →
+channel settings. No target URL in the subject (URLs in subjects trip spam
+filters and leak internals into notification previews).
+
+## 5. Acceptance
+
+- [ ] Unverified channels cannot be attached to rules
+- [ ] Webhook signature verifiable by the documented recipe (fixture test)
+- [ ] Down at t0 + recover at t1 < cooldown: both delivered, in order
+- [ ] Flapping storm produces exactly one alert + truthful history
+- [ ] Channel outage degrades that channel only; suppressions visible
+- [ ] `nodata` alerts fire only where opted in

--- a/docs/flows/auth.md
+++ b/docs/flows/auth.md
@@ -1,0 +1,45 @@
+# Flow: Authentication (Google-only, Firebase-backed)
+
+> Implements decision X-1 as hardened 2026-07-16: **Google sign-in only** —
+> no username/password, product-wide. Firebase Auth on `sandbox-e306a`.
+> Replaces `UserService` credential flows (CreateUser with password,
+> GetUser-with-password sign-in); `GoogleAuth` becomes *the* flow. `/signup`
+> retires; `/login` is the single auth screen.
+
+## 1. Hard rule & enforcement
+
+Ecosystem standard (apparule flows/auth.md §1): Firebase provider config +
+backend `sign_in_provider == google.com` check + single Google CTA. In gRPC
+terms: the unary interceptor verifies Firebase ID tokens from metadata and
+returns `PERMISSION_DENIED provider-not-allowed` for non-Google tokens.
+
+## 2. Session & boundaries
+
+Firebase SDK session; gRPC-Web carries `authorization: Bearer <ID token>`
+metadata (interceptor swaps local-JWT verification for Firebase);
+`upstat_token`/`upstat_user` cookies retire. Boundary inventory:
+
+| Caller | Mechanism |
+| --- | --- |
+| Browser (gRPC-Web + new HTTP surfaces) | Firebase ID token (Google-provider-checked) |
+| api/observability → api/common | `SERVICE_TOKEN` (unchanged — machine identity, not user auth) |
+| Tracking beacons | property public key (U-2) |
+| Public status/GetRecentChecks | unauthenticated allowlist (unchanged) |
+
+## 3. Migration
+
+Link-by-email on first Google sign-in (Google emails pre-verified), same
+shape as expendit flows/auth.md §3 including the 60-day window
+(`FAILED_PRECONDITION migrate-to-firebase` after) and the stranded-user
+support path. `CreateUser`/password fields deprecate out of `user.proto` at
+the next proto rev.
+
+## 4. Instrumentation & acceptance
+
+Events (dogfooded once the events layer lands): `auth_signin_completed`,
+`auth_migration_completed`.
+
+- [ ] Google sign-in end-to-end through Envoy gRPC-Web metadata
+- [ ] Interceptor rejects expired, foreign-project, and non-Google tokens
+- [ ] `/signup` removed; cookies removed; legacy sign-in 410s after window
+- [ ] Service tokens + property keys + public allowlist untouched

--- a/docs/flows/monitor.md
+++ b/docs/flows/monitor.md
@@ -1,0 +1,82 @@
+# Flow: Uptime Monitor (create → check → status)
+
+> The M1 core from the user's side plus the **evaluation semantics** the
+> worker implements — window behaviour, no-data policy, flapping. Grounded in
+> the existing implementation (`monitor_worker_service.go`, `checker_service.go`)
+> and marks deltas. Preconditions: authed (Google-only, flows/auth.md).
+
+## 1. Create / edit
+
+| Field | Validation | Notes |
+| --- | --- | --- |
+| Name | 1–80 chars, unique per owner | `409 name-taken` |
+| Target | absolute `http(s)://` URL; DNS-resolvable not required at save | private/internal IPs allowed (self-hosters monitor internal services); cloud MAY restrict RFC-1918 targets **[Decided default: warn, don't block]** |
+| Type | `website \| server \| api \| blog` | display taxonomy only — checks behave identically **[Current]** |
+| Interval | 30s–24h, default 60s **[Current default]** | sub-30s is a paid-tier conversation, out of scope |
+| Timeout | 1s–60s, default 10s; must be < interval | `422 timeout-gte-interval` |
+| Failure threshold | 1–10, default 3 | consecutive failures before `down` |
+
+Edits apply from the next scheduled check; in-flight checks complete under
+old config. Pausing (`active: false`) stops scheduling and freezes status at
+`paused` (a distinct display state — not `up`, not `down`).
+
+## 2. Evaluation semantics (the contract the worker honours)
+
+```mermaid
+stateDiagram-v2
+    [*] --> pending : created (never checked)
+    pending --> up : first passing check
+    pending --> down : threshold consecutive failures
+    up --> down : consecutiveFailures ≥ threshold
+    down --> up : first passing check (recovery is immediate)
+    up --> nodata : no check completed for 2×interval
+    nodata --> up : passing check
+    nodata --> down : threshold failures
+    up --> paused : active=false
+    down --> paused
+    paused --> pending : re-activated (fresh slate)
+```
+
+- **A check passes** iff HTTP response arrives within timeout AND status
+  code < 400 **[Current behaviour; 3xx follows redirects up to 5]**.
+- **Failure asymmetry is deliberate**: going `down` needs `threshold`
+  consecutive failures (flap damping); going `up` needs exactly one success
+  (recovery news travels fast).
+- **`nodata`** (delta — today the status just goes stale): if the worker
+  itself misses 2×interval (crash, deploy, overload), status becomes
+  `nodata`, never a synthetic `down` — we don't invent outages we didn't
+  observe. Alerting treats `nodata` per-rule (`on: nodata` opt-in).
+- **Flapping guard** (delta): >6 transitions in 30min collapses
+  notifications into one "flapping" alert (flows/alert.md §4); the status
+  history itself records every transition truthfully.
+- **Incidents** **[Current]**: opened on `up→down`, closed on `down→up`;
+  `pending/nodata/paused` transitions never touch incidents.
+
+## 3. Check records & per-monitor page
+
+Each check persists: `up`, `status_code` (0 = transport error), 
+`response_time_ms`, `checked_at` (90d retention, U-6). The monitor page
+(pages.md B7) renders: UptimeCard strip (90d), response-time chart, incident
+list, ML insight panel. Uptime % = passing ÷ completed checks over the window
+(`nodata` gaps excluded from the denominator — shown as gray, counted as
+neither).
+
+## 4. Error taxonomy (user-visible on check detail)
+
+| Recorded cause | Meaning |
+| --- | --- |
+| `timeout` | no response within timeout |
+| `dns` | resolution failed |
+| `tls` | handshake/cert failure (incl. expired cert — cert-expiry *warning* checks are OBS-011 later) |
+| `refused` | connection refused |
+| `http_4xx` / `http_5xx` | response ≥400 |
+
+## 5. Instrumentation & acceptance
+
+Dogfood events: `monitor_created`, `monitor_state_changed{to}`.
+
+- [ ] Threshold/recovery asymmetry proven by table-driven worker tests
+- [ ] Worker outage yields `nodata`, not `down`; no phantom incidents
+- [ ] Pause freezes status + stops checks; resume starts from `pending`
+- [ ] Edits apply next-cycle; no double-scheduling under config churn
+- [ ] Uptime % math excludes `nodata` from denominator

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -53,3 +53,4 @@ for detailed data flows, and the
 - [decisions.md](decisions.md) — the open-decision register: ratify to unblock phases
 - [deployment.md](deployment.md) — Cloud Run + App Hosting contract (cuesoft-iac provisioning, CI/CD pattern)
 - flows/ — feature flow specs with edge cases: [auth](flows/auth.md), [monitor](flows/monitor.md), [alert](flows/alert.md)
+- [analytics-math.md](analytics-math.md) — visitor hashing, sessionization, rollups, uniques honesty rules

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -40,3 +40,11 @@ machine learning, consuming the backend through a clear gRPC interface.
 See [setup.md](setup.md) to run the stack locally, [architecture.md](architecture.md)
 for detailed data flows, and the
 [repository structure](../README.md#repository-structure) in the README.
+
+## Product & design documentation
+
+- [prd.md](prd.md) — product requirements breakdown (triple mandate: monitoring, analytics, ecosystem tracking)
+- [architecture.md](architecture.md) — current system + PRD-phase target design (events layer, alerting)
+- [data-model.md](data-model.md) — current + target entities, retention & privacy defaults
+- [api.md](api.md) — gRPC surface map + the /v1/events ecosystem contract ("D2")
+- [roadmap.md](roadmap.md) — phased plan; Phase 1 unblocks apparule/expendit analytics

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -50,3 +50,4 @@ for detailed data flows, and the
 - [roadmap.md](roadmap.md) — phased plan; Phase 1 unblocks apparule/expendit analytics
 - [design.md](design.md) + [pages.md](pages.md) — design language, pillars, microinteractions
 - [query-grammar.md](query-grammar.md) — the shared query grammar behind explorers, widgets, monitors
+- [decisions.md](decisions.md) — the open-decision register: ratify to unblock phases

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -51,3 +51,5 @@ for detailed data flows, and the
 - [design.md](design.md) + [pages.md](pages.md) — design language, pillars, microinteractions
 - [query-grammar.md](query-grammar.md) — the shared query grammar behind explorers, widgets, monitors
 - [decisions.md](decisions.md) — the open-decision register: ratify to unblock phases
+- [deployment.md](deployment.md) — Cloud Run + App Hosting contract (cuesoft-iac provisioning, CI/CD pattern)
+- flows/ — feature flow specs with edge cases: [auth](flows/auth.md), [monitor](flows/monitor.md), [alert](flows/alert.md)

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -48,3 +48,5 @@ for detailed data flows, and the
 - [data-model.md](data-model.md) — current + target entities, retention & privacy defaults
 - [api.md](api.md) — gRPC surface map + the /v1/events ecosystem contract ("D2")
 - [roadmap.md](roadmap.md) — phased plan; Phase 1 unblocks apparule/expendit analytics
+- [design.md](design.md) + [pages.md](pages.md) — design language, pillars, microinteractions
+- [query-grammar.md](query-grammar.md) — the shared query grammar behind explorers, widgets, monitors

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -54,3 +54,4 @@ for detailed data flows, and the
 - [deployment.md](deployment.md) — Cloud Run + App Hosting contract (cuesoft-iac provisioning, CI/CD pattern)
 - flows/ — feature flow specs with edge cases: [auth](flows/auth.md), [monitor](flows/monitor.md), [alert](flows/alert.md)
 - [analytics-math.md](analytics-math.md) — visitor hashing, sessionization, rollups, uniques honesty rules
+- [engineering.md](engineering.md) — error catalog, authz matrix, rate limits, testing strategy, logging rules

--- a/docs/pages.md
+++ b/docs/pages.md
@@ -1,0 +1,142 @@
+# Upstat — Pages, Screens & Features
+
+> Component-level inventory referencing [design.md](design.md) (`MI-n`).
+> The 2026-07-16 directive expands Upstat to a **full observability & SRE
+> platform** (Datadog-class) — this supersedes the earlier PRD §5
+> "lightweight, avoid enterprise observability" restraint, which previous
+> docs treated as a guardrail. Superseded statements in prd.md/roadmap.md are
+> annotated rather than rewritten (audit trail). **[Directive]**
+
+## Part A — Public home page (upstat.cuesoft.io)
+
+Shared CueLABS open-source-site pattern (Discord, GitHub, preview, **Try
+Cloud** / **Self Host**) in a Datadog-style product-led execution. The
+existing Figma landing (single desktop frame; pillars "Dev-first workflows",
+"Works for your Business needs", "Open-source, Transparent and
+community-driven") remains the visual base, extended for the new pillars.
+
+| # | Section | Content | Interactions |
+| --- | --- | --- | --- |
+| A1 | Nav | logo · Platform (pillar dropdown) · Docs (GitBook) · Community · GitHub badge · Sign in · **Try Cloud** | pillar dropdown = mini feature map |
+| A2 | Hero | H1 (from Figma pillars); dual CTA **Try Cloud** / **Self Host**; hero visual: live-looking dashboard with animated timeseries + synced crosshair demo | crosshair demo animates on an 8s loop |
+| A3 | Pillar grid | 8 cards: Uptime & Synthetics · Website Analytics/RUM · Metrics · Logs · APM/Traces · Dashboards · Alerting · Incidents & SLOs | hover lifts + pillar color accent |
+| A4 | Live demo strip | embedded read-only demo org (synthetic telemetry): status page + one dashboard | interactive TimePicker within bounds |
+| A5 | How ingestion works | OTLP/agent diagram: your services → OTel SDK/collector → Upstat | copyable snippet tabs (Go/Python/Node/k8s) |
+| A6 | Reliability showcase | Upstat's own public status page embedded (self-referential trust, PRD §5) | |
+| A7 | Open source | compose snippet, architecture diagram, GitHub/CONTRIBUTING | |
+| A8 | Community | Discord card, roadmap, CueLABS | |
+| A9 | Cloud vs Self-host table | per-column CTAs | |
+| A10 | Footer | standard + privacy (UPS-005) | |
+
+## Part B — Dashboard (the observability app)
+
+Left icon rail (design.md §2): **Home · Dashboards · Metrics · Logs · Traces ·
+RUM/Analytics · Synthetics/Uptime · Monitors · Incidents · SLOs · Service
+Catalog · Settings**. Global TimePicker + QueryBar grammar shared across
+pillars. Every pillar's empty state = MI-16 inline onboarding.
+
+### B1 Home
+- Org health at a glance: open incidents banner (MI-14), triggered monitors,
+  SLO burn cards (MI-15), watched dashboards row, recent deploy markers
+  **[Proposed: deploy events via API]**.
+
+### B2 Dashboards
+- List (org-shared, favorites) → grid editor (MI-11/12): widget types:
+  timeseries, query value, top list, table, heatmap, log stream, trace
+  latency, SLO, status, service map, markdown.
+- Template variables (`$env`, `$service`) with dropdown bar; JSON
+  import/export of dashboard definitions **[Proposed: portable format]**.
+
+### B3 Metrics
+- Explorer: QueryBar (metric, filters, group-by, aggregation, rollup) → chart
+  with MI-2/3; save-to-dashboard.
+- Metrics summary: catalog with cardinality, ingestion rate, last seen; tag
+  explorer.
+- Ingestion: OTLP metrics + StatsD-compatible endpoint **[Proposed]**.
+
+### B4 Logs
+- Explorer: FacetSidebar (service, level, host, custom) + QueryBar + LogLine
+  list (virtualized) + histogram header (MI-6); live tail (MI-4); expand
+  pivots (MI-5).
+- Patterns view: auto-grouped similar lines with counts **[Later]**.
+- Retention/indexing settings per source; archive-to-object-storage
+  **[Later]**.
+
+### B5 Traces (APM)
+- Service list: req/s, p50/p95/p99, error rate, apdex-ish score; click →
+  service page (endpoints table + latency distribution + deps).
+- Trace explorer: search by service/endpoint/duration/status → TraceWaterfall
+  (MI-7) with span drawer (tags, logs-in-span, process info).
+- Service map: force-layout hexagons (design.md), edge tooltips with
+  throughput/error/latency.
+
+### B6 RUM / Website analytics
+- The Phase-1 events layer grows into RUM: page views, sessions (cookieless
+  visitor model per data-model.md), core web vitals (LCP/CLS/INP from the
+  browser SDK), top pages/referrers/devices/geo; error tracking (JS errors
+  grouped by fingerprint).
+- Existing traffic dashboard pages fold into this pillar (mock routes die
+  as planned, ANA-002).
+
+### B7 Synthetics / Uptime (the current core, absorbed)
+- Monitors (existing CRUD) → "Uptime checks" within Synthetics: HTTP checks
+  (existing), multi-step API checks **[Later]**, browser checks **[Later]**.
+- UptimeCards + per-monitor page: check history, response-time chart,
+  incidents, insight panel (existing ML insight surfaces here).
+- Public status pages: existing `GetStatusPage` + configurable status-page
+  builder (logo, components, subscribe-to-updates **[Later]**).
+
+### B8 Monitors (alerting on any signal)
+- Monitor types: uptime state (exists conceptually), metric threshold,
+  log count/pattern, trace latency/error-rate, SLO burn rate.
+- Rule editor: query + thresholds (warn/crit) + evaluation window + MI-9
+  test-replay; notification channels (email, webhook, Slack **[phased]**),
+  cooldown/renotify, mute windows.
+- Triggered feed with MI-14; monitor status page (grouped by state).
+
+### B9 Incidents
+- Existing incident records grow into incident management: declare (from
+  alert or manual), sev levels, roles (commander/responders), timeline
+  composer (MI-10), status page linkage, postmortem doc template on resolve
+  **[Proposed]**.
+
+### B10 SLOs
+- Define: SLI source (uptime check, metric ratio, latency threshold), target
+  (99.9%), window (30d rolling); SLOCards with burn (MI-15); burn-rate
+  monitors one click away.
+
+### B11 Service catalog
+- Registry: service name, owner, repo/runbook links, environments, telemetry
+  presence indicators per pillar; feeds the map + QueryBar autocomplete.
+
+### B12 Settings
+- Org/members/roles; **API keys & ingestion tokens** (per-pillar scopes);
+  property keys (RUM); integrations (webhooks, Slack); retention per signal;
+  usage metering per pillar **[Proposed]**; privacy/data controls.
+
+## Part C — Mobile companion (later; parity direction **[Directive]**)
+
+Sketch: on-call-first app — incident push, ack/resolve, sev timeline
+posting, monitor mute, status overview. Not scheduled before B-pillar
+maturity.
+
+## Feature register delta (extends prd.md)
+
+| ID | Pillar / feature | Priority | Depends on |
+| --- | --- | --- | --- |
+| OBS-001 | OTLP ingestion gateway (traces, metrics, logs) + SDK/collector docs | Must | TSDB/columnstore decision (architecture.md §"storage") |
+| OBS-002 | Metrics explorer + storage | Must | OBS-001 |
+| OBS-003 | Logs explorer + live tail + facets | Must | OBS-001 |
+| OBS-004 | APM: services, trace explorer, waterfall, service map | Must | OBS-001 |
+| OBS-005 | Composable dashboards (grid editor, portable JSON) | Must | OBS-002/003 minimum |
+| OBS-006 | Monitors on any signal + channels | Must | pillar queries |
+| OBS-007 | RUM: browser SDK (vitals, errors) atop events layer | Must | events layer (Phase 1) |
+| OBS-008 | Incident management (sev, roles, timeline, postmortem) | Should | OBS-006 |
+| OBS-009 | SLOs + burn-rate monitors | Should | OBS-002 |
+| OBS-010 | Service catalog | Should | OBS-004 |
+| OBS-011 | Synthetics beyond HTTP (multi-step API, browser checks) | Later | B7 |
+| OBS-012 | Log patterns, archives; usage metering | Later | OBS-003 |
+
+Cross-refs: ingestion/storage architecture + supersession note →
+architecture.md (appended section); entities → data-model.md §5; API →
+api.md §6; phasing → roadmap.md revision.

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -1,0 +1,121 @@
+# Upstat — Product Requirements Breakdown
+
+> Source: "Upstat Product Requirement Document" (provided 2026-07-15) combined
+> with the repository state on `main`. The linked
+> [Figma file](https://www.figma.com/design/F2b1icjCmZp1MvOft6HMCV/Upstat)
+> contains a single desktop landing design (messaging pillars: "Dev-first
+> workflows", "Works for your Business needs", "Open-source, Transparent and
+> community-driven") — usable for the landing build; its frames are unnamed,
+> so a light design-hygiene pass is recommended before handoff.
+>
+> Markers: **[PRD]** = stated requirement, **[Current]** = verified repository
+> fact, **[Proposed]** = design decision introduced here for ratification.
+
+## 1. Product definition — a triple mandate
+
+Upstat is a website & microservice analytics and status-monitoring product:
+real-time visibility into web-property health, traffic, and service
+statistics. **[PRD]** Reading the PRD against the code, Upstat carries three
+distinct mandates:
+
+| Mandate | PRD basis | Current state **[Current]** |
+| --- | --- | --- |
+| **M1 — Uptime & status monitoring** | "uptime checks, microservice status" (§3 features grid) | **Implemented**: monitors (interval, timeout, failure threshold), scheduled checker, check results, incidents, public status page, ML-assisted insights |
+| **M2 — Website analytics** | "website stats", "traffic", "tracking scripts" (§3, §5) | **UI shell only**: dashboard pages for traffic/bounce/SEO/page-load exist on mock `/api/dashboard/*` routes; no ingestion, no tracking script |
+| **M3 — Ecosystem event tracker** | "serves as the standardized event tracking service for other products" (§4.2) | **Missing** — and both sibling PRDs depend on it (apparule "Demo Starts"/"GitHub Clicks", expendit "Upload Success"/"Report Generation"). This repo *provides* what their roadmaps call dependency **D2** |
+
+The PRD's §5 restraint governs all three: *"initial functionality must focus on
+uptime and basic analytics, avoiding overpromises of complex enterprise
+observability."* Upstat is not an APM/tracing/logging product.
+
+Upstat is also self-referential: the PRD requires the site itself to
+demonstrate Cuesoft's engineering standards and infrastructure stability
+(§5 "Reliability Showcase") — Upstat should monitor Upstat, publicly.
+**[PRD, operationalized in roadmap P0]**
+
+## 2. Personas and jobs-to-be-done
+
+| Persona | Job-to-be-done | Primary surface |
+| --- | --- | --- |
+| Founders & technical teams | Credible, simple monitoring for their properties | Monitors, status pages, alerts |
+| Agencies & product owners | Visibility into product health/statistics | Dashboards, reports |
+| Cuesoft-managed clients | Reliability reporting on delivered solutions | Status pages, managed reports via `clients.cuesoft.io` |
+| Internal engineering (Cuesoft) | Ecosystem reliability + product event analytics | M3 events, dashboards |
+
+## 3. Functional requirements
+
+### 3.1 Stated requirements, mapped against current state
+
+| ID | Requirement | Priority | Current state **[Current]** | Gap |
+| --- | --- | --- | --- | --- |
+| UPS-001 | Public landing page — value understood within one page | Must | `/` page exists; Figma landing design available | Apply the design; copy per §6 CTAs |
+| UPS-002 | Dashboard / app entry — sign in and open the app | Must | Login/signup + Google auth + protected dashboard shell all work | Entry CTAs from landing; account.cuesoft.io later (D1) |
+| UPS-003 | Setup documentation — scripts, API endpoints, alert config, retention | Should | `docs/setup.md` covers self-hosting only | User-facing setup guides: monitor creation, tracking-script install, alert config, retention statement (needs M2/M3 + alerts to exist) |
+| UPS-004 | Example analytics cards on the public page | Should | Dashboard components exist (uptime cards, charts) | Reuse with demo data on landing |
+| UPS-005 | Privacy disclosure — what tracking/service data is collected | Must | Nothing | Privacy page + `privacy.cuesoft.io` clause (D3); must cover visitor-analytics collection (M2) |
+
+### 3.2 Ecosystem requirements
+
+| ID | Requirement | Notes |
+| --- | --- | --- |
+| ECO-AUTH | Identity via `account.cuesoft.io` | External (D1); current local JWT + Google auth is the interim |
+| **ECO-TRACK** | **Be** the standardized cross-product event tracker | Upstat is the *provider* of the ecosystem's D2. Contract in api.md §3; consumers: apparule, expendit, cuesoft.io properties |
+| ECO-SUPPORT | Managed-client monitoring reports via `clients.cuesoft.io` | Report generation/export needed first (roadmap P3) |
+
+### 3.3 Derived requirements **[Proposed]** (implied by §3 features grid + M-mandates)
+
+| ID | Requirement | Rationale |
+| --- | --- | --- |
+| MON-001 | **Alerting** — notify on monitor state change (email first, webhook second) | Features grid says "alerts"; today status flips are silent — a monitoring product that tells no one is a dashboard, not a monitor |
+| ANA-001 | Event-ingestion API + JS tracking script | M2/M3 foundation; lightweight page-view + custom-event beacon |
+| ANA-002 | Dashboards read real aggregates | Replace the mock `/api/dashboard/*` routes — mocks were acceptable scaffolding, not product |
+| ANA-003 | Data-retention policy, stated and enforced | UPS-003 requires documenting retention; you can't document what isn't defined (data-model.md §4 proposes 90d raw / 13mo rollups) |
+
+## 4. Non-goals (initial releases)
+
+- APM, distributed tracing, log aggregation, RUM session replay — the §5
+  restraint. Explicitly out until the PRD changes.
+- Paid plans/billing (not in PRD).
+- Mobile apps.
+- Replacing the mock SEO/bounce/page-load pages with real products in v1 —
+  they follow once ANA-001 data exists to derive them honestly (roadmap P2).
+
+## 5. Brand & content requirements
+
+- Aesthetic: clean, data-oriented, minimal, credible. **[PRD §2]**
+- Landing: hero + dashboard preview, features grid (stats, uptime checks,
+  microservice status, alerts, reporting), example dashboards, setup docs,
+  app-entry CTAs. **[PRD §3]**
+- CTAs: "Open App", "Create Monitor", "View Dashboard". **[PRD §6]**
+- Figma: apply the existing desktop design; note its three messaging pillars.
+
+## 6. Compliance & safety requirements
+
+| Concern | Requirement |
+| --- | --- |
+| Visitor privacy | UPS-005: disclose exactly what the tracking script collects; default to cookieless, anonymized collection **[Proposed]** (data-model.md §4) |
+| Ecosystem events | Events from sibling products are counters + coarse dimensions only — never measurement data (apparule) or financial data (expendit); enforce by schema, not convention (api.md §3.2) |
+| Legal | Upstat clause in central `privacy.cuesoft.io` hub (D3) **[PRD §7]** |
+
+## 7. Success metrics **[Proposed]**
+
+| Metric | Why |
+| --- | --- |
+| Monitors created; % monitors with ≥1 alert channel | M1 adoption + MON-001 uptake |
+| Properties with live tracking script; events/day ingested | M2/M3 adoption |
+| Sibling-product events flowing (apparule, expendit) | ECO-TRACK delivered — unblocks two roadmaps |
+| upstat.cuesoft.io's own public status page uptime | §5 reliability showcase, self-referential |
+
+## 8. Open questions
+
+1. **Event API authentication for browsers** — tracking scripts can't hold
+   secrets. Proposed: public write-only property key, origin-checked, rate
+   limited (api.md §3.1); confirm this satisfies the privacy posture.
+2. **Alert channels order** — email first (needs an SMTP/provider decision —
+   note the old SMTP plumbing was deliberately removed), webhook second,
+   Slack later? MON-001 assumes email→webhook.
+3. **gRPC-Web vs REST for new surfaces** — monitors stay gRPC (works today);
+   event ingestion + stats query are proposed as plain HTTP/JSON (browser
+   beacons + simpler consumer contract). Confirm the split is acceptable.
+4. **Managed-client reports** (ECO-SUPPORT) — format and cadence owned by
+   `clients.cuesoft.io`? Blocks roadmap P3 shape.

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -119,3 +119,26 @@ demonstrate Cuesoft's engineering standards and infrastructure stability
    beacons + simpler consumer contract). Confirm the split is acceptable.
 4. **Managed-client reports** (ECO-SUPPORT) — format and cadence owned by
    `clients.cuesoft.io`? Blocks roadmap P3 shape.
+
+---
+
+## 9. Scope expansion — full observability platform (2026-07-16) **[Directive]**
+
+Look and feel: **datadoghq.com** ([design.md](design.md)). Upstat's target is
+now "almost everything a full-fledged observability and SRE platform can do".
+**This supersedes §1's M-restraint and §4's non-goals list** (APM/tracing/logs
+were excluded there; they are now core pillars — kept above for audit trail).
+
+- Pillar & feature register: OBS-001…012 in [pages.md](pages.md); page-level
+  breakdowns for all pillars (dashboards, metrics, logs, traces, RUM,
+  synthetics, monitors, incidents, SLOs, service catalog).
+- Ingestion: OpenTelemetry-native (OTLP), plus the events layer (→ RUM) and
+  the existing uptime checker (→ synthetics) — architecture.md expansion
+  section.
+- New gating decision **R2**: unified telemetry store (ClickHouse proposed).
+- The three earlier mandates map in: M1 → Synthetics/Uptime pillar,
+  M2/M3 → RUM/Analytics pillar (events layer unchanged as its foundation).
+- Platform structure **[Directive]**: home page (shared open-source pattern:
+  Discord, GitHub, preview, Try Cloud / Self Host) + dashboard + eventual
+  mobile companion (on-call-first). Docs on GitBook (Git-synced from
+  `docs/`); API reference via Scalar.

--- a/docs/query-grammar.md
+++ b/docs/query-grammar.md
@@ -1,0 +1,79 @@
+# Upstat — Shared Query Grammar
+
+> The one grammar behind every pillar's QueryBar, `POST /v1/query`, dashboard
+> widgets, and monitor rules (design.md §3, api.md §6). Everything here is
+> **[Proposed]** — ratify before OBS-001 implementation freezes it.
+
+## 1. Shape
+
+```
+<query>      ::= <filters> [ "|" <aggregation> [ "by" <group-list> ] ]
+<filters>    ::= <term> { " " <term> }          # terms AND by default
+<term>       ::= <facet> ":" <value>
+               | <facet> ":" <op> <number>
+               | "-" <term>                      # negation
+               | <free-text>                     # message/full-text match
+               | "(" <term> { " OR " <term> } ")"
+<op>         ::= ">" | ">=" | "<" | "<=" | "="
+<aggregation>::= <fn> "(" [<field>] ")" [ "," <fn> "(" <field> ")" ... ]
+<fn>         ::= count | rate | sum | avg | min | max | p50 | p95 | p99 | uniq
+<group-list> ::= <facet> { "," <facet> }
+```
+
+Examples:
+
+| Query | Meaning |
+| --- | --- |
+| `service:api-common status:error` | error logs/spans for one service |
+| `service:api-common \| count() by level` | log counts grouped by level |
+| `metric:http.request.duration_ms service:web \| p95() by path` | p95 latency per path |
+| `-level:debug (service:web OR service:envoy) timeout` | free-text "timeout", two services, no debug |
+| `check:homepage \| rate()` | uptime check pass rate |
+
+## 2. Facet namespace
+
+| Prefix | Applies to | Examples |
+| --- | --- | --- |
+| *(core)* | all signals | `service`, `env`, `host`, `status`, `level` |
+| `metric:` | metrics | selects the series; remaining terms filter tags |
+| `check:` | synthetics | monitor name/id |
+| `trace.` | spans | `trace.endpoint`, `trace.duration_ms`, `trace.error` |
+| `rum.` | RUM events | `rum.path`, `rum.vital.lcp`, `rum.country` |
+| `@` | custom attributes | `@user_tier:pro` (log/span attrs map) |
+
+Facet autocomplete is fed by the service catalog + per-signal attribute
+indexes ranked by cardinality (design.md MI-13).
+
+## 3. Semantics
+
+- **Time never appears in the query** — the global TimePicker supplies
+  `[from, to)`; monitor rules supply their evaluation window. One less thing
+  to parse, and every query is reusable across ranges.
+- Terms AND; explicit `OR` requires parentheses; `-` negates a single term.
+- Free text applies to the signal's natural text field (log message, span
+  name, event name); quoted strings match phrases.
+- `| aggregation` returns series/tables; without it, the raw stream
+  (log lines, spans, events) paginates.
+- Unknown facets are **errors, not empty results** (MI-13 underline) —
+  silent-empty is how users lose an hour.
+- Case: facet names lowercase; values case-sensitive except `level`.
+
+## 4. Consumers & translation
+
+| Consumer | Uses |
+| --- | --- |
+| Explorers (logs/metrics/traces/RUM) | filters + optional aggregation |
+| Dashboard widgets | full query persisted in `WIDGET.query` |
+| Monitor rules | full query + thresholds evaluated on schedule |
+| `/v1/stats` (legacy events path) | sugar over `rum.*` count queries |
+
+One internal query service parses the grammar into an AST, validates facets
+against the catalog/indexes, then compiles per store: ClickHouse SQL for
+logs/spans/metrics (pending R2), Mongo aggregation for control-plane data.
+The AST — not the string — is what monitors persist, so grammar evolution
+can re-serialize saved queries.
+
+## 5. URL representation
+
+`?q=<url-encoded query>&from=…&to=…&live=1` on every explorer — shareable,
+back/forward-safe (MI-1), and the exact payload of `POST /v1/query`.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,75 @@
+# Upstat — Roadmap
+
+> Ordered plan from the gap analysis (api.md §4). Upstat's monitoring core
+> (M1) works; the phases apply the landing design, ship the events layer that
+> two sibling roadmaps wait on, make dashboards honest, and add alerting.
+
+## Phase 0 — Landing + privacy (public face)
+
+| Item | Requirement | Notes |
+| --- | --- | --- |
+| Apply the Figma landing design (hero + dashboard preview, features grid, example cards, CTAs) | UPS-001, UPS-004, PRD §6 | Design exists (single desktop frame; run a naming/hygiene pass + responsive interpretation) |
+| Example analytics/uptime cards with demo data | UPS-004 | Reuse dashboard components |
+| Privacy disclosure page | UPS-005, D3 | Must already describe the *intended* cookieless analytics posture so ANA-001 ships inside a published promise |
+| Public status page for upstat.cuesoft.io itself | PRD §5 reliability showcase | `GetStatusPage` already exists — configure + link it |
+
+**Exit criteria:** a visitor understands the product in one page; Upstat's own
+status is public; privacy stance published.
+
+## Phase 1 — Events layer (M3 first: unblock the ecosystem)
+
+> Highest cross-repo leverage: apparule Phase 0 and expendit Phase 3 are
+> blocked on this (their "D2").
+
+| Item | Requirement |
+| --- | --- |
+| Property + write-only key model, origin allowlists | ANA-001 |
+| `POST /v1/events` (schema-validated, rate-limited, batch) | ANA-001 / ECO-TRACK |
+| `upstat.js` tracking script (cookieless, SPA-aware) | ANA-001 |
+| Rollup worker in api/observability (hour/day, approx uniques) | ANA-001 |
+| `GET /v1/stats` | ANA-002 dependency |
+| TTL retention indexes + documented policy | ANA-003 |
+| Register sibling consumers (apparule, expendit event names) | ECO-TRACK |
+
+**Exit criteria:** sibling products' events flow end-to-end and appear in
+stats queries; retention enforced by TTL; D2 declared **delivered** to the
+other repos.
+
+## Phase 2 — Honest dashboards + alerting
+
+| Item | Requirement |
+| --- | --- |
+| Traffic dashboard reads `/v1/stats` (mock routes deleted) | ANA-002 |
+| Bounce/SEO/page-load pages: keep only what real data supports; park the rest | ANA-002, PRD §5 restraint |
+| `AlertService` (channels: email + webhook; rules: down/recovered, cooldown) | MON-001 |
+| Worker dispatch on state transitions | MON-001 |
+| Email provider decision + verified-channel flow | prd.md §8.2 |
+| User-facing setup docs: create monitor, install script, configure alerts, retention | UPS-003 |
+
+**Exit criteria:** no mock data anywhere; a down monitor emails its owner
+within one check interval; UPS-003 docs published.
+
+## Phase 3 — Ecosystem identity + managed reporting
+
+| Item | Requirement | Notes |
+| --- | --- | --- |
+| `account.cuesoft.io` sign-in + local-user linking | ECO-AUTH | Blocked by D1 |
+| Managed-client monitoring reports (export/scheduled) for `clients.cuesoft.io` | ECO-SUPPORT | Shape depends on prd.md §8.4 |
+| Cross-product analytics views for internal teams | M3 maturity | e.g. ecosystem-wide event dashboard |
+
+## Dependencies
+
+| ID | Dependency | Direction | Blocks |
+| --- | --- | --- | --- |
+| D1 | `account.cuesoft.io` contract | consumed | Phase 3 identity |
+| **D2** | Event-ingestion API | **provided by this repo (Phase 1)** | apparule P0 analytics, expendit P3 analytics |
+| D3 | Upstat clause on privacy.cuesoft.io | consumed | Phase 0 privacy copy |
+| D4 | Email provider decision | internal | Phase 2 email alerts (webhooks unaffected) |
+
+## Sequencing rationale
+
+Phase 0 is pure web + configuration. Phase 1 jumps ahead of alerting because
+two other product roadmaps are blocked on it and it's additive (new endpoints,
+no changes to the working monitor path). Phase 2 then makes the product honest
+(real data) and complete (alerts — the biggest monitoring-product gap). Phase 3
+waits on external contracts.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -73,3 +73,32 @@ two other product roadmaps are blocked on it and it's additive (new endpoints,
 no changes to the working monitor path). Phase 2 then makes the product honest
 (real data) and complete (alerts — the biggest monitoring-product gap). Phase 3
 waits on external contracts.
+
+---
+
+## Revision — observability platform expansion (2026-07-16)
+
+Supersedes the §5-restraint framing above (kept for audit). Phases 0–2 stand
+— they build the landing, the events layer (now the RUM foundation), honest
+dashboards, and alerting channels. The expansion then proceeds by pillar,
+each gated on the storage decision **R2 (ClickHouse — ratify)**:
+
+- **Phase 3 — Ingestion + Metrics**: OTLP gateway, ingest keys/quotas,
+  telemetry store, metrics explorer, dashboard grid v1 (OBS-001/002/005),
+  monitor engine generalized to metric thresholds.
+- **Phase 4 — Logs**: log intake, explorer + live tail + facets, log
+  monitors (OBS-003).
+- **Phase 5 — APM**: trace intake, service pages, waterfall, service map,
+  latency/error monitors (OBS-004, OBS-010 catalog alongside).
+- **Phase 6 — RUM maturation**: browser SDK grows vitals + error tracking on
+  the events layer (OBS-007); analytics pages complete.
+- **Phase 7 — SRE layer**: incident management v2, SLOs + burn monitors,
+  postmortems (OBS-008/009); mobile on-call companion enters design.
+- Ongoing: synthetics beyond HTTP, log patterns/archives, usage metering
+  (OBS-011/012).
+
+Sequencing rationale: metrics before logs before traces matches ingestion
+complexity and monitor value; RUM rides the already-shipped events layer;
+the SRE layer needs signals to exist first. Every pillar ships explorer +
+retention + monitors together (architecture honesty stance) — feature flags
+keep partial pillars invisible.


### PR DESCRIPTION
PRD documentation phase for upstat. Docs only — no code.

**Framing:** the PRD gives upstat a triple mandate — M1 uptime/status monitoring (**already implemented**: monitors, checker, incidents, status page, ML insights), M2 website analytics (**UI shell only** — traffic/bounce/SEO pages run on mock `/api/dashboard/*` routes), and M3 **the ecosystem's standardized event tracker** (§4.2) — the `D2` dependency both sibling PRD breakdowns wait on.

- **prd.md** — requirement register (UPS-001…005 + derived MON/ANA requirements incl. alerting, which the features grid promises but nothing implements), non-goals guardrail (§5 'no enterprise observability'), open questions (browser event auth, email provider, gRPC/REST split).
- **architecture.md** — existing current-state doc extended with the target design: events layer (ingestion → rollups → stats), alert dispatch sequence, mermaid throughout.
- **data-model.md** — current entities (ER) + target (properties, schema-validated events, rollups, alert rules/channels), cookieless `visitor_hash` design, TTL-based retention defaults.
- **api.md** — current gRPC map + the **`POST /v1/events` / `upstat.js` / `GET /v1/stats` contract**, including the consumer registry (apparule: demo_start/github_click; expendit: upload_success/report_generation — counters only, enforced by schema).
- **roadmap.md** — Phase 1 ships the events layer ahead of alerting deliberately: two other repos are blocked on it.

Also of note: the upstat Figma file (unlike the other two) **has a real landing design** — referenced in Phase 0.

Intended for iteration — comment inline and I'll revise on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)