### PR TITLE
docs: link the published GitBook site

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ token). See [docs/setup.md](docs/setup.md) for details; `make help` lists all
 targets. Never commit credentials or bake them into an image.
 
 ## Documentation
+- [Hosted docs](https://cuesoft.gitbook.io/upstat) — the full documentation site (auto-synced from `docs/`)
 
 - [Project overview](docs/overview.md) — architecture and components
 - [Local setup](docs/setup.md) — development environment and per-service run commands

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -42,6 +42,8 @@ for detailed data flows, and the
 [repository structure](../README.md#repository-structure) in the README.
 
 ## Product & design documentation
+> Published site: **https://cuesoft.gitbook.io/upstat** (Git-synced from this folder on every merge to main).
+
 
 - [prd.md](prd.md) — product requirements breakdown (triple mandate: monitoring, analytics, ecosystem tracking)
 - [architecture.md](architecture.md) — current system + PRD-phase target design (events layer, alerting)


### PR DESCRIPTION
Adds https://cuesoft.gitbook.io/upstat (live, Git-synced) to README + docs overview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)