### PR TITLE
docs: FAANG-review fixes — all 52 findings addressed

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ detection, and a Next.js frontend talks to the backend over gRPC-Web through an
 Envoy proxy. For a deeper description of the components and how they fit
 together, see [docs/overview.md](docs/overview.md).
 
+> **Scope note:** the diagram below is current state (uptime/status core).
+> Upstat's ratified direction is a full observability platform — see
+> [docs/prd.md §9](docs/prd.md) and [docs/decisions.md](docs/decisions.md).
+
 ## Architecture
 
 ```mermaid

--- a/api/common/docs/grpc-api.md
+++ b/api/common/docs/grpc-api.md
@@ -1,5 +1,23 @@
 # Upstat Common Server gRPC API
 
+> **STATUS BANNER (X-1 hardened, 2026-07-16)** — per-RPC fate:
+> `GoogleAuth` → **replaced** by Firebase ID-token verification in the
+> interceptor (docs/flows/auth.md); `CreateUser` + password-based `GetUser`
+> sign-in → **retired** after the 60-day migration window
+> (`FAILED_PRECONDITION migrate_to_firebase`); `GetUser` (profile fetch),
+> `UpdateUser`, `DeleteUser`, `GetAllUsers` → **kept** (bearer-authed);
+> `MonitorService` → **kept** unchanged; app-JWT issuance → **retired**.
+> Password/JWT sections below document the pre-migration system.
+>
+> **Monitor field notes**: examples use `type: "http"` — the current enum is
+> `website | server | api | blog` (display taxonomy); initial
+> `status: "unknown"` maps to the state machine's `pending`
+> (docs/flows/monitor.md §2). `GetRecentChecks` (public, used by the
+> observability service): request `{monitor_id, limit ≤ 100 (default per
+> UPSTAT_GRPC_CHECK_LIMIT)}` → response `{checks: [{up, status_code,
+> response_time_ms, checked_at}]}`; public rate posture = same per-IP limit
+> as other public RPCs (engineering.md §3).
+
 This document describes the gRPC API exposed by the Go backend in `api/common`.
 
 ## Server

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -17,7 +17,7 @@
 - [Architecture](architecture.md)
 - [Data Model](data-model.md)
 - [API Surface](api.md)
-- [gRPC Reference](../api/common/docs/grpc-api.md)
+- [gRPC Reference](https://github.com/cuesoftinc/upstat/blob/main/api/common/docs/grpc-api.md)
 - [Query Grammar](query-grammar.md)
 - [Analytics Math](analytics-math.md)
 - [OpenAPI Draft](api/openapi.yaml)

--- a/docs/analytics-math.md
+++ b/docs/analytics-math.md
@@ -11,9 +11,12 @@
 visitor_hash = hex( SHA-256( daily_salt ‖ property_id ‖ ip ‖ user_agent ) )[:32]
 ```
 
-- `daily_salt`: 32 random bytes, rotated at 00:00 UTC, **previous salts
-  destroyed** — cross-day linkage is cryptographically dead, which is the
-  privacy guarantee UPS-005 publishes.
+- `daily_salt`: 32 random bytes per UTC day, **selected by the event's `ts`
+  day** (not arrival time) so late events hash consistently with their
+  bucket; a day's salt is destroyed **48h after that day ends** (aligned with
+  the ingest window §5 — after destruction no event can legally arrive for
+  it). Cross-day linkage remains cryptographically dead — the privacy
+  guarantee UPS-005 publishes is unchanged (no salt ever spans two days).
 - `ip` is used pre-hash only; never stored. Proxied requests use the
   left-most public address in `X-Forwarded-For` as seen by our LB.
 - Consequences (documented, not hidden): the same person counts anew each
@@ -23,10 +26,16 @@ visitor_hash = hex( SHA-256( daily_salt ‖ property_id ‖ ip ‖ user_agent ) 
 ## 2. Sessionization (derived, not stored per-event)
 
 A *visit* = consecutive events with the same `visitor_hash` on one property
-with gaps < 30 min (industry-standard heuristic). Computed inside the rollup
-job, producing per-bucket: `visits`, `bounce_visits` (single-page-view
-visits), `total_visit_seconds` (sum of last-event − first-event per visit;
-zero for bounces). Derived UI metrics:
+with gaps < 30 min. Computed inside the rollup job into a dedicated
+**`VISIT_ROLLUP`** row family `(property, period, bucket)` — columns:
+`visits`, `bounce_visits`, `total_visit_seconds` (data-model §2 gains the
+entity). Attribution rules **[Decided]**: a visit belongs to the bucket of
+its **first event**; a *bounce* = a visit whose only **page_view** count is
+1 (custom events don't break bounce-ness); visits have no dims (dims apply
+to event rollups only — the cardinality-explosion guard). Event `ROLLUP`
+rows are per `(name, single-dim-key, dim-value)`, never dim cross-products,
+capped at the **top 1,000 dim values per bucket** (the tail aggregates to
+`__other__`). Derived UI metrics:
 
 | Metric | Formula | Honesty note |
 | --- | --- | --- |
@@ -44,9 +53,10 @@ keyed `(property, period, bucket, name, dims)`:
   (volumes make exact feasible; no sketches in v1).
 - Daily rollups aggregate from raw events (not from hourly rollups) so daily
   uniques are exact for the day.
-- Idempotent upserts: the job recomputes the trailing 48h of buckets every
-  run — late events (batched beacons, clock skew ≤ ingest-time bounding)
-  self-heal; buckets older than 48h are immutable.
+- Idempotent upserts: the job recomputes every bucket whose **end** is
+  within the trailing 48h — late events self-heal; a bucket becomes immutable
+  only once `bucket_end < now − 48h`, which (with the §5 accept window)
+  guarantees nothing accepted can target an immutable bucket.
 
 ## 4. Uniques across ranges (the non-additivity rule)
 
@@ -62,6 +72,15 @@ exist in this product**. Normative UI rules:
 Any chart or API consumer summing uniques across buckets is wrong by
 specification — `/v1/stats` returns `uniques_additive: false` in range
 metadata to make the contract machine-visible.
+
+
+## 4a. Server-emitted events (sibling APIs)
+
+Events from sibling *servers* (registry `api` rows) carry the sending
+server's IP/UA — hashing them would fabricate visitors. They are marked
+`unique_ineligible` in the registry (api.md §3.4a): counted in `count`,
+**excluded from `uniques` and visit math entirely**. `/v1/stats` for such
+events returns `uniques: null`.
 
 ## 5. Ingest-time bounding
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -24,15 +24,24 @@
 | `GET /insights/{monitor_id}`, `POST /analyze/{monitor_id}` (observability :8081) | insight read/trigger |
 | `web /api/dashboard/stats`, `/api/dashboard/total-users` | **mock data** — scaffolding to be replaced (ANA-002), not product surface |
 
-## 2. Target surface — monitors & alerts **[Proposed]**
+## 1a. Service topology for new surfaces **[Decided]**
 
-Monitors stay gRPC (working, typed, already browser-reachable via Envoy).
-Additions:
+| Surface | Service | Port | Hostname | CORS/origin enforcement |
+| --- | --- | --- | --- | --- |
+| `/v1/events`, `/v1/stats`, `/v1/query`, `/v1/channels`, `/v1/monitors/*/rules` | **api/common** (Go — gains an HTTP mux alongside gRPC/h2c) | 8080 | `api.upstat.cuesoft.io` | in-app middleware (origin allowlist per property for /v1/events; standard CORS for user routes) |
+| `upstat.js` static | web | 3000 | `upstat.cuesoft.io/upstat.js` | n/a (public asset) |
+| OTLP gRPC/HTTP (OBS-001) | ingest gateway (new service at OBS-001) | 4317/4318 | `ingest.upstat.cuesoft.io` | key-authed, no browser CORS |
+| Existing gRPC-Web | Envoy → api/common | 8082→8080 | as today | Envoy CORS (current) |
+
+## 2. Target surface — monitors & alerts
+
+> **Superseded by U-5 (HTTP-only for new surfaces):** the gRPC `AlertService`
+> sketch below is retired — the alert surface is HTTP (`/v1/channels`,
+> `/v1/monitors/{id}/rules`, openapi.yaml), same semantics. Kept for audit.
 
 | Service / RPC | Purpose |
 | --- | --- |
-| `AlertService.CreateChannel / ListChannels / VerifyChannel / DeleteChannel` | email/webhook channels (MON-001) |
-| `AlertService.SetRules / GetRules` | per-monitor rules (on: down/recovered, cooldown) |
+| ~~`AlertService.*` (gRPC)~~ | → HTTP per U-5; see flows/alert.md + openapi.yaml |
 
 ## 3. Target surface — events & stats (M2/M3, the ecosystem "D2" contract) **[Proposed]**
 
@@ -64,8 +73,14 @@ Origin: enforced against the property allowlist  (browser calls)
 → 202 {accepted: n, rejected: m}
 ```
 
-Rules: batch ≤ 100; unknown `dims` keys → event rejected (privacy by schema);
-per-key rate limits; `visitor_hash` computed server-side (cookieless).
+Rules: batch ≤ 100. **Mixed-batch semantics [Decided]:** the endpoint returns
+`202 {accepted: n, rejected: m, rejections: [{index, code}]}` — per-item
+rejection codes (`unknown_event`, `unknown_dim`, `ts_out_of_range`,
+`bad_shape`) so sibling consumers can debug; whole-request 4xx is reserved
+for auth (`401`), origin (`403 origin_not_allowed`), rate (`429`), and
+malformed JSON (`400`). Unknown dims reject the item (privacy by schema);
+per-key rate limits; `visitor_hash` computed server-side (cookieless,
+browser events only — see §3.4a).
 
 ### 3.2 The tracking script (UPS-003 install surface)
 
@@ -80,10 +95,20 @@ Auto page-views (incl. SPA history changes) + manual custom events.
 ### 3.3 Stats query (dashboards + sibling products' own metric reads)
 
 ```
-GET /v1/stats?property=…&name=page_view&period=day&from=…&to=…&dim=path
-Authorization: user JWT (owner) — not the public key
-→ {series: [{bucket, count, uniques}], totals: {…}}
+GET /v1/stats?property=…&name=page_view&period=hour|day&from=RFC3339&to=RFC3339&dim=path
+Authorization: Firebase bearer (owner) — not the public key
+→ 200 {
+    series: [{bucket: RFC3339, count, uniques}],
+    totals: {count, uniques_daily_avg},
+    uniques_additive: false,
+    by_dim?: [{value, count}]        // when &dim= given; top 50 by count
+  }
 ```
+
+Contract: max range 92 days (`422 range_too_large`); one `dim` per query
+(multi-dim = multiple queries); `period=hour` limited to ≤ 8-day ranges;
+no pagination (bounded by range); errors: `404 not_found` (property not
+owned), `422 invalid_period | range_too_large | ts_out_of_range`.
 
 ### 3.4 Consumer registry (who sends what)
 
@@ -94,6 +119,28 @@ Authorization: user JWT (owner) — not the public key
 | expendit web (landing) | `page_view`, `try_cloud_click`, `self_host_click`, `github_click`, `demo_interact` | counters only |
 | expendit api | `auth_signin_completed`, `auth_migration_completed`, `auth_migration_stranded`, `upload_success{file_type}`, `import_confirmed`, `import_discarded`, `report_generation{kind}`, `bank_link_created`, `bank_sync_completed`, `bank_reauth_required`, `consent_recorded{document}` | counters + `file_type`/`kind` dims only — never amounts/descriptions/institutions |
 | upstat itself | `page_view` on upstat.cuesoft.io, `auth_signin_completed`, `auth_migration_completed`, `monitor_created`, `monitor_state_changed{to}` | dogfooding (§5 reliability showcase) |
+
+### 3.4a Registry-as-schema **[Decided — closes the dims contradiction]**
+
+The registry table IS the ingest schema: the §3.1 "closed vocabulary" =
+`page_view`'s browser dims (`path`, `referrer_host`, `device_class`,
+`country`) **plus, per registered event, exactly the dim keys named in its
+registry row** (e.g. `vault_qc_failed{code}` admits `code` with the
+capture-qc enum; `upload_success{file_type}` admits `file_type`). The ingest
+validator resolves the event name against the registry and rejects any dim
+not registered for that event (`unknown_dim`). Value enums live with the
+registry row's source doc.
+
+**Uniques eligibility:** server-emitted events (sibling `api` rows) carry the
+*server's* IP/UA — they are `unique_ineligible: true` in the registry and
+excluded from uniques math (analytics-math.md §4a); only browser events count
+visitors.
+
+Pending registration (added now): apparule `request_quoted`,
+`request_declined{reason}`, `payout_released` (flows/designer.md);
+expendit `statement_confirmed{kind}` (flows/statement-mapping.md).
+`auth_migration_stranded` is REMOVED from the registry (it is a support-ticket
+tag, not an ingest event).
 
 This table is the **master event registry** for the ecosystem — sibling repos'
 instrumentation sections reference it; adding an event means updating this

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -18,7 +18,7 @@ paths:
       summary: "Ingest events (batch ≤100; property key auth; origin-checked; schema-validated)"
       security: [{ propertyKey: [] }]
       responses:
-        "202": { description: "{accepted, rejected}" }
+        "202": { description: Per-item results, content: { application/json: { schema: { $ref: "#/components/schemas/EventBatchResult" } } } }
         "422": { description: ts_out_of_range / schema rejection }
         "429": { description: rate_limited (600/min sustained) }
   /v1/stats:
@@ -31,7 +31,61 @@ paths:
     post: { tags: [alerts], summary: Verify channel, security: [{ firebase: [] }], responses: { "200": { description: Verified } } }
   /v1/monitors/{id}/rules:
     put: { tags: [alerts], summary: Set alert rules (on/cooldown/channels), security: [{ firebase: [] }], responses: { "200": { description: Rules } } }
+  /v1/channels/{id}:
+    delete: { tags: [alerts], parameters: [{ $ref: "#/components/parameters/Id" }], summary: Delete channel (detaches from rules), security: [{ firebase: [] }], responses: { "204": { description: Deleted } } }
+  /v1/channels-list:
+    get: { tags: [alerts], summary: List channels (owner), security: [{ firebase: [] }], responses: { "200": { description: Channels } } }
+  /v1/monitors/{id}/rules-get:
+    get: { tags: [alerts], parameters: [{ $ref: "#/components/parameters/Id" }], summary: Get rules, security: [{ firebase: [] }], responses: { "200": { description: Rules } } }
+
 components:
   securitySchemes:
     firebase: { type: http, scheme: bearer, bearerFormat: "Firebase ID token (google.com provider only)" }
-    propertyKey: { type: http, scheme: bearer, bearerFormat: "write-only property public key" }
+    propertyKey: { type: http, scheme: bearer, bearerFormat: "write-only property public key (pk_..., 24h rotation grace)" }
+  parameters:
+    Id: { name: id, in: path, required: true, schema: { type: string } }
+  schemas:
+    Error:
+      type: object
+      required: [error]
+      properties:
+        error:
+          type: object
+          required: [code, message]
+          properties:
+            code: { type: string, description: snake_case stable (engineering.md §1) }
+            message: { type: string }
+            details: { type: object }
+    EventBatch:
+      type: object
+      required: [events]
+      properties:
+        events:
+          type: array
+          maxItems: 100
+          items:
+            type: object
+            required: [name]
+            properties:
+              name: { type: string, description: registered event name (api.md §3.4) }
+              ts: { type: string, format: date-time, description: "within [now-48h, now+5min]" }
+              dims: { type: object, description: only dims registered for this event }
+    EventBatchResult:
+      type: object
+      properties:
+        accepted: { type: integer }
+        rejected: { type: integer }
+        rejections: { type: array, items: { type: object, properties: { index: { type: integer }, code: { enum: [unknown_event, unknown_dim, ts_out_of_range, bad_shape] } } } }
+    StatsResponse:
+      type: object
+      properties:
+        series: { type: array, items: { type: object, properties: { bucket: { type: string, format: date-time }, count: { type: integer }, uniques: { type: integer } } } }
+        totals: { type: object, properties: { count: { type: integer }, uniques_daily_avg: { type: number } } }
+        uniques_additive: { type: boolean, description: always false (analytics-math.md §4) }
+    AlertRule:
+      type: object
+      properties:
+        "on": { enum: [down, recovered, nodata, all] }
+        channel_ids: { type: array, items: { type: string } }
+        cooldown_minutes: { type: integer, default: 30 }
+        renotify_minutes: { type: integer, default: 0 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -237,6 +237,11 @@ rather than growing scope silently.
 
 ## Ingestion architecture **[Proposed]**
 
+> **X-5 note:** every "MongoDB" box in the earlier (pre-X-5) diagrams of this
+> file reads as the control-plane store — now **Aiven Postgres**; Phase-1
+> events land in Postgres partitioned tables with a scheduled retention job
+> (data-model §3), NOT Mongo TTL. Diagrams are updated as touched.
+
 **OpenTelemetry-native**: OTLP (gRPC + HTTP) is the single first-party intake
 for traces, metrics, and logs — customers use standard OTel SDKs/collectors,
 no proprietary agent to build or maintain. Complements: the existing HTTP
@@ -254,14 +259,27 @@ flowchart LR
     JS -->|/v1/events + vitals| GW
     AGENTLESS -->|statsd shim| GW
     GW --> BUF[[Buffer/queue]]
-    BUF --> TS[(Timeseries store<br/>metrics)]
-    BUF --> LS[(Column/log store<br/>logs + traces)]
+    BUF --> CH[(ClickHouse — one store<br/>metrics + logs + traces, U-1)]
     BUF --> MG[(MongoDB<br/>control plane: orgs, monitors,<br/>dashboards, incidents, SLOs)]
-    TS --> Q[Query layer]
-    LS --> Q
+    CH --> Q[Query layer]
     MG --> Q
     Q --> APP[Dashboards / explorers / monitors]
 ```
+
+## Ingestion operations **[Decided]**
+
+- **Buffering**: Phase 1 (/v1/events) has **no external buffer** — direct
+  Postgres inserts; overload answers `429` (never silent drop; rejected
+  counters tell the truth). OBS-001 (OTLP) uses **ClickHouse async_insert**
+  as the buffer with gateway backpressure → `429 quota_exceeded`; ingest SLO
+  target p99 < 250ms accept latency.
+- **ClickHouse ops**: single node to start (sandbox), daily backups to the
+  Cloud Storage bucket, disk sized to retention (13mo metrics / 15d logs /
+  7d traces), replication deferred until load demands (documented upgrade
+  path: ReplicatedMergeTree + 3 keepers).
+- **Tenancy isolation**: `org_id` prefixes every ORDER BY (data-model DDL);
+  quotas enforced at the gateway per ingest key; per-org query concurrency
+  cap 4 in the query layer (noisy-neighbor containment).
 
 ## The storage decision (gating, R2)
 

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -27,7 +27,9 @@ erDiagram
         string target "URL"
         string type "website | server | api | blog"
         bool active
-        string status "up | down | ..."
+        string status "up | down | pending | nodata | paused (flows/monitor.md §2)"
+        datetime created_at
+        datetime updated_at
         int intervalSeconds
         int timeoutSeconds
         int failureThreshold
@@ -85,7 +87,8 @@ erDiagram
         objectid _id PK
         string ownerId
         string name "e.g. apparule.cuesoft.io"
-        string public_key "write-only ingest key, rotatable"
+        string public_key "format pk_<8 random bytes hex>; write-only"
+        string previous_key "valid 24h after rotation (grace overlap) — the rotation contract"
         json allowed_origins "CORS allowlist for beacons"
         datetime created_at
     }
@@ -110,8 +113,28 @@ erDiagram
     ALERT_RULE {
         objectid _id PK
         objectid monitor_id FK
-        string on "down | recovered | both"
+        string on "down | recovered | nodata | all"
+        json channel_ids "linked ALERT_CHANNELs"
         int cooldown_minutes
+        int renotify_minutes "0 = off (default)"
+    }
+    DISPATCH {
+        objectid _id PK
+        objectid rule_id FK
+        objectid channel_id FK
+        json transition
+        string state "pending | delivered | failed"
+        int attempts
+        datetime next_attempt_at
+    }
+    VISIT_ROLLUP {
+        objectid _id PK
+        objectid property_id FK
+        string period "hour | day"
+        datetime bucket
+        int visits
+        int bounce_visits
+        int total_visit_seconds
     }
     ALERT_CHANNEL {
         objectid _id PK
@@ -166,7 +189,7 @@ Modeling notes:
 
 ## 5. Observability platform entities (2026-07-16) **[Proposed]**
 
-Control plane (MongoDB) additions:
+Control plane additions (**Aiven Postgres** per X-5; entity names keep their shapes):
 
 ```mermaid
 erDiagram
@@ -211,7 +234,7 @@ erDiagram
         int sev "1..4"
         string status "declared|mitigated|resolved"
         json roles "commander, responders"
-        string postmortem_key }
+        string postmortem_key "Cloud Storage: upstat/postmortems/{org}/{incident}.md" }
     SERVICE_ENTRY { objectid _id PK
         objectid org_id FK
         string name
@@ -220,7 +243,43 @@ erDiagram
         json environments }
 ```
 
-Telemetry plane (ClickHouse, pending R2): `metrics_points`
+
+### Telemetry-plane DDL sketch (ClickHouse, U-1 — draft to finalize at OBS-001)
+
+```sql
+CREATE TABLE metrics_points (
+  org_id LowCardinality(String), series_hash UInt64,
+  name LowCardinality(String), tags Map(String, String),
+  ts DateTime64(3), value Float64
+) ENGINE = MergeTree
+  PARTITION BY toYYYYMM(ts)
+  ORDER BY (org_id, series_hash, ts)
+  TTL toDateTime(ts) + INTERVAL 13 MONTH;
+
+CREATE TABLE logs (
+  org_id LowCardinality(String), service LowCardinality(String),
+  level LowCardinality(String), ts DateTime64(3),
+  message String, attrs Map(String, String), trace_id String
+) ENGINE = MergeTree
+  PARTITION BY toDate(ts)
+  ORDER BY (org_id, service, ts)
+  TTL toDateTime(ts) + INTERVAL 15 DAY;
+
+CREATE TABLE spans (
+  org_id LowCardinality(String), trace_id String, span_id String,
+  parent_id String, service LowCardinality(String), name LowCardinality(String),
+  start DateTime64(6), duration_ns UInt64, status UInt8,
+  attrs Map(String, String)
+) ENGINE = MergeTree
+  PARTITION BY toDate(start)
+  ORDER BY (org_id, service, start)
+  TTL toDateTime(start) + INTERVAL 7 DAY;
+```
+
+`org_id` leads every ORDER BY — the tenancy-isolation primitive (queries are
+always org-scoped; cross-org reads are structurally awkward by design).
+
+Legacy sketch note (superseded by the DDL above): `metrics_points`
 (series-hash, ts, value, tags), `logs` (ts, org, service, level, message,
 attrs map, trace_id), `spans` (trace_id, span_id, parent, service, name,
 start, duration, status, attrs) — schemas finalized during OBS-001 design.

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -61,7 +61,9 @@ incidents, SLOs). Browsers and sibling products never need proto toolchains.
 
 **Recommendation ⭐:** raw events 90d · hourly rollups 90d · daily rollups
 13mo · check results 90d · incidents indefinite · metrics 13mo
-(rollup-thinned) · logs 15d hot (archive later) · traces 7d sampled.
+(**rollup ladder: raw 15d → 1m avg 90d → 1h avg 13mo**) · logs 15d hot
+(archive later) · traces 7d (**head sampling, default 10%, per-org
+configurable; errors always kept — tail sampling later**).
 
 ☑ Ratified as recommended
 
@@ -98,9 +100,9 @@ observability-service touch, not as its own phase.
   the Firebase project; backends reject non-Google-provider tokens
   (`provider_not_allowed`); UI ships exactly one auth CTA. Full contract:
   [flows/auth.md](flows/auth.md). Environment/secrets live in **Doppler**
-  (`cueprise/cuesoft_stg`; see also the `cuesoft-iac` project) — CLI token
-  currently expired (`doppler login` to refresh); config names to be mirrored
-  into docs once readable. ☑
+  — resolved: Doppler access works via the cuesoft-iac token; **services read
+  project `upstat`, config `stg`** (dev* = local convenience; prd empty until
+  a production exists). Redis DB index recorded when assigned. ☑
 - **X-2 Docs platform**: GitBook space per product, Git-synced; Scalar API
   refs. ☑
 - **X-3 Cloud deployment target (RATIFIED, directive)**: all backend

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -9,9 +9,9 @@
 
 | Surface | Runs on | Provisioned by |
 | --- | --- | --- |
-| `api/common` (Go, gRPC/h2c) | Cloud Run (HTTP/2 enabled) | cuesoft-iac stack `upstat` |
+| `api/common` (Go, gRPC/h2c) | Cloud Run (HTTP/2 enabled), **`min-instances: 1`** — the monitor worker must never scale to zero, and check scheduling runs under a Postgres advisory-lock lease so scale-out never double-checks (flows/monitor.md §3) | cuesoft-iac stack `upstat` |
 | `api/observability` (Python) | Cloud Run | cuesoft-iac stack `upstat` |
-| envoy gRPC-Web proxy | Cloud Run (or folded into gateway design at OBS-001) | cuesoft-iac stack `upstat` |
+| envoy gRPC-Web proxy | Cloud Run **[Decided: ships as its own service now; revisit only when OBS-001's gateway lands — UX-6 builds against 3 services]** | cuesoft-iac stack `upstat` |
 | `web` (Next.js) | **Firebase App Hosting** | App Hosting backend |
 
 ## 2. Provisioning (cuesoft-iac)
@@ -49,8 +49,9 @@ Two hard-won rules inherited from cueprise, non-negotiable:
 2. **WIF only** (`google-github-actions/auth@v3` with
    `workload_identity_provider` + `service_account`) — no JSON keys.
 
-GitHub environments (`Staging <Project>`, `Production`) gate the deploy
-jobs and carry the URLs.
+The single protected GitHub environment is **`Sandbox`** (X-6) — required
+reviewers + the sandbox URLs (`api.upstat.cuesoft.io`,
+`ingest.upstat.cuesoft.io` at OBS-001). No other deploy environments exist.
 
 ## 4. Not in this phase
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -46,7 +46,7 @@
 | `warn` | #C77D00 | #FFB020 | degraded / warn thresholds |
 | `crit` | #D32F2F | #FF5C5C | down / alerting |
 | `nodata` | #9AA0AA | #5C6270 | no data / muted monitors |
-| Series palette | 8-step categorical (colorblind-safe, starts purple) | — | charts; consistent series→color per view session |
+| Series palette | 8-step categorical **[Decided]**: `#7C6CF0 #00B4D8 #F4A259 #E86A92 #43AA8B #B5179E #FFCA3A #4361EE` (validated ≥3:1 against both `bg` values; colorblind-checked) | same | charts; series→color stable per view session |
 
 Status semantics are sacred: `ok/warn/crit/nodata` colors are reserved — never
 used decoratively anywhere in the product. Because the brand accent is teal,
@@ -56,8 +56,11 @@ verified in both themes) — the one extra constraint the teal brand imposes.
 ### Type & numerals
 
 - UI: `Inter`; data/query/code: `JetBrains Mono` (log lines, queries, IDs).
-- Base 13px in data views (density), 14px in settings/forms; tabular figures
-  in all numeric contexts; fixed-precision latencies (`142 ms`, `1.24 s`).
+- Type ramp **[Decided]**: 11 (axis labels) / 12 (dense meta) / **13 base**
+  (data views, lh 1.45) / 14 (settings/forms) / 16 (panel titles, 600) /
+  20 (page titles, 600) / 24–32 (marketing only); weights 400/500/600;
+  tabular figures in all numeric contexts; fixed-precision latencies
+  (`142 ms`, `1.24 s`).
 
 ### Layout
 

--- a/docs/engineering.md
+++ b/docs/engineering.md
@@ -1,7 +1,9 @@
 # Upstat — Engineering Contracts
 
 > Error catalog, authorization matrix, rate limits, testing strategy, logging
-> rules. Ecosystem envelope + conventions per apparule engineering.md §1;
+> rules. Ecosystem envelope (inlined, normative):
+> `{"error": {"code": "snake_case_stable", "message": "human copy", "details": {}}}` —
+> codes stable, cross-tenant access always `not_found`;
 > gRPC surfaces map the same codes onto status codes
 > (`INVALID_ARGUMENT`/`UNAUTHENTICATED`/`PERMISSION_DENIED`/`NOT_FOUND`/
 > `ALREADY_EXISTS`/`RESOURCE_EXHAUSTED`/`FAILED_PRECONDITION`).
@@ -33,7 +35,11 @@ owner-only model as "owner=everything, others=nothing" until then:
 | Incidents declare/update | — | ✓ | ✓ | ✓ |
 | SLOs define | — | — | ✓ | ✓ |
 | Org members, retention settings | — | — | — | ✓ |
-| Public status pages | world-readable by design | | | config: admin+ |
+| Public status pages (read) | ✓ (world) | ✓ | ✓ | ✓ |
+| Status-page config | — | — | ✓ | ✓ |
+
+Role source **[Decided]**: org roles live in the control-plane DB (not
+Firebase custom claims) — resolved per request alongside org context.
 
 Machine identities: `SERVICE_TOKEN` (observability↔common, fixed scope);
 property public keys (write-only ingest, U-2) — neither ever grants user-API
@@ -48,13 +54,18 @@ access.
 | Monitor CRUD | 60/min per user |
 | Monitor test-replay (MI-9) | 6/min per user |
 | Channel verification sends | 5/hr per channel |
-| OTLP ingest (OBS-001) | per-key quotas (data-model.md `INGEST_KEY.quotas`) |
+| OTLP ingest (OBS-001) | per-key quotas, defaults: 10k metric points/s, 5k log lines/s, 1k spans/s **[Decided defaults]** |
+| `/v1/events` pre-auth | 1,000 req/min per IP (invalid-key flood guard) |
+| Insights `GET /insights/*`, `POST /analyze/*` | **bearer-authed (REVISED — was open)**; analyze 6/min per user (LLM cost guard) |
+
+Limit store: **shared Aiven Redis** (X-5 — this is Redis's role here, plus
+dispatch cooldown cache); `429 rate_limited` + `Retry-After` (cataloged §1).
 
 ## 4. Testing strategy
 
 | Layer | Scope | Non-negotiables |
 | --- | --- | --- |
-| Unit (Go/pytest) | worker, dispatcher, rollups, hash | **evaluation-semantics transition table** (flows/monitor.md §2 — every edge incl. `nodata`); dispatch ordering + cooldown fixtures (flows/alert.md §5); visitor-hash rotation vectors; rollup idempotency (analytics-math.md §7) |
+| Unit (Go/pytest) | worker, dispatcher, rollups, hash | **evaluation-semantics transition table** (flows/monitor.md §2 — every edge incl. `nodata`); dispatch ordering + cooldown fixtures (flows/alert.md §3); visitor-hash rotation vectors; rollup idempotency (analytics-math.md §7) |
 | Contract | error catalog + query grammar | grammar: valid/invalid corpus with position-accurate errors; `uniques_additive:false` metadata presence |
 | Integration (compose) | web → envoy → gRPC; events → rollup → stats | webhook signature fixture (documented recipe verifies) |
 | E2E smoke (release tag) | signin → create monitor → down-simulation → alert → recover | against sandbox in release.yml; uses a controllable target service |

--- a/docs/features.md
+++ b/docs/features.md
@@ -17,11 +17,12 @@
 
 | ID | Unit | Delivers | Refs | Deps |
 | --- | --- | --- | --- | --- |
-| U1-1 | Property + key model | PROPERTY docs, write-only keys, origin allowlists, rotation | data-model §2, U-2 | — |
+| U1-0 | Postgres control-plane provisioning | Aiven PG (X-5) schema for events/rollups/properties | data-model, X-5 | — |
+| U1-1 | Property + key model | PROPERTY rows, write-only keys (24h rotation grace), origin allowlists | data-model §2, U-2 | U1-0 |
 | U1-2 | Ingest endpoint | POST /v1/events: schema/origin/ts/rate validation, rejection counters | api.md §3.1, analytics-math §5–6 | U1-1 |
 | U1-3 | visitor_hash | daily salt rotation, hash pipeline, no-raw-IP storage test | analytics-math §1 | U1-2 |
 | U1-4 | upstat.js | cookieless script: auto page_view (SPA-aware), custom events, batching | api.md §3.2 | U1-2 |
-| U1-5 | Rollup worker | hourly/daily buckets, sessionization, exact uniques, 48h self-heal | analytics-math §2–3 | U1-2 |
+| U1-5 | Rollup worker | hourly/daily buckets, sessionization (VISIT_ROLLUP), exact uniques, 48h self-heal | analytics-math §2–3 | U1-2, U1-3 |
 | U1-6 | Stats API | GET /v1/stats + uniques_additive metadata | api.md §3.3, analytics-math §4 | U1-5 |
 | U1-7 | Property settings UI | keys, origins, rejection counters | pages.md B12 | U1-1 |
 | U1-8 | Sibling onboarding | register apparule/expendit events per master registry | api.md §3.4 | U1-2 |
@@ -48,10 +49,22 @@
 | U3-4 | Metrics explorer | QueryBar + TimeseriesPanel + MI-1/2/3 | pages.md B3, design.md |
 | U3-5 | Dashboard grid v1 | widgets, editing MI-11/12, portable JSON | pages.md B2 |
 | U3-6 | Metric monitors | thresholds on query results via generalized evaluator | pages.md B8 |
-| U4-1..3 | Logs pillar | intake → explorer/live-tail/facets (MI-4/5/6) → log monitors | pages.md B4 |
-| U5-1..4 | APM pillar | trace intake → service pages → waterfall MI-7 → service map + catalog | pages.md B5/B11 |
-| U6-1..2 | RUM maturation | upstat.js vitals + error tracking; analytics pages complete | pages.md B6 |
-| U7-1..3 | SRE layer | incidents v2 (timeline MI-10, postmortems), SLOs + burn monitors MI-15 | pages.md B9/B10 |
+| U4-1 | Log intake | OTLP logs → ClickHouse `logs` table, org quotas | data-model DDL | U3-1, U3-2 |
+| U4-2 | Logs explorer | FacetSidebar + QueryBar + virtualized LogLine + histogram + live tail (MI-4/5/6) | pages.md B4, query-grammar | U4-1, U3-3 |
+| U4-3 | Log monitors | count/pattern rules via the generalized evaluator | flows/alert, U3-6 | U4-2 |
+| U5-1 | Trace intake | OTLP traces → `spans` table | data-model DDL | U3-1, U3-2 |
+| U5-2 | Service list + pages | req/s, p50/95/99, error rate per service; endpoints table | pages.md B5 | U5-1, U3-3 |
+| U5-3 | Trace explorer + waterfall | search → TraceWaterfall (MI-7) + span drawer | pages.md B5 | U5-2 |
+| U5-4 | Service map + catalog | force-layout map; SERVICE_ENTRY registry (OBS-010) | pages.md B5/B11 | U5-2 |
+| U6-1 | RUM SDK v2 | upstat.js gains web vitals (LCP/CLS/INP) + JS error capture (fingerprint grouping) | pages.md B6 | U1-4 |
+| U6-2 | RUM pages complete | vitals dashboards, error tracking UI; bounce/SEO pages resolve honestly | pages.md B6, ANA-002 | U6-1 |
+| U7-1 | Incidents v2 | sev/roles/timeline composer (MI-10), postmortem template on resolve | pages.md B9, data-model §5 | U2-4 |
+| U7-2 | SLOs | SLI sources (check/metric ratio/latency), 30d rolling windows, SLOCards (MI-15) | pages.md B10 | U3-4 |
+| U7-3 | Burn-rate monitors | fast/slow burn rules (2h @ 14.4x, 24h @ 6x — Google SRE defaults) | U7-2, U3-6 | U7-2 |
+
+Acceptance per pillar = its pages.md section + the engineering.md privacy/
+retention gates; every pillar ships explorer + retention + monitors together
+(architecture honesty stance).
 
 ## Cross-phase engineering units
 

--- a/docs/flows/alert.md
+++ b/docs/flows/alert.md
@@ -16,9 +16,10 @@
 - Webhook signing: `X-Upstat-Signature: hex(hmac-sha256(secret, body))` +
   `X-Upstat-Timestamp`; consumers must reject >5min skew (documented in
   UPS-003 setup docs).
-- Failing channels: 5 consecutive delivery failures → `degraded` badge +
-  email-to-owner (if any email channel works) + banner; deliveries keep
-  trying (no auto-disable — silent alert loss is worse than noise).
+- Failing channels: 5 consecutive **dispatch-level failures** (post-retry
+  `failed` rows) → `degraded` badge + email-to-owner + banner; resets on the
+  first `delivered`. Email (Resend) failures use the same ladder/timeout as
+  webhooks. Deliveries keep trying (no auto-disable).
 - Deleting a channel detaches it from all rules; rules left with zero
   channels show a "no destination" warning badge.
 
@@ -48,18 +49,29 @@ sequenceDiagram
     end
 ```
 
-- **At-least-once** per channel with the retry ladder; a channel's failure
-  never blocks the others.
-- **Ordering**: `recovered` dispatch always awaits the corresponding `down`
-  dispatch outcome (never out-of-order pairs on one channel).
+- **At-least-once, durably [Decided]**: every dispatch writes a
+  `DISPATCH { rule, channel, transition, state: pending|delivered|failed,
+  attempts, next_attempt_at }` row BEFORE delivery; a crash-recovery scan on
+  worker start re-drives `pending` rows — the transition and its
+  notifications can't be lost together. Per-attempt webhook timeout **10s**;
+  retry ladder 1s/5s/25s then `failed`.
+- **Ordering**: `recovered` dispatch on a channel waits for the paired
+  `down` dispatch to reach a terminal state (`delivered` OR `failed` after
+  retries); if the `down` ended `failed`, the `recovered` message prepends
+  "(missed: was down since {t})" so the recipient gets the full story.
 - **Cooldown** applies per rule per state-direction — a `down` at minute 0
   suppresses re-`down` noise until cooldown lapses, but never suppresses the
   `recovered`.
 - **Renotify** (delta, optional): `renotify_minutes` re-sends "still down"
   while an incident stays open; off by default.
-- **Flapping guard** (with monitor.md §2): >6 transitions/30min → one
-  "Monitor X is flapping" alert; normal dispatch resumes after 30 quiet
-  minutes; suppressed transitions visible in the alert feed (MI-14).
+- **Flapping guard** (with monitor.md §2), precise algorithm **[Decided]**:
+  count only `up↔down` edges (nodata/pause edges excluded) in a **sliding
+  30-min window**; the 7th edge enters flapping mode → one `monitor.flapping`
+  dispatch (bypasses per-rule cooldown, fires on rules with `on: down` or
+  `all`), then suppression; exit when the sliding window holds ≤1 edge
+  ("30 quiet minutes" = that predicate); on exit, one summary line in the
+  feed and normal dispatch resumes with cooldown stamps reset. Suppressed
+  transitions remain visible in the alert feed (MI-14).
 
 ## 4. Payloads
 

--- a/docs/flows/auth.md
+++ b/docs/flows/auth.md
@@ -26,13 +26,23 @@ metadata (interceptor swaps local-JWT verification for Firebase);
 | Tracking beacons | property public key (U-2) |
 | Public status/GetRecentChecks | unauthenticated allowlist (unchanged) |
 
-## 3. Migration
+## 3. Migration & failure paths
 
 Link-by-email on first Google sign-in (Google emails pre-verified), same
-shape as expendit flows/auth.md §3 including the 60-day window
-(`FAILED_PRECONDITION migrate_to_firebase` after) and the stranded-user
-support path. `CreateUser`/password fields deprecate out of `user.proto` at
-the next proto rev.
+shape as expendit flows/auth.md §3 including the stranded-user support path.
+Precise semantics **[Decided]**: the **60-day window starts at the release
+tag that ships Firebase auth** (recorded in decisions.md when cut); after it,
+password sign-in returns `FAILED_PRECONDITION migrate_to_firebase`.
+`CreateUser`/password fields deprecate out of `user.proto` at the next proto
+rev; RPC fates per grpc-api.md's status banner (normative).
+
+Failure paths: Firebase outage → sign-ins fail closed
+(`UNAVAILABLE auth_upstream`); existing sessions survive until token expiry
+(~1h). Token revocation (disabled user) → `PERMISSION_DENIED
+account_disabled` on next verify. Clock skew absorbed by Firebase's ±5min
+leeway. Email collision (legacy row's email now owned by a different Google
+account): first-verifier wins the link; the loser routes to support — same
+policy as the stranded path.
 
 ## 4. Instrumentation & acceptance
 

--- a/docs/flows/monitor.md
+++ b/docs/flows/monitor.md
@@ -10,7 +10,7 @@
 | Field | Validation | Notes |
 | --- | --- | --- |
 | Name | 1–80 chars, unique per owner | `409 name_taken` |
-| Target | absolute `http(s)://` URL; DNS-resolvable not required at save | private/internal IPs allowed (self-hosters monitor internal services); cloud MAY restrict RFC-1918 targets **[Decided default: warn, don't block]** |
+| Target | absolute `http(s)://` URL; DNS-resolvable not required at save; URL userinfo (`user:pass@`) rejected (`422 invalid_target`) | **Cloud: RFC-1918/link-local/loopback/metadata (169.254.169.254) targets are DENIED (`422 target_not_allowed`), enforced at check time on every resolved IP (DNS-rebinding-safe: resolve, validate, pin)** — SSRF hard rule, REVISES the earlier warn-only default. Self-host: allowed by default, deny-list configurable |
 | Type | `website \| server \| api \| blog` | display taxonomy only — checks behave identically **[Current]** |
 | Interval | 30s–24h, default 60s **[Current default]** | sub-30s is a paid-tier conversation, out of scope |
 | Timeout | 1s–60s, default 10s; must be < interval | `422 timeout_gte_interval` |
@@ -42,17 +42,36 @@ stateDiagram-v2
 - **Failure asymmetry is deliberate**: going `down` needs `threshold`
   consecutive failures (flap damping); going `up` needs exactly one success
   (recovery news travels fast).
-- **`nodata`** (delta — today the status just goes stale): if the worker
-  itself misses 2×interval (crash, deploy, overload), status becomes
-  `nodata`, never a synthetic `down` — we don't invent outages we didn't
-  observe. Alerting treats `nodata` per-rule (`on: nodata` opt-in).
+- **`nodata`** (delta): if no check completes for 2×interval, status becomes
+  `nodata`, never a synthetic `down`. **Mechanism [Decided]**: evaluated
+  lazily at read time (status queries compare `lastCheckedAt` vs 2×interval)
+  AND materialized by a sweep in the worker loop (so alert rules with
+  `on: nodata` fire without reads). A crashed worker can't write anything —
+  lazy evaluation is what keeps the UI honest; the sweep catches up on
+  restart. Alerting treats `nodata` per-rule (opt-in).
+- **Pause/resume side-effects [Decided]**: pause freezes status at `paused`,
+  closes any open incident as `resolved: paused`, clears cooldown stamps and
+  `consecutiveFailures`; resume starts at `pending` with a fresh slate (first
+  check decides). 
 - **Flapping guard** (delta): >6 transitions in 30min collapses
   notifications into one "flapping" alert (flows/alert.md §4); the status
   history itself records every transition truthfully.
-- **Incidents** **[Current]**: opened on `up→down`, closed on `down→up`;
-  `pending/nodata/paused` transitions never touch incidents.
+- **Incidents [REVISED]**: opened on any transition **into `down`**
+  (`up→down`, `pending→down`, `nodata→down`), closed on `down→up`;
+  transitions among `pending/nodata/paused` (not involving `down`) never
+  touch incidents. Pausing a monitor with an open incident **closes it as
+  `resolved: paused`** (annotated cause).
 
 ## 3. Check records & per-monitor page
+
+Scheduler contract **[Decided]**: monitors are spread across their interval
+by hash-jitter (no thundering herd); worker concurrency cap 50 in-flight
+checks per instance; missed slots (downtime) are skipped, not backfilled
+(drift policy: next slot wins); cloud egress IPs are published in setup docs
+for customer allowlists. **Cloud Run: the worker requires `min-instances: 1`
+and a scheduler singleton lease** (Postgres advisory lock) so scale-out
+never double-schedules — checks are leased by one instance; the HTTP surface
+scales freely (deployment.md).
 
 Each check persists: `up`, `status_code` (0 = transport error), 
 `response_time_ms`, `checked_at` (90d retention, U-6). The monitor page
@@ -65,11 +84,12 @@ neither).
 
 | Recorded cause | Meaning |
 | --- | --- |
-| `timeout` | no response within timeout |
+| `timeout` | no response within timeout (measured across the whole redirect chain) |
 | `dns` | resolution failed |
 | `tls` | handshake/cert failure (incl. expired cert — cert-expiry *warning* checks are OBS-011 later) |
 | `refused` | connection refused |
 | `http_4xx` / `http_5xx` | response ≥400 |
+| `too_many_redirects` | >5 redirects |
 
 ## 5. Instrumentation & acceptance
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -17,7 +17,7 @@ flowchart LR
 
 - **`web`** — Next.js dashboard and public status pages. Talks to the backend
   over **gRPC-Web**.
-- **Envoy** — front proxy at [deploy/helm/envoy/envoy.yaml](../deploy/helm/envoy/envoy.yaml).
+- **Envoy** — front proxy at [deploy/helm/envoy/envoy.yaml](https://github.com/cuesoftinc/upstat/blob/main/deploy/helm/envoy/envoy.yaml).
   Translates browser gRPC-Web into native gRPC for the Go backend and applies
   CORS.
 - **`api/common`** — Go gRPC backend: `MonitorService` and `UserService`, the
@@ -36,7 +36,7 @@ machine learning, consuming the backend through a clear gRPC interface.
 
 See [setup.md](setup.md) to run the stack locally, [architecture.md](architecture.md)
 for detailed data flows, and the
-[repository structure](../README.md#repository-structure) in the README.
+[repository structure](https://github.com/cuesoftinc/upstat#repository-structure) in the README.
 
 ## Product & design documentation
 > Published site: **https://cuesoft.gitbook.io/upstat** (Git-synced from this folder on every merge to main).

--- a/docs/pages.md
+++ b/docs/pages.md
@@ -20,7 +20,7 @@ community-driven") remains the visual base, extended for the new pillars.
 | A1 | Nav | logo · Platform (pillar dropdown) · Docs (GitBook) · Community · GitHub badge · Sign in · **Try Cloud** | pillar dropdown = mini feature map |
 | A2 | Hero | H1 (from Figma pillars); dual CTA **Try Cloud** / **Self Host**; hero visual: live-looking dashboard with animated timeseries + synced crosshair demo | crosshair demo animates on an 8s loop |
 | A3 | Pillar grid | 8 cards: Uptime & Synthetics · Website Analytics/RUM · Metrics · Logs · APM/Traces · Dashboards · Alerting · Incidents & SLOs | hover lifts + pillar color accent |
-| A4 | Live demo strip | embedded read-only demo org (synthetic telemetry): status page + one dashboard | interactive TimePicker within bounds |
+| A4 | Demo strip | **static demo cards** (synthetic data, U0-3) — the interactive embedded demo org is descoped to a post-Phase-3 enhancement **[Decided]** | — |
 | A5 | How ingestion works | OTLP/agent diagram: your services → OTel SDK/collector → Upstat | copyable snippet tabs (Go/Python/Node/k8s) |
 | A6 | Reliability showcase | Upstat's own public status page embedded (self-referential trust, PRD §5) | |
 | A7 | Open source | compose snippet, architecture diagram, GitHub/CONTRIBUTING | |
@@ -37,8 +37,9 @@ pillars. Every pillar's empty state = MI-16 inline onboarding.
 
 ### B1 Home
 - Org health at a glance: open incidents banner (MI-14), triggered monitors,
-  SLO burn cards (MI-15), watched dashboards row, recent deploy markers
-  **[Proposed: deploy events via API]**.
+  SLO burn cards (MI-15), watched dashboards row. (Deploy markers CUT from
+  v1 — no deploy-events API exists; aspirational item for the service
+  catalog era.)
 
 ### B2 Dashboards
 - List (org-shared, favorites) → grid editor (MI-11/12): widget types:
@@ -79,12 +80,19 @@ pillars. Every pillar's empty state = MI-16 inline onboarding.
   as planned, ANA-002).
 
 ### B7 Synthetics / Uptime (the current core, absorbed)
+- **Coexistence contract [Decided]**: existing gRPC monitors ARE the uptime
+  pillar — at monitors-v2 (OBS-006) each becomes a `MONITOR_RULE` with
+  `signal: uptime` via one-time migration; no dual-write period (v2 reads
+  both until migration completes within the release). B7 reads the unified
+  view.
 - Monitors (existing CRUD) → "Uptime checks" within Synthetics: HTTP checks
   (existing), multi-step API checks **[Later]**, browser checks **[Later]**.
 - UptimeCards + per-monitor page: check history, response-time chart,
   incidents, insight panel (existing ML insight surfaces here).
-- Public status pages: existing `GetStatusPage` + configurable status-page
-  builder (logo, components, subscribe-to-updates **[Later]**).
+- Public status pages: URL scheme **[Decided]** `status.upstat.cuesoft.io/{slug}`
+  (owner-chosen slug, unique; never raw owner ids in URLs); upstat's own page
+  = slug `upstat` (U0-5 config = create the slugged page over the existing
+  `GetStatusPage` data). Builder (logo, components, subscribe) **[Later]**.
 
 ### B8 Monitors (alerting on any signal)
 - Monitor types: uptime state (exists conceptually), metric threshold,
@@ -128,7 +136,7 @@ maturity.
 | OBS-002 | Metrics explorer + storage | Must | OBS-001 |
 | OBS-003 | Logs explorer + live tail + facets | Must | OBS-001 |
 | OBS-004 | APM: services, trace explorer, waterfall, service map | Must | OBS-001 |
-| OBS-005 | Composable dashboards (grid editor, portable JSON) | Must | OBS-002/003 minimum |
+| OBS-005 | Composable dashboards (grid editor, portable JSON) | Must | OBS-002 **or** OBS-003 (either signal suffices) |
 | OBS-006 | Monitors on any signal + channels | Must | pillar queries |
 | OBS-007 | RUM: browser SDK (vitals, errors) atop events layer | Must | events layer (Phase 1) |
 | OBS-008 | Incident management (sev, roles, timeline, postmortem) | Should | OBS-006 |

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -66,7 +66,7 @@ demonstrate Cuesoft's engineering standards and infrastructure stability
 
 | ID | Requirement | Rationale |
 | --- | --- | --- |
-| MON-001 | **Alerting** — notify on monitor state change (email first, webhook second) | Features grid says "alerts"; today status flips are silent — a monitoring product that tells no one is a dashboard, not a monitor |
+| MON-001 | **Alerting** — notify on monitor state change *(U-4 ratified: webhooks first, email via Resend)* | Features grid says "alerts"; today status flips are silent — a monitoring product that tells no one is a dashboard, not a monitor |
 | ANA-001 | Event-ingestion API + JS tracking script | M2/M3 foundation; lightweight page-view + custom-event beacon |
 | ANA-002 | Dashboards read real aggregates | Replace the mock `/api/dashboard/*` routes — mocks were acceptable scaffolding, not product |
 | ANA-003 | Data-retention policy, stated and enforced | UPS-003 requires documenting retention; you can't document what isn't defined (data-model.md §4 proposes 90d raw / 13mo rollups) |
@@ -108,13 +108,13 @@ demonstrate Cuesoft's engineering standards and infrastructure stability
 
 ## 8. Open questions
 
-1. **Event API authentication for browsers** — tracking scripts can't hold
+1. ~~**Event API authentication for browsers**~~ **RESOLVED (U-2)**. Original — tracking scripts can't hold
    secrets. Proposed: public write-only property key, origin-checked, rate
    limited (api.md §3.1); confirm this satisfies the privacy posture.
-2. **Alert channels order** — email first (needs an SMTP/provider decision —
+2. ~~**Alert channels order**~~ **RESOLVED (U-4: webhooks first, Resend email)**. Original — email first (needs an SMTP/provider decision —
    note the old SMTP plumbing was deliberately removed), webhook second,
    Slack later? MON-001 assumes email→webhook.
-3. **gRPC-Web vs REST for new surfaces** — monitors stay gRPC (works today);
+3. ~~**gRPC-Web vs REST**~~ **RESOLVED (U-5: new surfaces HTTP)**. Original — monitors stay gRPC (works today);
    event ingestion + stats query are proposed as plain HTTP/JSON (browser
    beacons + simpler consumer contract). Confirm the split is acceptable.
 4. **Managed-client reports** (ECO-SUPPORT) — format and cadence owned by

--- a/docs/query-grammar.md
+++ b/docs/query-grammar.md
@@ -69,9 +69,50 @@ indexes ranked by cardinality (design.md MI-13).
 
 One internal query service parses the grammar into an AST, validates facets
 against the catalog/indexes, then compiles per store: ClickHouse SQL for
-logs/spans/metrics (pending R2), Mongo aggregation for control-plane data.
-The AST — not the string — is what monitors persist, so grammar evolution
-can re-serialize saved queries.
+logs/spans/metrics (U-1 ratified), **Postgres** for control-plane data (X-5).
+**Persistence [Decided — unified]: both monitors AND dashboard widgets
+persist the AST** (widgets additionally cache the display string).
+
+### AST v1 (versioned JSON — the compatibility contract)
+
+```json
+{
+  "v": 1,
+  "filters": {"op": "and", "terms": [
+    {"facet": "service", "cmp": "eq", "value": "api-common"},
+    {"op": "or", "terms": [{"facet": "level", "cmp": "eq", "value": "error"},
+                             {"facet": "level", "cmp": "eq", "value": "warn"}]},
+    {"facet": "trace.duration_ms", "cmp": "gt", "value": 250},
+    {"not": {"facet": "level", "cmp": "eq", "value": "debug"}},
+    {"text": "timeout"}
+  ]},
+  "agg": [{"fn": "p95", "field": "trace.duration_ms"}],
+  "group_by": ["path"],
+  "step": "auto"
+}
+```
+
+Rules the string grammar adds to §1 **[Decided]**:
+- **Quoting/escaping**: values with `:`/spaces/parens are double-quoted;
+  `\"` escapes a quote; facet names never need quoting.
+- **Nesting**: parentheses nest arbitrarily — `(a OR (b c)) -d` is legal;
+  the AST is the normative structure.
+- **Typing**: facets are typed at registration (string/number/duration);
+  numeric comparators on string facets → `invalid_query`.
+- **Step**: `| … by …` series take an implicit `step=auto`
+  (range/200 buckets, snapped to 10s/1m/5m/1h/1d); `?step=` overrides.
+
+### Function semantics per signal (normative table)
+
+| fn | logs/events | spans | metrics | checks |
+| --- | --- | --- | --- | --- |
+| `count()` | row count | span count | point count | check count |
+| `rate()` | rows/sec | spans/sec | — (use the metric) | **pass ratio** (passing ÷ completed — the documented exception) |
+| `sum/avg/min/max/p50/p95/p99(field)` | numeric attr | field required (e.g. `trace.duration_ms`) | over values | `response_time_ms` |
+| `uniq(field)` | distinct attr values | distinct field | distinct series | — |
+
+Bare `p95()` with no field is `invalid_query` everywhere except metrics
+(where the selected series' value is implicit).
 
 ## 5. URL representation
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -28,12 +28,14 @@ status is public; privacy stance published.
 | `upstat.js` tracking script (cookieless, SPA-aware) | ANA-001 |
 | Rollup worker in api/observability (hour/day, approx uniques) | ANA-001 |
 | `GET /v1/stats` | ANA-002 dependency |
-| TTL retention indexes + documented policy | ANA-003 |
+| Scheduled retention job (Postgres partitioned events, X-5) + documented policy | ANA-003 |
 | Register sibling consumers (apparule, expendit event names) | ECO-TRACK |
 
 **Exit criteria:** sibling products' events flow end-to-end and appear in
-stats queries; retention enforced by TTL; D2 declared **delivered** to the
-other repos.
+stats queries; retention enforced by the scheduled job; D2 declared
+**delivered** to the other repos. **Phase 1 includes provisioning the
+Aiven Postgres control plane (new unit U1-0)** — events never touch Mongo;
+U2-7 then migrates only the pre-existing Mongo control-plane data.
 
 ## Phase 2 — Honest dashboards + alerting
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -21,6 +21,7 @@ service ships a `.env.example` to copy from.
 | `JWT_SECRET` | Secret used to sign/verify JWTs |
 | `BASE_URL` | Public base URL of the backend |
 | `INSIGHT_SERVICE_GRPC_ADDRESS` | Address of the observability gRPC server |
+| `SERVICE_TOKEN_HASH` | Server-side hash api/common validates the observability service token against (client sends `UPSTAT_GRPC_AUTH_TOKEN`) |
 
 ### `api/observability` (Python service)
 


### PR DESCRIPTION
Applies every finding from the deep documentation review (14 high / 28 med / 10 low). The big ones: event-storage contradiction resolved (Postgres Phase 1), durable at-least-once alert dispatch, nodata/scheduler-singleton contracts, incident coverage on all paths into down, salt-rotation correctness for late events, registry-as-schema for the ecosystem event contract, the query-grammar AST v1 spec, OBS phase decomposition, ClickHouse DDL + tenancy isolation, and SSRF hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)