### PR TITLE
docs: X-10 minimal tier — ORG timezone (IANA) for accurate reporting

### DIFF
--- a/docs/analytics-math.md
+++ b/docs/analytics-math.md
@@ -57,6 +57,9 @@ keyed `(property, period, bucket, name, dims)`:
   within the trailing 48h — late events self-heal; a bucket becomes immutable
   only once `bucket_end < now − 48h`, which (with the §5 accept window)
   guarantees nothing accepted can target an immutable bucket.
+- Bucket keys and storage are **UTC**; display bucketing resolves in the org
+  timezone (`ORG.timezone`, data-model.md §5 / X-10) — presentation only,
+  rollup keys never shift.
 
 ## 4. Uniques across ranges (the non-additivity rule)
 

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -203,6 +203,10 @@ erDiagram
     INCIDENT_V2 ||--o{ TIMELINE_ENTRY : logs
     ORG ||--o{ SERVICE_ENTRY : catalogs
 
+    ORG { objectid _id PK
+        string name
+        string timezone "IANA tz, default UTC - set at org creation, editable in Settings (pages.md B12)"
+        datetime created_at }
     INGEST_KEY { objectid _id PK
         objectid org_id FK
         string scope "otlp|rum|statsd|all"
@@ -243,6 +247,15 @@ erDiagram
         json environments }
 ```
 
+Identity posture (X-10, ratified 2026-07-16 — [decisions.md](decisions.md)):
+upstat is **tier 0 + tier-1-minimal** — Google identity (X-1) plus exactly
+one profile field, `ORG.timezone` (IANA, default `UTC`; set at org creation,
+editable in Settings, pages.md B12). It exists so report rendering and
+time-bucketing *display* resolve in the org's timezone while storage and
+rollups stay UTC ([analytics-math.md](analytics-math.md) §3). The `country`
+in `EVENT.dims` (§2) is a coarse *event* dimension, **not** org identity —
+no address or country identity field exists. Tier 2 (provider-verified
+financial identity) is N/A until billing enters the PRD.
 
 ### Telemetry-plane DDL sketch (ClickHouse, U-1 — draft to finalize at OBS-001)
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -170,3 +170,29 @@ observability-service touch, not as its own phase.
   /v1/events counters) — never mix the pipelines. Env names standard:
   OTEL_SERVICE_NAME, OTEL_EXPORTER_OTLP_ENDPOINT, OTEL_EXPORTER_OTLP_HEADERS,
   OTEL_RESOURCE_ATTRIBUTES. ☑
+- **X-10 Identity, profile & KYC tiers (RATIFIED, directive 2026-07-16)**: layered on
+  X-1 — Google-only sign-in stays the sole credential; tiers add profile data and
+  verification, never alternative logins. **Tier 0 — Google identity** (all
+  products): firebase_uid + Google-verified email; grants all read/basic use.
+  **Tier 1 — self-attested profile & location** (captured in product
+  profile/settings; sensitive PII, never logged): apparule = bio + profile
+  location {city, state, country} powering proximity-ranked designer
+  recommendations ("near me") and delivery-address pre-fill (delivery address
+  itself stays frozen per order); expendit = tax-jurisdiction location —
+  state_of_residence for individuals, registered_address for company orgs —
+  which resolves the remittance authority (State IRS vs FIRS); upstat = org
+  timezone (IANA) only, for accurate report rendering and time-bucketing —
+  deliberately the entire upstat requirement. **Tier 2 — provider-verified
+  financial identity** (only where money moves or government filings
+  generate; store provider refs + verification state, never raw government
+  IDs): apparule designer payouts = Paystack bank resolution, BVN-backed
+  (already ratified A-2 — canonized as the ecosystem pattern); expendit
+  filing identity = TIN (+ RC number + registered address for companies)
+  required at filing-pack generation (422 tax_identity_incomplete); v1
+  verification is format validation + attestation, provider-verified arrives
+  with direct e-filing (post-v1); upstat = N/A until billing enters the PRD.
+  **Rules**: tiers gate capabilities, never sign-in; KYC state machines +
+  error codes live in flow docs (apparule kyc_incomplete/post_unavailable is
+  the template); tier-2 fields are high-sensitivity in every data-model §4
+  classification; verification is delegated to the money/filing provider —
+  no in-house document review. ☑

--- a/docs/design.md
+++ b/docs/design.md
@@ -173,7 +173,7 @@ component samples are the next Style Guide iteration.
 | --- | --- | --- |
 | 0 Foundations | type ramp (§2) · series palette swatches ×8 · Lucide icons · 12-col dashboard grid + 8px gutters | everything |
 | 1 Atoms | Button, Input, StatusPill, query pill, level chip, Toast | molecules |
-| 2 Molecules | TimePicker, QueryBar (pills+autocomplete), FacetSidebar group, MonitorRow, LogLine (collapsed/expanded), SLOCard, IncidentBanner, UptimeCard | panels |
+| 2 Molecules | TimePicker, QueryBar (pills+autocomplete), FacetSidebar group, MonitorRow, LogLine (collapsed/expanded), SLOCard, IncidentBanner, UptimeCard, SettingsRow | panels |
 | 3 Panels | TimeseriesPanel (line/area/bars + legend), WidgetShell, TraceWaterfall row + span drawer, ServiceMapNode, alert channel/rule forms · **widget content kit**: QueryValue, TopList, Table, Heatmap, LogHistogram · **status page kit**: StatusPageHeader, StatusPageComponentRow, IncidentHistoryEntry | dashboards + status pages |
 | 4 Screen templates | dashboard home, monitors list+detail, alert config, traffic (real-data layout), status page (slug public view), settings/properties | app design |
 | 5 Landing | extend Desktop-1: pillar grid (8), ingestion diagram section, demo cards, cloud-vs-oss | landing v2 |
@@ -204,6 +204,7 @@ component samples are the next Style Guide iteration.
 | StatusPageHeader | overall: operational / degraded / partial_outage / major_outage · last-updated ts (public status page, pages.md B7) |
 | StatusPageComponentRow | component name + StatusPill + 90-day bar strip + uptime % (UptimeCard technique, public view) |
 | IncidentHistoryEntry | phase: investigating / identified / monitoring / resolved · timestamped update list (status page history + incident timeline) |
+| SettingsRow | label + description + control slot: text / select / toggle · default / disabled (settings screens; org timezone IANA selector per X-10) |
 | EmptyState | per-pillar MI-16 (snippet + radar + docs link) ×4 minimum |
 
 Remaining pages.md widget types compose existing sets inside `WidgetShell`

--- a/docs/pages.md
+++ b/docs/pages.md
@@ -121,6 +121,11 @@ pillars. Every pillar's empty state = MI-16 inline onboarding.
 - Org/members/roles; **API keys & ingestion tokens** (per-pillar scopes);
   property keys (RUM); integrations (webhooks, Slack); retention per signal;
   usage metering per pillar **[Proposed]**; privacy/data controls.
+- **Organization profile**: name, **timezone (IANA)** — all report rendering
+  and time-bucketing (dashboards, uptime day boundaries, rollup display,
+  scheduled reports) resolve in the org timezone; storage stays UTC
+  (analytics-math.md §3). Deliberately the entire upstat identity
+  requirement per X-10 tier-1-minimal (decisions.md).
 
 ## Part C — Mobile companion (later; parity direction **[Directive]**)
 


### PR DESCRIPTION
Closes the upstat half of the ecosystem KYC/identity audit gap [kyc-5], revised by the 2026-07-16 directive: upstat needs ONLY basic timezone data for accurate reporting — no address, no country identity field.

## Changes

- **decisions.md** — cross-cutting **X-10 Identity, profile & KYC tiers** (ratified 2026-07-16) inserted after X-9. Upstat's slice: tier 0 (Google identity per X-1) + tier-1-minimal (org timezone, IANA, only) for report rendering and time-bucketing; tier 2 N/A until billing enters the PRD.
- **data-model.md §5** — ORG gets a real attribute block: `{ _id PK, name, timezone (IANA tz, default UTC — set at org creation, editable in Settings B12), created_at }`, plus an identity-posture note. Analytics `country` dims (`EVENT.dims`) stay coarse *event* data — deliberately NOT an org identity field.
- **pages.md B12** — Settings gains **Organization profile: name, timezone (IANA)** with the explainer: all report rendering and time-bucketing (dashboards, uptime day boundaries, rollup display, scheduled reports) resolve in the org timezone; storage stays UTC.
- **analytics-math.md §3** — one-line cross-ref: bucket keys/storage are UTC; display bucketing resolves in `ORG.timezone` (presentation only, rollup keys never shift).
- **design.md §8** — `SettingsRow` molecule added to the Stage 2 build order and the §8.2 variant matrix (label + description + control slot: text / select / toggle · default / disabled — hosts the org timezone IANA selector per X-10).

## Validation

- §5 erDiagram (the only mermaid block touched) re-validated with `@mermaid-js/mermaid-cli` — renders clean.
- No code changes; docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)