### PR TITLE
docs: SUMMARY nav label parity — Web Implementation Standard

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -22,7 +22,7 @@
 - [Analytics Math](analytics-math.md)
 - [OpenAPI Draft](api/openapi.yaml)
 - [Engineering Contracts](engineering.md)
-- [Web Implementation](web-implementation.md)
+- [Web Implementation Standard](web-implementation.md)
 - [Deployment](deployment.md)
 
 ## Flows


### PR DESCRIPTION
SUMMARY label convention is H1-minus-product-prefix; apparule already reads 'Web Implementation Standard' — this aligns the nav label. 

🤖 Generated with [Claude Code](https://claude.com/claude-code)