### PR TITLE
fix(web): W1 Figma-match QA — component fidelity pass

### DIFF
--- a/web/src/app/dev/components/page.tsx
+++ b/web/src/app/dev/components/page.tsx
@@ -455,7 +455,7 @@ function GalleryAll() {
           <div className="flex w-72 flex-col gap-[var(--space-2)]">
             <Input placeholder="Monitor name" aria-label="Monitor name" />
             <Input mono defaultValue="service:checkout | p95()" aria-label="Query" />
-            <Input error defaultValue="not-a-url" aria-label="Target" />
+            <Input error errorMessage="Must be a valid HTTPS URL" defaultValue="not-a-url" aria-label="Target" />
             <Input disabled placeholder="Disabled" aria-label="Disabled input" />
           </div>
         </Cell>
@@ -665,7 +665,7 @@ function GalleryAll() {
           </div>
         </Cell>
         <Cell label="UptimeCard 90-day strip (outage + nodata gaps)" grow>
-          <UptimeCard name="upstat.cuesoft.io" days={DAYS_90} uptimePct={99.87} sparkline={SPARKLINE} />
+          <UptimeCard name="upstat.cuesoft.io" days={DAYS_90} uptimePct={99.87} p95Ms={96} />
         </Cell>
         <Cell label="AlertChannelCard webhook/email × health ×3">
           <div className="flex w-96 flex-col gap-[var(--space-2)]">
@@ -807,9 +807,9 @@ function GalleryAll() {
         </Cell>
         <Cell label="ServiceMapNode healthy / erroring / selected">
           <div className="flex gap-[var(--space-4)]">
-            <ServiceMapNode name="api-common" reqPerS={1204} errorRate={0.004} />
-            <ServiceMapNode name="checkout" reqPerS={311} errorRate={0.11} />
-            <ServiceMapNode name="worker" reqPerS={88} errorRate={0.01} selected />
+            <ServiceMapNode name="api-common" reqPerS={1204} errorRate={0.004} colorIndex={0} />
+            <ServiceMapNode name="checkout" reqPerS={311} errorRate={0.11} colorIndex={1} />
+            <ServiceMapNode name="worker" reqPerS={88} errorRate={0.01} colorIndex={2} selected />
           </div>
         </Cell>
       </Section>

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -4,7 +4,7 @@
  * keep their current rendering. The existing `*` reset below covers new
  * token-based components.
  */
-@layer theme, base, components, utilities;
+@layer theme, base, legacy, components, utilities;
 @import "tailwindcss/theme.css" layer(theme);
 @import "tailwindcss/utilities.css" layer(utilities);
 @import "../design/tokens.css";
@@ -54,8 +54,36 @@
   --ease-exit: var(--ease-exit);
 }
 
+/*
+ * Minimal control reset for the token component library. Tailwind preflight
+ * is off (legacy routes), so UA button chrome (ButtonFace background, 2px
+ * outset border, centered system text) leaked into every bg-less <button>
+ * row/chip. Layered `base` keeps this below utilities; legacy
+ * styled-components rules are unlayered and still win where they declare.
+ */
+@layer base {
+  button {
+    background-color: transparent;
+    border: 0 solid;
+    color: inherit;
+    font: inherit;
+    text-align: inherit;
+  }
+}
+
 /* Component-library keyframes (design.md §4 MIs; consumers pair these
    with motion-reduce fallbacks). */
+@keyframes breathe {
+  /* MI-8: crit dot breathes 1→1.25→1, ~1.6s loop */
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.25);
+  }
+}
+
 @keyframes bar-fill {
   from {
     transform: scaleY(0);
@@ -97,62 +125,70 @@
 /* ------------------------------------------------------------------ */
 /* Legacy global styles (pre-W0 app) — live until W3 retires the old   */
 /* dashboard routes; do not extend.                                    */
+/* Layered `legacy` (below components/utilities): previously these     */
+/* were unlayered and silently overrode every Tailwind utility         */
+/* (`* { padding: 0 }` nuked padding/margin utilities and              */
+/* `svg { width: 24px }` collapsed every class-sized chart). Legacy    */
+/* routes are styled-components-only                                   */
+/* (unlayered ⇒ still win over this layer), so their rendering is      */
+/* unchanged.                                                          */
 /* ------------------------------------------------------------------ */
 
-* {
-  box-sizing: border-box;
-  padding: 0;
-  margin: 0;
-}
+@layer legacy {
+  * {
+    box-sizing: border-box;
+    padding: 0;
+    margin: 0;
+  }
 
-:root {
-  background: #16151C; /* legacy canvas — new routes paint bg-bg themselves */
-  color: white;
-  --rem: 16px;
-}
+  :root {
+    background: #16151C; /* legacy canvas — new routes paint bg-bg themselves */
+    color: white;
+    --rem: 16px;
+  }
 
-body {
-  font-family: "Poppins", sans-serif;
-}
+  body {
+    font-family: "Poppins", sans-serif;
+  }
 
-main {
-  display: flex;
-  min-width: 100vw;
-}
+  main {
+    display: flex;
+    min-width: 100vw;
+  }
 
-.content {
+  .content {
+    width: 100%;
+    overflow: auto;
+  }
 
-  width: 100%;
-  overflow: auto;
-}
+  a {
+    color: inherit;
+    cursor: pointer;
+    text-decoration: none;
+  }
 
-a {
-  color: inherit;
-  cursor: pointer;
-  text-decoration: none;
-}
+  button { cursor: pointer;}
 
-button { cursor: pointer;}
+  svg {
+    width: 24px;
+    height: 24px;
+  }
 
-svg {
-  width: 24px;
-  height: 24px;
-}
+  .dummy-classname {
+    height: 80%;
+    display: grid;
+    place-content: center;
+    color: #fff;
+    height: 100%;
+    background: #16151C;
+  }
 
-.dummy-classname {
-  height: 80%;
-  display: grid;
-  place-content: center;
-  color: #fff;
-  height: 100%;
-  background: #16151C;
-}
+  .axis-bottom-text {
+    color: white;
+  }
 
-.axis-bottom-text {
-  color: white;
-}
-
-html, body {
-  overflow-x: hidden;
-  max-width: 100%;
+  html, body {
+    overflow-x: hidden;
+    max-width: 100%;
+  }
 }

--- a/web/src/components/ui/AlertRuleCard.test.tsx
+++ b/web/src/components/ui/AlertRuleCard.test.tsx
@@ -18,9 +18,10 @@ const RULE: AlertRule = {
 
 describe("AlertRuleCard", () => {
   it("shows the mono query + thresholds", () => {
-    render(<AlertRuleCard rule={RULE} />);
+    const { container } = render(<AlertRuleCard rule={RULE} />);
     expect(screen.getByText(RULE.query_string)).toBeInTheDocument();
-    expect(screen.getByText("1500")).toBeInTheDocument();
-    expect(screen.getByText("metric threshold")).toBeInTheDocument();
+    // Figma 69:520 threshold line: `warn > 800 · crit > 1500 · for 5m`
+    expect(screen.getByText(/warn > 800 · crit > 1500 · for 5m/)).toBeInTheDocument();
+    expect(container.querySelector("[data-signal='metric']")).not.toBeNull();
   });
 });

--- a/web/src/components/ui/AlertRuleCard.tsx
+++ b/web/src/components/ui/AlertRuleCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { clsx } from "clsx";
+import { Activity, BarChart2, Globe, ScrollText, Zap } from "lucide-react";
 import type { AlertRule, AlertSignal } from "@/models";
 import { StatusPill, type StatusPillStatus } from "./StatusPill";
 
@@ -10,12 +11,14 @@ export interface AlertRuleCardProps {
   className?: string;
 }
 
-const SIGNAL_LABEL: Record<AlertSignal, string> = {
-  uptime: "uptime",
-  metric: "metric threshold",
-  log: "log pattern",
-  trace: "trace latency",
-  slo_burn: "SLO burn",
+// Signal icon (Figma 69:564 leads each card with the signal's icon;
+// metric-threshold = icon/bar-chart).
+const SIGNAL_ICON: Record<AlertSignal, typeof BarChart2> = {
+  uptime: Globe,
+  metric: BarChart2,
+  log: ScrollText,
+  trace: Activity,
+  slo_burn: Zap,
 };
 
 const STATE_TO_PILL: Record<AlertRule["state"], StatusPillStatus> = {
@@ -26,43 +29,38 @@ const STATE_TO_PILL: Record<AlertRule["state"], StatusPillStatus> = {
 };
 
 /**
- * AlertRuleCard — §8.2: type metric-threshold / log-pattern / trace-latency
- * / slo-burn · mono query summary + threshold line.
+ * AlertRuleCard — §8.2 (Figma 69:564): signal icon + name + StatusPill,
+ * mono query summary, mono threshold line
+ * (`warn > 800 · crit > 1500 · for 5m`).
  */
 export function AlertRuleCard({ rule, onClick, className }: AlertRuleCardProps) {
+  const Icon = SIGNAL_ICON[rule.signal];
   return (
     <button
       type="button"
       onClick={onClick}
       data-signal={rule.signal}
       className={clsx(
-        "font-ui flex w-full flex-col gap-2 rounded-(--radius) border border-border bg-bg-elev p-3 text-left",
+        "font-ui flex w-full flex-col gap-2 rounded-(--radius) border border-border bg-bg-elev p-3.5 text-left",
         "transition-colors duration-[var(--duration-fast)] ease-standard hover:border-text-2",
         className,
       )}
     >
-      <div className="flex items-center gap-2">
-        <StatusPill status={STATE_TO_PILL[rule.state]} dotOnly />
+      <div className="flex w-full items-center gap-2">
+        <Icon aria-hidden="true" className="size-4 shrink-0 text-text-2" />
         <span className="min-w-0 flex-1 truncate text-[13px] font-medium text-text">{rule.name}</span>
-        <span className="shrink-0 rounded-(--radius) border border-border px-1.5 text-[10px] uppercase tracking-wide text-text-2">
-          {SIGNAL_LABEL[rule.signal]}
-        </span>
+        <StatusPill status={STATE_TO_PILL[rule.state]} />
       </div>
-      <code className="font-data truncate rounded-(--radius) bg-bg px-2 py-1 text-[12px] text-text-2">
-        {rule.query_string}
-      </code>
-      <div className="flex items-center gap-3 text-[11px] tabular-nums text-text-2">
-        {rule.thresholds.warn !== null && (
-          <span>
-            warn <span className="text-warn">{rule.thresholds.warn}</span>
-          </span>
-        )}
-        <span>
-          crit <span className="text-crit">{rule.thresholds.crit}</span>
+      <code className="font-data w-full truncate text-[12px] text-text-2">{rule.query_string}</code>
+      <div className="font-data flex w-full items-center gap-2 text-[12px] tabular-nums text-text">
+        <span className="truncate">
+          {rule.thresholds.warn !== null && <>warn &gt; {rule.thresholds.warn} · </>}
+          crit &gt; {rule.thresholds.crit} · for {rule.thresholds.window}
         </span>
-        <span>window {rule.thresholds.window}</span>
         {rule.last_triggered_at && (
-          <span className="ml-auto">last triggered {rule.last_triggered_at.slice(0, 16).replace("T", " ")}</span>
+          <span className="ml-auto shrink-0 text-[11px] text-text-2">
+            last triggered {rule.last_triggered_at.slice(0, 16).replace("T", " ")}
+          </span>
         )}
       </div>
     </button>

--- a/web/src/components/ui/Button.tsx
+++ b/web/src/components/ui/Button.tsx
@@ -31,15 +31,17 @@ export function Button({
         "font-ui inline-flex items-center justify-center gap-2 rounded-(--radius) font-medium",
         "transition-colors duration-[var(--duration-fast)] ease-standard",
         "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand",
-        "disabled:cursor-not-allowed disabled:opacity-60",
+        // Figma 37:29 — disabled (every kind) = bg-elev + border + text-2
+        "disabled:cursor-not-allowed disabled:border disabled:border-border disabled:bg-bg-elev disabled:text-text-2",
         size === "sm" ? "h-7 px-2 text-[12px]" : "h-8 px-3 text-[13px]",
         kind === "brand" &&
-          "bg-brand text-on-brand hover:bg-brand-deep disabled:hover:bg-brand",
+          "bg-brand text-on-brand hover:bg-brand-deep disabled:hover:bg-bg-elev",
         kind === "quiet" &&
-          "border border-border bg-transparent text-text hover:bg-bg-elev disabled:hover:bg-transparent",
+          "border border-border bg-transparent text-text hover:bg-bg-elev disabled:hover:bg-bg-elev",
         kind === "destructive" &&
-          // raw #FFFFFF label pending an `on-crit` token (design.md §2)
-          "bg-crit text-[#FFFFFF] hover:opacity-90 disabled:hover:opacity-60",
+          // raw #FFFFFF label pending an `on-crit` token (design.md §2);
+          // hover dims the crit fill to 85% (Figma 37:25), label stays white
+          "bg-crit text-[#FFFFFF] hover:bg-crit/85 disabled:hover:bg-bg-elev",
         className,
       )}
       {...rest}

--- a/web/src/components/ui/CountBadge.tsx
+++ b/web/src/components/ui/CountBadge.tsx
@@ -34,16 +34,19 @@ export interface BufferedCountChipProps {
   className?: string;
 }
 
-/** BufferedCountChip — the "▼ n new" pill (MI-4, §8.2b). */
+/**
+ * BufferedCountChip — the "▼ n new" pill (MI-4, §8.2b). Outlined brand +
+ * 12% brand tint, mono label (Figma 94:1556) — not a solid brand fill.
+ */
 export function BufferedCountChip({ count, onClick, className }: BufferedCountChipProps) {
   return (
     <button
       type="button"
       onClick={onClick}
       className={clsx(
-        "font-ui inline-flex h-6 items-center gap-1 rounded-full bg-brand px-2",
-        "text-[12px] font-medium text-on-brand",
-        "transition-colors duration-[var(--duration-fast)] ease-standard hover:bg-brand-deep",
+        "font-data inline-flex items-center gap-1 rounded-[10px] border border-brand bg-brand/12 px-2 py-[3px]",
+        "text-[11px] font-medium text-brand",
+        "transition-colors duration-[var(--duration-fast)] ease-standard hover:bg-brand/20",
         className,
       )}
     >

--- a/web/src/components/ui/GoogleAuthButton.test.tsx
+++ b/web/src/components/ui/GoogleAuthButton.test.tsx
@@ -19,7 +19,7 @@ describe("GoogleAuthButton", () => {
   it("shows the loading state and blocks interaction", async () => {
     const onClick = vi.fn();
     render(<GoogleAuthButton onClick={onClick} loading />);
-    const button = screen.getByRole("button", { name: /connecting/i });
+    const button = screen.getByRole("button", { name: /signing in/i });
     expect(button).toBeDisabled();
     expect(button).toHaveAttribute("aria-busy", "true");
     await userEvent.click(button).catch(() => undefined);

--- a/web/src/components/ui/GoogleAuthButton.tsx
+++ b/web/src/components/ui/GoogleAuthButton.tsx
@@ -42,6 +42,8 @@ export interface GoogleAuthButtonProps {
 /**
  * GoogleAuthButton — the product's single auth CTA (X-1; design.md §8.2b:
  * default / hover / loading). Same name in every CueLABS product.
+ * Google brand button colors are brand-mandated raw values (white /
+ * #1F1F1F / #D9D9D9 — Figma 92:1449), NOT token-bound, in both modes.
  */
 export function GoogleAuthButton({
   onClick,
@@ -56,24 +58,27 @@ export function GoogleAuthButton({
       disabled={disabled || loading}
       aria-busy={loading}
       className={clsx(
-        "font-ui inline-flex h-10 w-full items-center justify-center gap-[var(--space-3)]",
-        "rounded-(--radius) border border-border bg-bg-elev px-[var(--space-4)]",
-        "text-[14px] font-medium text-text",
+        "font-ui inline-flex h-9 w-full items-center justify-center gap-[var(--space-3)]",
+        // raw values: the token theme resets Tailwind's default palette,
+        // so bg-white does not exist — use arbitrary values
+        "rounded-(--radius) border border-[#D9D9D9] bg-[#FFFFFF] px-[var(--space-4)]",
+        "text-[14px] font-medium text-[#1F1F1F]",
         "transition-colors duration-[var(--duration-fast)] ease-standard",
-        "hover:border-brand focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand",
-        "disabled:cursor-not-allowed disabled:opacity-60",
+        "hover:bg-[#F5F5F5] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand",
+        "disabled:cursor-not-allowed",
+        !loading && "disabled:opacity-60", // loading is busy, not dimmed (Figma 92:1448)
         className,
       )}
     >
       {loading ? (
         <span
           aria-hidden="true"
-          className="inline-block size-[18px] animate-spin rounded-full border-2 border-border border-t-brand motion-reduce:animate-none"
+          className="inline-block size-4 animate-spin rounded-full border-2 border-[#D9D9D9] border-t-brand-deep motion-reduce:animate-none"
         />
       ) : (
         <GoogleGlyph />
       )}
-      <span>{loading ? "Connecting…" : "Continue with Google"}</span>
+      <span>{loading ? "Signing in…" : "Continue with Google"}</span>
     </button>
   );
 }

--- a/web/src/components/ui/Heatmap.tsx
+++ b/web/src/components/ui/Heatmap.tsx
@@ -13,50 +13,73 @@ export interface HeatmapProps {
   className?: string;
 }
 
-/** Heatmap — §8.2: time×bucket cell grid, intensity ramp on series/1, hover tooltip. */
+const CELL = 14; // px — fixed cell size; Tooltip wrappers hug content
+
+/**
+ * Heatmap — §8.2: time×bucket cell grid, intensity ramp on series/1,
+ * hover tooltip, mono axis labels + time labels below (Figma 73:682).
+ */
 export function Heatmap({ columns, rows, values, className }: HeatmapProps) {
   const max = Math.max(...values.flat(), 1);
+  // sparse x labels: first / quarter / mid / three-quarter / last
+  const labelIdx = new Set(
+    [0, 0.25, 0.5, 0.75, 1].map((t) => Math.round(t * (columns.length - 1))),
+  );
   return (
-    <div className={clsx("font-ui flex gap-1", className)}>
-      <div className="flex flex-col justify-between py-0.5 text-right">
+    <div className={clsx("font-ui flex w-fit gap-1.5", className)}>
+      <div
+        className="flex flex-col justify-between py-0.5 text-right"
+        style={{ height: rows.length * (CELL + 1) }}
+      >
         {rows.map((row) => (
-          <span key={row} className="font-data text-[11px] tabular-nums text-text-2">
+          <span key={row} className="font-data text-[11px] leading-none tabular-nums text-text-2">
             {row}
           </span>
         ))}
       </div>
-      <div
-        role="img"
-        aria-label="heatmap"
-        className="grid flex-1 gap-px"
-        style={{
-          gridTemplateColumns: `repeat(${columns.length}, minmax(0,1fr))`,
-          gridTemplateRows: `repeat(${rows.length}, 14px)`,
-          gridAutoFlow: "column",
-        }}
-      >
-        {columns.map((col, ci) =>
-          rows.map((row, ri) => {
-            const v = values[ri]?.[ci] ?? 0;
-            return (
-              <Tooltip
-                key={`${col}-${row}`}
-                content={[
-                  { label: `${col} · ${row}`, value: String(v) },
-                ]}
-              >
-                <span
-                  data-count={v}
-                  className="block size-full rounded-[1px]"
-                  style={{
-                    background: "var(--color-series-1)",
-                    opacity: v === 0 ? 0.06 : 0.15 + (v / max) * 0.85,
-                  }}
-                />
-              </Tooltip>
-            );
-          }),
-        )}
+      <div className="flex flex-col gap-1">
+        <div
+          role="img"
+          aria-label="heatmap"
+          className="grid gap-px"
+          style={{
+            gridTemplateColumns: `repeat(${columns.length}, ${CELL}px)`,
+            gridTemplateRows: `repeat(${rows.length}, ${CELL}px)`,
+            gridAutoFlow: "column",
+          }}
+        >
+          {columns.map((col, ci) =>
+            rows.map((row, ri) => {
+              const v = values[ri]?.[ci] ?? 0;
+              return (
+                <Tooltip
+                  key={`${col}-${row}`}
+                  content={[{ label: `${col} · ${row}`, value: String(v) }]}
+                >
+                  <span
+                    data-count={v}
+                    className="block rounded-[1px]"
+                    style={{
+                      width: CELL,
+                      height: CELL,
+                      background: "var(--color-series-1)",
+                      opacity: v === 0 ? 0.06 : 0.15 + (v / max) * 0.85,
+                    }}
+                  />
+                </Tooltip>
+              );
+            }),
+          )}
+        </div>
+        <div className="flex justify-between">
+          {columns
+            .filter((_, i) => labelIdx.has(i))
+            .map((col) => (
+              <span key={col} className="font-data text-[11px] tabular-nums text-text-2">
+                {col}
+              </span>
+            ))}
+        </div>
       </div>
     </div>
   );

--- a/web/src/components/ui/Input.tsx
+++ b/web/src/components/ui/Input.tsx
@@ -6,27 +6,41 @@ import type { InputHTMLAttributes } from "react";
 export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   /** §8.2 Input: default / focus / error / disabled. */
   error?: boolean;
+  /** Crit hint line under the field (Figma 38:14 error state). */
+  errorMessage?: string;
   /** Query/data inputs render in JetBrains Mono (design.md §2). */
   mono?: boolean;
 }
 
-export function Input({ error = false, mono = false, className, ...rest }: InputProps) {
-  return (
+export function Input({ error = false, errorMessage, mono = false, className, ...rest }: InputProps) {
+  const invalid = error || Boolean(errorMessage);
+  const field = (
     <input
-      aria-invalid={error || undefined}
+      aria-invalid={invalid || undefined}
       className={clsx(
-        "h-8 w-full rounded-(--radius) border bg-bg px-2 text-[14px] text-text",
+        "h-8 w-full rounded-(--radius) border bg-bg-elev px-2.5 text-[14px] text-text",
         mono ? "font-data" : "font-ui",
         "placeholder:text-text-2",
         "transition-colors duration-[var(--duration-fast)] ease-standard",
         "focus:outline-none focus-visible:outline-none",
-        error
-          ? "border-crit focus:border-crit"
-          : "border-border focus:border-brand",
-        "disabled:cursor-not-allowed disabled:opacity-60",
+        // 2px ring per the ecosystem focus standard (Figma 38:9/38:14):
+        // 1px border + 1px ring, no layout shift.
+        invalid
+          ? "border-crit ring-1 ring-crit"
+          : "border-border focus:border-brand focus:ring-1 focus:ring-brand",
+        "disabled:cursor-not-allowed disabled:opacity-55",
         className,
       )}
       {...rest}
     />
+  );
+  if (!errorMessage) return field;
+  return (
+    <span className="flex w-full flex-col gap-1.5">
+      {field}
+      <span role="alert" className="font-ui text-[12px] text-crit">
+        {errorMessage}
+      </span>
+    </span>
   );
 }

--- a/web/src/components/ui/LevelChip.tsx
+++ b/web/src/components/ui/LevelChip.tsx
@@ -9,13 +9,13 @@ export interface LevelChipProps {
 }
 
 // Mapping [Decided 2026-07-16]: INFO → brand · DEBUG → text-2 · TRACE →
-// nodata; ERROR/WARN keep crit/warn.
+// nodata; ERROR/WARN keep crit/warn. 14% tint container (Figma 40:33).
 const TINT: Record<LogLevel, string> = {
-  ERROR: "text-crit border-crit/40",
-  WARN: "text-warn border-warn/40",
-  INFO: "text-brand border-brand/40",
-  DEBUG: "text-text-2 border-border",
-  TRACE: "text-nodata border-border",
+  ERROR: "text-crit bg-crit/14",
+  WARN: "text-warn bg-warn/14",
+  INFO: "text-brand bg-brand/14",
+  DEBUG: "text-text-2 bg-text-2/14",
+  TRACE: "text-nodata bg-nodata/14",
 };
 
 /** LevelChip — log level chip ×5, extracted from LogLine (§8.2). */
@@ -24,8 +24,8 @@ export function LevelChip({ level, className }: LevelChipProps) {
     <span
       data-level={level}
       className={clsx(
-        "font-data inline-flex h-4.5 w-[52px] items-center justify-center rounded-(--radius)",
-        "border text-[11px] font-medium tracking-wide",
+        "font-data inline-flex items-center justify-center rounded-(--radius)",
+        "px-1.5 py-0.5 text-[11px] font-medium",
         TINT[level],
         className,
       )}

--- a/web/src/components/ui/LogHistogram.tsx
+++ b/web/src/components/ui/LogHistogram.tsx
@@ -11,6 +11,9 @@ export interface LogHistogramProps {
 }
 
 // stacking order bottom→top; tints follow the LevelChip mapping
+// (info=brand · debug=text-2 · trace=nodata · warn · error=crit, Figma 75:822;
+// TRACE keeps its LevelChip tint here even though the Figma mock stacks four
+// levels — data-driven).
 const STACK: { level: LogLevel; color: string }[] = [
   { level: "INFO", color: "var(--color-brand)" },
   { level: "DEBUG", color: "var(--color-text-2)" },
@@ -19,54 +22,93 @@ const STACK: { level: LogLevel; color: string }[] = [
   { level: "ERROR", color: "var(--color-crit)" },
 ];
 
-/** LogHistogram — §8.2: level-stacked volume bars over the time axis (B4). */
-export function LogHistogram({ buckets, height = 48, className }: LogHistogramProps) {
+function formatCount(n: number): string {
+  if (n >= 1000) return `${(n / 1000).toFixed(1)}k`;
+  return String(n);
+}
+
+/**
+ * LogHistogram — §8.2: B4 logs-explorer histogram header. Level-stacked
+ * volume bars in a bg-elev card with a mono totals header and time axis
+ * (Figma 75:646); MI-6 crossfade on facet change.
+ */
+export function LogHistogram({ buckets, height = 64, className }: LogHistogramProps) {
   const totals = buckets.map((b) =>
     STACK.reduce((s, { level }) => s + (b.counts[level] ?? 0), 0),
   );
   const max = Math.max(...totals, 1);
+  const grandTotal = totals.reduce((a, b) => a + b, 0);
+  const errorTotal = buckets.reduce((s, b) => s + (b.counts.ERROR ?? 0), 0);
+  const warnTotal = buckets.reduce((s, b) => s + (b.counts.WARN ?? 0), 0);
+  const labelIdx = new Set(
+    [0, 0.25, 0.5, 0.75, 1].map((t) => Math.round(t * (buckets.length - 1))),
+  );
 
   return (
     <div
-      role="img"
-      aria-label="log volume histogram"
-      className={clsx("flex w-full items-end gap-px", className)}
-      style={{ height }}
+      className={clsx(
+        "flex w-fit max-w-full flex-col gap-2 rounded-(--radius) border border-border bg-bg-elev p-3.5",
+        className,
+      )}
     >
-      {buckets.map((bucket, i) => (
-        <Tooltip
-          key={bucket.ts}
-          content={STACK.filter(({ level }) => (bucket.counts[level] ?? 0) > 0)
-            .reverse()
-            .map(({ level }) => ({
-              label: level,
-              value: String(bucket.counts[level]),
-            }))}
-        >
-          <span
-            data-ts={bucket.ts}
-            className="flex h-full min-w-0 flex-1 flex-col-reverse"
-            style={{ width: `${100 / buckets.length}%`, height }}
+      <div className="font-data flex gap-3 text-[12px]">
+        <span className="text-text tabular-nums">{formatCount(grandTotal)} events</span>
+        <span className="text-text-2 tabular-nums">
+          error {formatCount(errorTotal)} · warn {formatCount(warnTotal)}
+        </span>
+      </div>
+
+      <div
+        role="img"
+        aria-label="log volume histogram"
+        className="flex items-end gap-0.5"
+        style={{ height }}
+      >
+        {buckets.map((bucket, i) => (
+          <Tooltip
+            key={bucket.ts}
+            content={STACK.filter(({ level }) => (bucket.counts[level] ?? 0) > 0)
+              .reverse()
+              .map(({ level }) => ({
+                label: level,
+                value: String(bucket.counts[level]),
+              }))}
           >
-            {STACK.map(({ level, color }) => {
-              const v = bucket.counts[level] ?? 0;
-              if (v === 0) return null;
-              return (
-                <span
-                  key={level}
-                  style={{
-                    height: `${(v / max) * 100}%`,
-                    background: color,
-                    opacity: 0.9,
-                  }}
-                  className="block w-full"
-                />
-              );
-            })}
-            <span className="sr-only">{totals[i]} lines</span>
-          </span>
-        </Tooltip>
-      ))}
+            <span
+              data-ts={bucket.ts}
+              className="flex flex-col-reverse"
+              style={{ width: 6, height }}
+            >
+              {STACK.map(({ level, color }) => {
+                const v = bucket.counts[level] ?? 0;
+                if (v === 0) return null;
+                return (
+                  <span
+                    key={level}
+                    style={{
+                      height: `${(v / max) * 100}%`,
+                      background: color,
+                      opacity: 0.9,
+                    }}
+                    className="block w-full"
+                  />
+                );
+              })}
+              <span className="sr-only">{totals[i]} lines</span>
+            </span>
+          </Tooltip>
+        ))}
+      </div>
+
+      <div className="flex justify-between">
+        {buckets
+          .filter((_, i) => labelIdx.has(i))
+          .map((b) => (
+            <span key={b.ts} className="font-data text-[11px] tabular-nums text-text-2">
+              {b.ts.slice(11, 16)}
+            </span>
+          ))}
+      </div>
     </div>
   );
 }

--- a/web/src/components/ui/QueryPill.tsx
+++ b/web/src/components/ui/QueryPill.tsx
@@ -20,7 +20,8 @@ export function QueryPill({ facet, value, negated = false, onRemove, className }
       className={clsx(
         "font-data inline-flex h-6 items-center gap-1 rounded-(--radius) border border-border",
         "bg-bg-elev px-1.5 text-[12px] text-text",
-        "transition-colors duration-[var(--duration-fast)] ease-standard hover:border-brand",
+        // hover lifts the hairline to text-2 (Figma 40:16)
+        "transition-colors duration-[var(--duration-fast)] ease-standard hover:border-text-2",
         className,
       )}
     >

--- a/web/src/components/ui/QueryValue.test.tsx
+++ b/web/src/components/ui/QueryValue.test.tsx
@@ -4,9 +4,11 @@ import { QueryValue } from "./QueryValue";
 
 describe("QueryValue", () => {
   it("shows the delta chip and threshold tint", () => {
-    render(<QueryValue value="142 ms" deltaPct={-3.4} threshold="warn" />);
-    expect(screen.getByText("142 ms")).toHaveClass("text-warn");
-    expect(screen.getByText("-3.4%")).toBeInTheDocument();
+    const { container } = render(<QueryValue value="142 ms" deltaPct={-3.4} threshold="warn" />);
+    // Figma 70:537 — tint wash carries the threshold, the value stays neutral
+    expect(screen.getByText("142 ms")).toHaveClass("text-text");
+    expect(container.querySelector(".bg-warn\\/8")).not.toBeNull();
+    expect(screen.getByText("▼ 3.4%")).toHaveClass("text-warn");
   });
 
   it("renders the sparkline variant", () => {

--- a/web/src/components/ui/QueryValue.tsx
+++ b/web/src/components/ui/QueryValue.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { clsx } from "clsx";
-import { TrendingDown, TrendingUp } from "lucide-react";
 
 export type QueryValueThreshold = "none" | "ok" | "warn" | "crit";
 
@@ -13,12 +12,30 @@ export interface QueryValueProps {
   deltaPct?: number;
   /** Threshold tint (§8.2). */
   threshold?: QueryValueThreshold;
-  /** Sparkline values. */
+  /** Sparkline values (bound series/1, Figma 70:537). */
   sparkline?: number[];
   className?: string;
 }
 
-/** QueryValue — §8.2: big tabular value + delta chip · threshold tint · sparkline. */
+// 8% tint-bg card wash per threshold (Figma tint-bg, inset −1px).
+const TINT: Record<Exclude<QueryValueThreshold, "none">, string> = {
+  ok: "bg-ok/8",
+  warn: "bg-warn/8",
+  crit: "bg-crit/8",
+};
+
+const DELTA_TEXT: Record<Exclude<QueryValueThreshold, "none">, string> = {
+  ok: "text-ok",
+  warn: "text-warn",
+  crit: "text-crit",
+};
+
+/**
+ * QueryValue — §8.2 dashboard query-value widget body (Figma 70:537):
+ * bg-elev card + threshold tint wash, mono 28 value in text (tint carries
+ * the threshold; the value itself stays neutral), mono ▲/▼ delta,
+ * series/1 sparkline.
+ */
 export function QueryValue({
   value,
   label,
@@ -30,56 +47,52 @@ export function QueryValue({
   return (
     <div
       data-threshold={threshold}
-      className={clsx("font-ui flex flex-col items-start gap-1", className)}
+      className={clsx(
+        "font-ui relative flex w-fit min-w-44 flex-col items-start gap-1.5 overflow-hidden",
+        "rounded-(--radius) border border-border bg-bg-elev p-4",
+        className,
+      )}
     >
-      {label && <span className="text-[12px] text-text-2">{label}</span>}
-      <div className="flex items-baseline gap-2">
-        <span
-          className={clsx(
-            "font-data text-[28px] font-semibold tabular-nums leading-none",
-            threshold === "none" && "text-text",
-            threshold === "ok" && "text-ok",
-            threshold === "warn" && "text-warn",
-            threshold === "crit" && "text-crit",
-          )}
-        >
-          {value}
-        </span>
+      {threshold !== "none" && (
+        <span aria-hidden="true" className={clsx("absolute -inset-px rounded-(--radius)", TINT[threshold])} />
+      )}
+      {label && <span className="relative text-[12px] text-text-2">{label}</span>}
+      <div className="font-data relative flex items-center gap-2.5">
+        <span className="text-[28px] leading-none tabular-nums text-text">{value}</span>
         {deltaPct !== undefined && (
           <span
             className={clsx(
-              "inline-flex items-center gap-0.5 text-[12px] font-medium tabular-nums",
-              deltaPct >= 0 ? "text-ok" : "text-crit",
+              "text-[12px] tabular-nums",
+              threshold !== "none"
+                ? DELTA_TEXT[threshold]
+                : deltaPct >= 0
+                  ? "text-ok"
+                  : "text-crit",
             )}
           >
-            {deltaPct >= 0 ? (
-              <TrendingUp className="size-3" aria-hidden="true" />
-            ) : (
-              <TrendingDown className="size-3" aria-hidden="true" />
-            )}
-            {deltaPct >= 0 ? "+" : ""}
-            {deltaPct.toFixed(1)}%
+            {deltaPct >= 0 ? "▲" : "▼"} {Math.abs(deltaPct).toFixed(1)}%
           </span>
         )}
       </div>
       {sparkline && sparkline.length > 1 && (
         <svg
-          viewBox={`0 0 ${sparkline.length - 1} 20`}
+          viewBox={`0 0 ${sparkline.length - 1} 28`}
           preserveAspectRatio="none"
           aria-hidden="true"
-          style={{ width: 96, height: 20 }}
+          className="relative"
+          style={{ width: 200, height: 28 }}
         >
           <polyline
             fill="none"
-            stroke="var(--color-brand)"
-            strokeWidth={1}
+            stroke="var(--color-series-1)"
+            strokeWidth={1.5}
             vectorEffect="non-scaling-stroke"
             points={sparkline
               .map((v, i) => {
                 const max = Math.max(...sparkline, 1);
                 const min = Math.min(...sparkline);
                 const range = Math.max(max - min, 1);
-                return `${i},${20 - ((v - min) / range) * 16 - 2}`;
+                return `${i},${28 - ((v - min) / range) * 24 - 2}`;
               })
               .join(" ")}
           />

--- a/web/src/components/ui/SLOCard.tsx
+++ b/web/src/components/ui/SLOCard.tsx
@@ -19,7 +19,7 @@ export function SLOCard({ slo, className }: SLOCardProps) {
     <div
       data-state={slo.state}
       className={clsx(
-        "font-ui flex w-64 flex-col gap-2 rounded-(--radius) border border-border bg-bg-elev p-3",
+        "font-ui flex w-64 flex-col gap-2 rounded-(--radius) border border-border bg-bg-elev p-4",
         className,
       )}
     >
@@ -31,10 +31,13 @@ export function SLOCard({ slo, className }: SLOCardProps) {
       </div>
 
       <div className="flex items-baseline gap-2">
+        {/* Figma 48:95: Inter semibold 20, colored per state (ok/warn/crit) */}
         <span
           className={clsx(
-            "font-data text-[20px] font-semibold tabular-nums",
-            slo.state === "exhausted" ? "text-crit" : "text-text",
+            "text-[20px] font-semibold tabular-nums",
+            slo.state === "healthy" && "text-ok",
+            slo.state === "burning" && "text-warn",
+            slo.state === "exhausted" && "text-crit",
           )}
         >
           {slo.current.toFixed(2)}%
@@ -51,7 +54,7 @@ export function SLOCard({ slo, className }: SLOCardProps) {
         aria-valuenow={budget}
         aria-valuemin={0}
         aria-valuemax={100}
-        className="h-1.5 w-full overflow-hidden rounded-full bg-bg"
+        className="h-1.5 w-full overflow-hidden rounded-full bg-border"
       >
         <div
           style={{ width: `${budget}%` }}
@@ -64,10 +67,10 @@ export function SLOCard({ slo, className }: SLOCardProps) {
         />
       </div>
 
-      <div className="flex items-center justify-between text-[11px] tabular-nums text-text-2">
-        <span>{budget.toFixed(0)}% budget left</span>
-        <span>burn ×{slo.burn_rate.toFixed(1)}</span>
-      </div>
+      {/* single meta line (Figma 48:71) */}
+      <span className="text-[12px] tabular-nums text-text-2">
+        error budget {budget.toFixed(0)}% left · burn {slo.burn_rate.toFixed(1)}×
+      </span>
     </div>
   );
 }

--- a/web/src/components/ui/ServiceMapNode.tsx
+++ b/web/src/components/ui/ServiceMapNode.tsx
@@ -5,15 +5,18 @@ import { clsx } from "clsx";
 export interface ServiceMapNodeProps {
   name: string;
   reqPerS: number;
-  /** Error rate 0..1 — drawn as the ring fill (§3 anatomy). */
+  /** Error rate 0..1 — drawn as the circular ring segment (§3 anatomy). */
   errorRate: number;
+  /** Series color index for the service (hexagon stroke, Figma 68:445). */
+  colorIndex?: number;
   selected?: boolean;
   onClick?: () => void;
   className?: string;
 }
 
-const SIZE = 112;
-const R = 44;
+const SIZE = 150;
+const RING_R = 64; // 128px circle (Figma)
+const HEX_R = 48; // 96px hexagon
 
 function hexPoints(cx: number, cy: number, r: number): string {
   return Array.from({ length: 6 }, (_, i) => {
@@ -22,21 +25,29 @@ function hexPoints(cx: number, cy: number, r: number): string {
   }).join(" ");
 }
 
+function formatReq(reqPerS: number): string {
+  return reqPerS >= 1000 ? `${(reqPerS / 1000).toFixed(1)}k` : reqPerS.toFixed(0);
+}
+
 /**
- * ServiceMapNode — §8.2: hexagon (name + req/s + error-% ring) ·
- * healthy / erroring / selected.
+ * ServiceMapNode — §8.2 (Figma 68:445): hexagon stroked in the service
+ * series color inside a circular border ring; ring segment = error %
+ * (crit when erroring, ok sliver otherwise); selected = brand outline +
+ * glow (brand at 45%).
  */
 export function ServiceMapNode({
   name,
   reqPerS,
   errorRate,
+  colorIndex = 0,
   selected = false,
   onClick,
   className,
 }: ServiceMapNodeProps) {
   const erroring = errorRate >= 0.05;
-  const ringLength = 6 * R; // hexagon perimeter approximation for dash math
-  const errorLen = Math.min(Math.max(errorRate, 0), 1) * ringLength;
+  const seriesColor = `var(--color-series-${(colorIndex % 8) + 1})`;
+  const circumference = 2 * Math.PI * RING_R;
+  const arcLen = Math.max(Math.min(errorRate, 1), 0.005) * circumference;
 
   return (
     <button
@@ -49,49 +60,71 @@ export function ServiceMapNode({
         className,
       )}
     >
-      <svg width={SIZE} height={SIZE} viewBox={`0 0 ${SIZE} ${SIZE}`} aria-hidden="true">
-        <polygon
-          points={hexPoints(SIZE / 2, SIZE / 2, R)}
-          fill="var(--color-bg-elev)"
-          stroke={selected ? "var(--color-brand)" : "var(--color-border)"}
-          strokeWidth={selected ? 2 : 1}
+      <svg
+        viewBox={`0 0 ${SIZE} ${SIZE}`}
+        style={{ width: SIZE, height: SIZE }}
+        aria-hidden="true"
+      >
+        {/* base ring — hairline circle (Figma stroke 4 border) */}
+        <circle
+          cx={SIZE / 2}
+          cy={SIZE / 2}
+          r={RING_R}
+          fill="none"
+          stroke="var(--color-border)"
+          strokeWidth={4}
         />
-        {/* error ring */}
-        <polygon
-          points={hexPoints(SIZE / 2, SIZE / 2, R)}
+        {/* error segment — starts at 12 o'clock */}
+        <circle
+          cx={SIZE / 2}
+          cy={SIZE / 2}
+          r={RING_R}
           fill="none"
           stroke={erroring ? "var(--color-crit)" : "var(--color-ok)"}
-          strokeWidth={2.5}
-          strokeDasharray={`${errorLen === 0 ? ringLength : errorLen} ${ringLength}`}
-          opacity={errorRate === 0 ? 0.35 : 1}
+          strokeWidth={4}
+          strokeLinecap="round"
+          strokeDasharray={`${arcLen} ${circumference}`}
+          transform={`rotate(-90 ${SIZE / 2} ${SIZE / 2})`}
+        />
+        {/* hexagon in the service series color; brand outline + glow when selected */}
+        <polygon
+          points={hexPoints(SIZE / 2, SIZE / 2, HEX_R)}
+          fill="var(--color-bg-elev)"
+          stroke={selected ? "var(--color-brand)" : seriesColor}
+          strokeWidth={selected ? 2.5 : 2}
+          style={
+            selected
+              ? { filter: "drop-shadow(0 0 8px rgba(0, 224, 158, 0.45))" } // brand glow — effect color not token-bindable (Figma note)
+              : undefined
+          }
         />
         <text
           x={SIZE / 2}
-          y={SIZE / 2 - 4}
+          y={SIZE / 2 - 8}
           textAnchor="middle"
           fontSize={12}
-          fontWeight={600}
+          fontWeight={500}
           fill="var(--color-text)"
         >
           {name.length > 12 ? `${name.slice(0, 11)}…` : name}
         </text>
         <text
           x={SIZE / 2}
-          y={SIZE / 2 + 12}
+          y={SIZE / 2 + 8}
           textAnchor="middle"
           fontSize={11}
           fill="var(--color-text-2)"
-          className="tabular-nums"
+          className="font-data tabular-nums"
         >
-          {reqPerS.toFixed(1)} req/s
+          {formatReq(reqPerS)} req/s
         </text>
         <text
           x={SIZE / 2}
-          y={SIZE / 2 + 26}
+          y={SIZE / 2 + 22}
           textAnchor="middle"
-          fontSize={11}
+          fontSize={10}
           fill={erroring ? "var(--color-crit)" : "var(--color-text-2)"}
-          className="tabular-nums"
+          className="font-data tabular-nums"
         >
           {(errorRate * 100).toFixed(1)}% err
         </text>

--- a/web/src/components/ui/Skeleton.tsx
+++ b/web/src/components/ui/Skeleton.tsx
@@ -8,13 +8,14 @@ export interface SkeletonProps {
   /** §8.2b: kind line / value / panel-axis. */
   kind?: SkeletonKind;
   className?: string;
+  style?: React.CSSProperties;
 }
 
 /**
  * Skeleton — the Stage-4 loading-frame primitive (§8.1 three-frame rule).
  * Shimmer sweep; static under prefers-reduced-motion (§5).
  */
-export function Skeleton({ kind = "line", className }: SkeletonProps) {
+export function Skeleton({ kind = "line", className, style }: SkeletonProps) {
   const shimmer =
     "animate-pulse motion-reduce:animate-none bg-bg-elev";
   if (kind === "panel-axis") {
@@ -23,6 +24,7 @@ export function Skeleton({ kind = "line", className }: SkeletonProps) {
       <div
         data-kind={kind}
         aria-hidden="true"
+        style={style}
         className={clsx("relative h-32 w-full", className)}
       >
         <div className="absolute inset-y-0 left-6 w-px bg-border" />
@@ -35,6 +37,7 @@ export function Skeleton({ kind = "line", className }: SkeletonProps) {
     <span
       data-kind={kind}
       aria-hidden="true"
+      style={style}
       className={clsx(
         "block rounded-(--radius)",
         shimmer,

--- a/web/src/components/ui/SpanRow.tsx
+++ b/web/src/components/ui/SpanRow.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { clsx } from "clsx";
+import { XCircle } from "lucide-react";
 import type { Span } from "@/models";
 
 export interface SpanRowProps {
@@ -24,8 +25,9 @@ function formatNs(ns: number): string {
 }
 
 /**
- * SpanRow — §8.2: depth indent · service color (series/n) · status ok/error
- * · default/hover/selected; duration label pops on hover (MI-7).
+ * SpanRow — §8.2 (Figma 64:558): depth indent · series color tick + mono
+ * span name · error = 8% crit tint + x-circle + crit bar · selected =
+ * brand outline; duration label pops on hover (MI-7).
  */
 export function SpanRow({
   span,
@@ -39,6 +41,7 @@ export function SpanRow({
   className,
 }: SpanRowProps) {
   const color = `var(--color-series-${(colorIndex % 8) + 1})`;
+  const error = span.status === "error";
   return (
     <button
       type="button"
@@ -48,9 +51,10 @@ export function SpanRow({
       onMouseEnter={() => onHover?.(true)}
       onMouseLeave={() => onHover?.(false)}
       className={clsx(
-        "font-ui group flex h-7 w-full items-center gap-2 border-b border-border px-2 text-left",
+        "font-ui group flex h-7 w-full items-center gap-2 rounded-[3px] px-2 text-left",
         "transition-colors duration-[var(--duration-fast)] ease-standard",
-        selected ? "bg-bg-elev" : "hover:bg-bg-elev",
+        error && "bg-crit/8",
+        selected ? "ring-1 ring-inset ring-brand" : "hover:bg-bg-elev",
         className,
       )}
     >
@@ -58,28 +62,28 @@ export function SpanRow({
         className="flex w-56 shrink-0 items-center gap-1.5 truncate"
         style={{ paddingLeft: depth * 12 }}
       >
+        {error && <XCircle aria-label="error span" className="size-3 shrink-0 text-crit" />}
         <span
           aria-hidden="true"
-          className="size-2 shrink-0 rounded-[1px]"
+          className="h-3.5 w-[3px] shrink-0"
           style={{ background: color }}
         />
-        <span className="truncate text-[12px] text-text">{span.name}</span>
+        <span className="font-data truncate text-[12px] text-text">{span.name}</span>
       </span>
-      <span className="w-20 shrink-0 truncate text-[11px] text-text-2">{span.service}</span>
-      <span className="relative h-3 min-w-0 flex-1 rounded-[1px] bg-bg">
+      <span className="w-20 shrink-0 truncate text-[12px] text-text-2">{span.service}</span>
+      <span className="relative h-4 min-w-0 flex-1">
         <span
-          className={clsx("absolute inset-y-0 rounded-[1px]", span.status === "error" && "outline outline-1 outline-crit")}
+          className="absolute inset-y-[5px] rounded-[2px]"
           style={{
             left: `${offsetFrac * 100}%`,
             width: `${Math.max(widthFrac * 100, 0.5)}%`,
-            background: color,
+            background: error ? "var(--color-crit)" : color,
           }}
         />
       </span>
       <span
         className={clsx(
-          "font-data w-16 shrink-0 text-right text-[11px] tabular-nums",
-          span.status === "error" ? "text-crit" : "text-text-2",
+          "font-data w-16 shrink-0 text-right text-[11px] tabular-nums text-text-2",
           "transition-transform duration-[var(--duration-fast)] ease-standard group-hover:scale-105 motion-reduce:transition-none",
         )}
       >

--- a/web/src/components/ui/StatusPageHeader.tsx
+++ b/web/src/components/ui/StatusPageHeader.tsx
@@ -26,8 +26,10 @@ const COPY: Record<OverallStatus, string> = {
 
 /** StatusPageHeader — §8.2: overall ×4 + last-updated ts (public page, B7). */
 export function StatusPageHeader({ orgName, overall, lastUpdated, className }: StatusPageHeaderProps) {
+  // Figma 75:862: outages (partial + major) carry crit + x-circle;
+  // only degraded stays warn + triangle.
   const Icon =
-    overall === "operational" ? CheckCircle2 : overall === "major_outage" ? XCircle : AlertTriangle;
+    overall === "operational" ? CheckCircle2 : overall === "degraded" ? AlertTriangle : XCircle;
   return (
     <header
       data-overall={overall}
@@ -39,8 +41,8 @@ export function StatusPageHeader({ orgName, overall, lastUpdated, className }: S
           "flex items-center gap-2 rounded-(--radius) border p-3",
           overall === "operational" && "border-ok/40 bg-ok/10",
           overall === "degraded" && "border-warn/40 bg-warn/10",
-          overall === "partial_outage" && "border-warn/40 bg-warn/10",
-          overall === "major_outage" && "border-crit/40 bg-crit/10",
+          overall === "partial_outage" && "border-crit/40 bg-crit/10",
+          overall === "major_outage" && "border-crit bg-crit/15",
         )}
       >
         <Icon
@@ -48,8 +50,8 @@ export function StatusPageHeader({ orgName, overall, lastUpdated, className }: S
           className={clsx(
             "size-5",
             overall === "operational" && "text-ok",
-            (overall === "degraded" || overall === "partial_outage") && "text-warn",
-            overall === "major_outage" && "text-crit",
+            overall === "degraded" && "text-warn",
+            (overall === "partial_outage" || overall === "major_outage") && "text-crit",
           )}
         />
         <span className="text-[16px] font-semibold text-text">{COPY[overall]}</span>

--- a/web/src/components/ui/StatusPill.test.tsx
+++ b/web/src/components/ui/StatusPill.test.tsx
@@ -5,14 +5,14 @@ import { StatusPill } from "./StatusPill";
 describe("StatusPill", () => {
   it("breathes only while crit (MI-8)", () => {
     const { container, rerender } = render(<StatusPill status="crit" />);
-    expect(container.querySelector(".animate-pulse")).not.toBeNull();
+    expect(container.querySelector("[class*='breathe']")).not.toBeNull();
     rerender(<StatusPill status="ok" />);
-    expect(container.querySelector(".animate-pulse")).toBeNull();
+    expect(container.querySelector("[class*='breathe']")).toBeNull();
   });
 
   it("keeps an accessible label in dot-only mode", () => {
     render(<StatusPill status="paused" dotOnly />);
-    expect(screen.getByText("paused")).toHaveClass("sr-only");
+    expect(screen.getByText("PAUSED")).toHaveClass("sr-only");
   });
 
   it("renders all six statuses", () => {

--- a/web/src/components/ui/StatusPill.tsx
+++ b/web/src/components/ui/StatusPill.tsx
@@ -20,13 +20,14 @@ export interface StatusPillProps {
   className?: string;
 }
 
+// Figma 39:51 — labels are the uppercase status names.
 const LABELS: Record<StatusPillStatus, string> = {
-  ok: "up",
-  warn: "degraded",
-  crit: "down",
-  nodata: "no data",
-  paused: "paused",
-  pending: "pending",
+  ok: "OK",
+  warn: "WARN",
+  crit: "CRIT",
+  nodata: "NO DATA",
+  paused: "PAUSED",
+  pending: "PENDING",
 };
 
 // Decided 2026-07-16: paused → nodata tint · pending → text-2.
@@ -48,16 +49,30 @@ const TEXT: Record<StatusPillStatus, string> = {
   pending: "text-text-2",
 };
 
+// 14% tint container in the status color (Figma tint-bg).
+const TINT: Record<StatusPillStatus, string> = {
+  ok: "bg-ok/14",
+  warn: "bg-warn/14",
+  crit: "bg-crit/14",
+  nodata: "bg-nodata/14",
+  paused: "bg-nodata/14",
+  pending: "bg-text-2/14",
+};
+
 /**
- * StatusPill — status semantics are sacred (§2). Breathing animation only
- * while crit (MI-8); disabled under prefers-reduced-motion (§5).
+ * StatusPill — status semantics are sacred (§2). 14% tint container +
+ * status-colored dot/label (Figma 39:51). Breathing animation only while
+ * crit (MI-8: dot scale 1→1.25→1, ~1.6s); disabled under
+ * prefers-reduced-motion (§5).
  */
 export function StatusPill({ status, dotOnly = false, label, className }: StatusPillProps) {
   return (
     <span
       data-status={status}
       className={clsx(
-        "font-ui inline-flex items-center gap-1.5 text-[12px] font-medium",
+        "font-ui inline-flex items-center gap-1.5 rounded-(--radius) text-[12px] font-medium",
+        dotOnly ? "p-[5px]" : "px-2 py-[3px]",
+        TINT[status],
         TEXT[status],
         className,
       )}
@@ -67,7 +82,8 @@ export function StatusPill({ status, dotOnly = false, label, className }: Status
         className={clsx(
           "inline-block size-2 rounded-full",
           DOT[status],
-          status === "crit" && "animate-pulse motion-reduce:animate-none",
+          status === "crit" &&
+            "animate-[breathe_1.6s_var(--ease-standard)_infinite] motion-reduce:animate-none",
         )}
       />
       {!dotOnly && <span>{label ?? LABELS[status]}</span>}

--- a/web/src/components/ui/TimeseriesPanel.tsx
+++ b/web/src/components/ui/TimeseriesPanel.tsx
@@ -38,6 +38,11 @@ function formatValue(v: number): string {
   return v % 1 === 0 ? String(v) : v.toFixed(1);
 }
 
+function formatTime(ts: string): string {
+  // hh:mm in UTC — bucketing renders UTC per X-10.
+  return ts.slice(11, 16);
+}
+
 /**
  * TimeseriesPanel — §3/§8.2: bespoke SVG line/area/bars, legend with
  * per-series toggle, synced crosshair (MI-2), loading (axis-first) and
@@ -129,7 +134,9 @@ export function TimeseriesPanel({
       </header>
 
       {loading ? (
-        <Skeleton kind="panel-axis" className={`h-[${plotH}px]`} />
+        // height via style — a template-built `h-[…]` class never reaches
+        // Tailwind's scanner, so it emitted no CSS
+        <Skeleton kind="panel-axis" style={{ height: plotH }} />
       ) : empty ? (
         <EmptyState
           pillar="metrics"
@@ -173,6 +180,28 @@ export function TimeseriesPanel({
               </g>
             );
           })}
+
+          {/* x-axis time labels (mono 11, §2 ramp — Figma 50:100) */}
+          {visible[0] &&
+            [0, 0.25, 0.5, 0.75, 1].map((t) => {
+              const pts = visible[0].points;
+              const idx = Math.round(t * (pts.length - 1));
+              const ts = pts[idx]?.ts;
+              if (!ts) return null;
+              return (
+                <text
+                  key={`x${t}`}
+                  x={PAD_L + t * innerW}
+                  y={plotH - 4}
+                  textAnchor={t === 0 ? "start" : t === 1 ? "end" : "middle"}
+                  fontSize={11}
+                  fill="var(--color-text-2)"
+                  className="font-data tabular-nums"
+                >
+                  {formatTime(ts)}
+                </text>
+              );
+            })}
 
           {/* series */}
           {visible.map((s, si) => {

--- a/web/src/components/ui/Toast.tsx
+++ b/web/src/components/ui/Toast.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { clsx } from "clsx";
-import { CheckCircle2, Info, XCircle, X } from "lucide-react";
+import { Bell, CheckCircle2, XCircle, X } from "lucide-react";
 
 export type ToastKind = "info" | "success" | "error";
 
@@ -12,8 +12,9 @@ export interface ToastProps {
   className?: string;
 }
 
-const ICONS: Record<ToastKind, typeof Info> = {
-  info: Info,
+// info carries the bell (Figma 38:21 icon/bell), not an info glyph.
+const ICONS: Record<ToastKind, typeof Bell> = {
+  info: Bell,
   success: CheckCircle2,
   error: XCircle,
 };
@@ -27,7 +28,8 @@ export function Toast({ kind = "info", message, onDismiss, className }: ToastPro
       data-kind={kind}
       className={clsx(
         "font-ui z-[var(--z-toast)] flex w-fit min-w-[240px] items-center gap-2 rounded-(--radius)",
-        "border border-border bg-bg-elev px-3 py-2 text-[13px] leading-[1.45] text-text shadow-lg",
+        "border border-border bg-bg-elev px-3 py-2.5 text-[13px] leading-[1.45] text-text",
+        "shadow-[0px_4px_16px_0px_rgba(0,0,0,0.4)]", // Figma 38:42 toast shadow
         className,
       )}
     >

--- a/web/src/components/ui/UptimeCard.test.tsx
+++ b/web/src/components/ui/UptimeCard.test.tsx
@@ -3,21 +3,24 @@ import { render, screen } from "@testing-library/react";
 import { UptimeCard } from "./UptimeCard";
 
 describe("UptimeCard", () => {
-  it("renders one bar per day with the uptime %", () => {
+  it("renders one bar per day with the uptime % meta line and status dot", () => {
     const days = Array.from({ length: 90 }, (_, i) => ({
       date: `2026-04-${(i % 30) + 1}-${i}`,
       uptime_pct: 100,
       down_minutes: 0,
     }));
-    render(<UptimeCard name="Homepage" days={days} uptimePct={99.987} />);
+    render(<UptimeCard name="Homepage" days={days} uptimePct={99.987} p95Ms={96} />);
     expect(screen.getByRole("img", { name: "Homepage 90-day uptime" }).children).toHaveLength(90);
-    expect(screen.getByText("99.987%")).toBeInTheDocument();
+    expect(screen.getByText(/99\.987% uptime/)).toBeInTheDocument();
+    expect(screen.getByText("p95 96 ms")).toBeInTheDocument();
+    // all-up strip → ok dot-only pill in the header
+    expect(screen.getByText("OK")).toHaveClass("sr-only");
   });
 
-  it("shows — for nodata and renders the sparkline", () => {
+  it("shows — and a nodata pill when there is no data", () => {
     const days = [{ date: "2026-07-18", uptime_pct: null, down_minutes: 0 }];
-    render(<UptimeCard name="Docs" days={days} uptimePct={null} sparkline={[100, 130, 90]} />);
-    expect(screen.getByText("—")).toBeInTheDocument();
-    expect(screen.getByLabelText("latency sparkline")).toBeInTheDocument();
+    render(<UptimeCard name="Docs" days={days} uptimePct={null} />);
+    expect(screen.getByText(/— uptime/)).toBeInTheDocument();
+    expect(screen.getByText("NO DATA")).toHaveClass("sr-only");
   });
 });

--- a/web/src/components/ui/UptimeCard.tsx
+++ b/web/src/components/ui/UptimeCard.tsx
@@ -2,6 +2,7 @@
 
 import { clsx } from "clsx";
 import type { UptimeDay } from "@/models";
+import { StatusPill, type StatusPillStatus } from "./StatusPill";
 import { Tooltip } from "./Tooltip";
 
 export interface UptimeCardProps {
@@ -10,8 +11,10 @@ export interface UptimeCardProps {
   days: UptimeDay[];
   /** 90-day uptime %, null when nodata. */
   uptimePct: number | null;
-  /** Latency sparkline values (recent response times, ms). */
-  sparkline?: number[];
+  /** p95 response time (ms) for the footer meta (Figma 49:164). */
+  p95Ms?: number;
+  /** Header status pill; derived from the latest day when omitted. */
+  status?: StatusPillStatus;
   className?: string;
 }
 
@@ -22,26 +25,33 @@ function barTint(day: UptimeDay): string {
   return "bg-crit";
 }
 
+function deriveStatus(days: UptimeDay[]): StatusPillStatus {
+  const latest = days[days.length - 1];
+  if (!latest || latest.uptime_pct === null) return "nodata";
+  if (latest.uptime_pct >= 99.9) return "ok";
+  if (latest.uptime_pct >= 98) return "warn";
+  return "crit";
+}
+
 /**
- * UptimeCard — the classic 90-day status strip (§3/§8.2). Bars fill on first
- * render with a 400ms stagger (MI-8); per-day tooltip detail.
+ * UptimeCard — the classic 90-day status strip (§3/§8.2, Figma 49:370):
+ * name + dot-only StatusPill header, 3×24 bars, mono uptime/p95 footer.
+ * Bars fill on first render with a 400ms stagger (MI-8); per-day tooltip.
  */
-export function UptimeCard({ name, days, uptimePct, sparkline, className }: UptimeCardProps) {
+export function UptimeCard({ name, days, uptimePct, p95Ms, status, className }: UptimeCardProps) {
   return (
     <div
       className={clsx(
-        "font-ui flex w-full max-w-xl flex-col gap-2 rounded-(--radius) border border-border bg-bg-elev p-3",
+        "font-ui flex w-full max-w-xl flex-col gap-2.5 rounded-(--radius) border border-border bg-bg-elev p-4",
         className,
       )}
     >
-      <div className="flex items-baseline justify-between gap-2">
+      <div className="flex items-center justify-between gap-2">
         <span className="truncate text-[13px] font-medium text-text">{name}</span>
-        <span className="font-data text-[13px] font-semibold tabular-nums text-text">
-          {uptimePct === null ? "—" : `${uptimePct.toFixed(3)}%`}
-        </span>
+        <StatusPill status={status ?? deriveStatus(days)} dotOnly />
       </div>
 
-      <div className="flex h-8 items-stretch gap-px" role="img" aria-label={`${name} 90-day uptime`}>
+      <div className="flex items-stretch gap-px" role="img" aria-label={`${name} 90-day uptime`}>
         {days.map((day, i) => (
           <Tooltip
             key={day.date}
@@ -56,7 +66,7 @@ export function UptimeCard({ name, days, uptimePct, sparkline, className }: Upti
               data-date={day.date}
               style={{ animationDelay: `${(i / days.length) * 400}ms` }}
               className={clsx(
-                "block h-8 w-1 origin-bottom rounded-[1px]",
+                "block h-6 w-[3px] origin-bottom rounded-[1px]",
                 barTint(day),
                 "animate-[bar-fill_var(--duration-entrance)_var(--ease-standard)_both] motion-reduce:animate-none",
               )}
@@ -65,32 +75,12 @@ export function UptimeCard({ name, days, uptimePct, sparkline, className }: Upti
         ))}
       </div>
 
-      {sparkline && sparkline.length > 1 && (
-        <svg
-          viewBox={`0 0 ${sparkline.length - 1} 24`}
-          preserveAspectRatio="none"
-          aria-label="latency sparkline"
-          className="h-6 w-full"
-          style={{ width: "100%", height: 24 }}
-        >
-          <polyline
-            fill="none"
-            stroke="var(--color-brand)"
-            strokeWidth={1}
-            vectorEffect="non-scaling-stroke"
-            points={sparklinePoints(sparkline)}
-          />
-        </svg>
-      )}
+      <div className="font-data flex items-center justify-between gap-2 text-[12px] tabular-nums">
+        <span className="text-text">
+          {uptimePct === null ? "— uptime" : `${uptimePct.toFixed(3)}% uptime`} · {days.length} days
+        </span>
+        {p95Ms !== undefined && <span className="text-text-2">p95 {p95Ms} ms</span>}
+      </div>
     </div>
   );
-}
-
-function sparklinePoints(values: number[]): string {
-  const max = Math.max(...values, 1);
-  const min = Math.min(...values);
-  const range = Math.max(max - min, 1);
-  return values
-    .map((v, i) => `${i},${24 - ((v - min) / range) * 20 - 2}`)
-    .join(" ");
 }


### PR DESCRIPTION
## Summary

Figma-match QA loop over the W1 component registry: audited `/dev/components` (dark primary + light) section-by-section against the Figma Components page (Stage 0 `35:3` · Stage 1 Atoms `35:4` · Stage 2 Molecules & Panels `35:5` · Stage 3 Panels & Platform Kit `64:338` · Stage 4 Chrome, Overlays & Marketing `86:1239`), then fixed real divergences and re-verified with fresh gallery captures.

## Root cause (systemic)

The legacy pre-W0 globals in `globals.css` were **unlayered**, so they beat every layered Tailwind utility:

- `* { padding: 0; margin: 0 }` nuked all padding/margin utilities (Table cells collided, card paddings vanished)
- `svg { width: 24px; height: 24px }` collapsed every class-sized chart — TimeseriesPanel rendered as a 24px sliver
- UA button chrome (ButtonFace bg, 2px outset border) leaked into every bg-less `<button>` row — AlertFeedRow / IncidentBanner / MonitorRow / LogLine pivots / FacetGroup / TimePicker / DashboardListRow / ErrorGroupRow all rendered as light-gray boxes in dark mode

**Fix:** legacy block moved into `@layer legacy` (declared below `components`/`utilities`), plus a minimal base-layer button reset (`background: transparent; border: 0; color/font/text-align: inherit`). Legacy routes are styled-components-only (unlayered ⇒ still win where they declare), so their rendering is unchanged; every legacy styled button declares its own background/border (verified).

## Per-component findings → fixes

| Component | Divergence | Fix |
|---|---|---|
| StatusPill | no tint container; lowercase `up/degraded/down` labels; crit pulse was opacity | 14% status-tint pill (`px-2 py-[3px]`, dot-only `p-[5px]`), uppercase `OK/WARN/CRIT/NO DATA/PAUSED/PENDING`, MI-8 scale-breathe keyframe (1→1.25→1, 1.6s); paused→nodata, pending→text-2 kept |
| Button | disabled = 60% opacity of kind fill; destructive hover dimmed label | disabled = bg-elev + border + text-2 (all kinds, Figma 37:29); destructive hover = crit@85% fill, label stays raw #FFF |
| LevelChip | outlined, fixed 52px width | 14% tint containers, hug content; INFO→brand · DEBUG→text-2 · TRACE→nodata mapping kept |
| QueryPill | hover border was brand | hover border → text-2 (Figma 40:16) |
| Toast | info used lucide `Info`; generic shadow | info → bell (Figma icon/bell); explicit `0 4 16 rgba(0,0,0,.4)` shadow |
| Input | bg-bg; 1px focus; no error hint; disabled 60% | bg-elev; 2px brand focus ring (border+ring, no layout shift); `errorMessage` crit hint line (Figma 38:14); disabled 55% |
| GoogleAuthButton | dark token button, “Connecting…” | Google-brand raw white/#1F1F1F/#D9D9D9 (both modes, per Figma [Decided]), hover #F5F5F5, loading “Signing in…” not dimmed |
| CountBadge / BufferedCountChip | solid brand fill + on-brand ink | outlined brand + 12% tint, mono 11 brand “▼ n new” (Figma 94:1556) |
| TimeseriesPanel | **bug**: template-built `h-[${h}px]` skeleton class emitted no CSS; missing x-axis time labels | style-based height; mono x-axis time labels at 0/25/50/75/100% |
| Heatmap | cells collapsed to 0-width in Tooltip wrappers; no time axis | fixed 14px cells; sparse mono time labels below |
| LogHistogram | bare bars, no card/header/axis | bg-elev card + mono totals header (`n events · error x · warn y`) + time axis; 6px bars; level mapping kept (TRACE stays nodata — data-driven extension of the 4-level Figma mock) |
| UptimeCard | header showed uptime %; sparkline not in spec | header = name + dot-only StatusPill (derived); mono footer `{pct}% uptime · 90 days` + `p95 n ms` (new `p95Ms` prop, `sparkline` removed); 3×24 bars |
| QueryValue | bare (no card), value colored by threshold, brand sparkline, lucide delta icons | bg-elev card + 8% threshold tint wash; value stays neutral mono 28; mono ▲/▼ delta colored by tint; sparkline bound series/1 |
| SLOCard | value mono, colored only when exhausted; track bg-bg; split footer | value Inter semibold 20 colored ok/warn/crit per state; track = border token; single meta line `error budget n% left · burn r×`; p-16 |
| AlertRuleCard | dot-only pill + uppercase signal chip; bg-chip query | signal icon (bar-chart/log/trace/zap/globe) + full StatusPill; plain mono query; mono `warn > 800 · crit > 1500 · for 5m` line |
| SpanRow | ui-font span name; dot swatch; error = outline on series bar | mono span name; 3×14 series tick; error = 8% crit row tint + x-circle + **crit** bar; selected = brand outline (was bg swap) |
| ServiceMapNode | error ring drawn as second hexagon; svg attr sizing (24px collapse); ui-font metrics | Figma geometry: circular border ring + error arc (ok sliver / crit), hexagon stroked in service series color (`colorIndex` prop), selected = brand stroke + 45% brand glow; mono req/s + err% |
| StatusPageHeader | partial_outage mapped to warn | outages (partial + major) = crit + x-circle; major carries the stronger border |

## Intentional adaptations (logged, not bugs)

- SpanRow keeps **service-indexed** series colors (Figma note says “series/1..4 by depth”, but the anatomy is “service color bar”; the mock’s depths coincide with services)
- SLOCard keeps lucide `Flame` — the Figma zap is documented as a stand-in (“Lucide flame not in the 16-icon set”)
- TimeseriesPanel crosshair values render under the plot rather than a floating box (web hover UX; MI-2 sync unchanged)
- EmptyState pillar names (`rum`/`uptime` superset vs Figma `monitors`) unchanged
- QueryValue delta for `threshold="none"` stays direction-colored (Figma’s only none-example is a latency tile where ▼ is green)
- TraceWaterfall axis ticks can crowd at very narrow gallery widths — real layouts give the waterfall Figma’s ≥620px

## Verification

- Gallery re-captured post-fix (dark + light, all 12 sections) and compared against the five Figma stage frames
- `lint` ✓ · `typecheck` ✓ · `vitest` 149/149 ✓ (5 tests updated to the Figma-correct assertions) · `next build` ✓ · Playwright e2e 3/3 ✓
- Legacy safety: all legacy styled-components buttons declare their own background/border; layered legacy styles still apply to legacy routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)