### PR TITLE
docs: W2 closeout — mark Home stage DONE (PR #146)

### DIFF
--- a/docs/web-implementation.md
+++ b/docs/web-implementation.md
@@ -93,8 +93,25 @@ design-phase QA loops, design.md §8).
 | --- | --- | --- |
 | **W0 Foundations** | `tokens.css` (§3) + Tailwind mapping · Inter/JetBrains Mono via `next/font` + the §2 type ramp in the Tailwind theme · MVC skeleton (`models/`, `controllers/`, `components/ui/`) · `AuthProvider` interface + `TestModeAuthProvider` · new `/signin` (single GoogleAuthButton screen; the ONLY auth route per the route standard) with the legacy login/signup pages quarantined per X-1 (§8) · mock server + seed dataset (§5–6) · Vitest + Playwright harnesses wired into CI build+test (UX-5) | tokens render both themes correctly vs the Style Guide page (dark default); TEST_MODE boots to a stubbed `/dashboard` against the mock server; `/signup` gone from routing (flows/auth.md); CI green |
 | **W1 Components** | `components/ui/*` per the design.md §8.1 build order (Stage 1 atoms → Stage 2 molecules → Stage 3 panels/chrome) and the §8.2/§8.2b contract rows — the bespoke-SVG chart set included · MI specs MI-1…MI-18 · unit tests per component. The §8.2b Marketing (Stage 5) rows land at the top of W2 instead — they have no consumer before it | every built component passes QA vs its Figma component set (variants, states, both themes, motion specs) |
-| **W2 Home** | Marketing kit (§8.2b Stage-5 rows) · Part A screens (§4): A1–A10 + iteration rows A11–A16 · demo cards on §8.3 synthetic data (U0-3) · live GitHub star fetch at runtime (A1 badge + A13 — no static count, per the as-built MarketingNav note) · dogfood instrumentation: `page_view` per the api.md §3.4 registry row, env-gated until the events layer (Phase 1) is live; CTA-click events are registered in the §3.4 master registry **before** W2 instruments them (registry-first discipline, api.md §3.4a) | QA vs the Stage-5 Figma page; Playwright covers the landing flow (§8.4) incl. the cross-page CTA handoff into the app |
+| **W2 Home — DONE (as built 2026-07-19, PR #146)** | Marketing kit (§8.2b Stage-5 rows) · Part A screens (§4): A1–A10 + iteration rows A11–A16 · demo cards on §8.3 synthetic data (U0-3) · live GitHub star fetch at runtime (A1 badge + A13 — no static count, per the as-built MarketingNav note) · dogfood instrumentation: `page_view` per the api.md §3.4 registry row, env-gated until the events layer (Phase 1) is live; CTA-click events are registered in the §3.4 master registry **before** W2 instruments them (registry-first discipline, api.md §3.4a) | QA vs the Stage-5 Figma page; Playwright covers the landing flow (§8.4) incl. the cross-page CTA handoff into the app |
 | **W3 Dashboards** | Part B routes (§4) under the `/dashboard` IA: NavRail (12 pillars) + TopBar chrome · first-run onboarding (create-org → send-your-first-data, MI-16) · B1–B12 screens with their create flows (dashboard + widget picker, monitor type-picker → rule editor, RUM property, declare-incident modal) and drill-ins · public status page route · feature controllers per pillar · legacy dashboard quarantine on close (§8) | QA vs the Stage-4 Figma frames + §8.4 prototype flows; Playwright covers the §8.4 "Login" journey (§7); remaining legacy component trees + mock `/api/dashboard/*` quarantined (the legacy `/dashboard/*` routes moved to `src/legacy` at W1, §8) |
+
+**W2 as-built (2026-07-19, PR #146).** Radix convergence complete — Modal/Sheet,
+Tooltip, Select type-ahead, Switch, Checkbox, NotificationPopover, and the
+IncidentComposer autocomplete now ride `@radix-ui` primitives (the headless-
+primitive allowance, §1); rendered chrome is the W1 Figma-QA'd markup
+unchanged and zero visual regression was verified (before/after gallery
+screenshots). Landing A1–A16 built from the registry, with six fidelity
+fixes found in the closing QA loop against the Stage-5 Figma frame: the
+MarketingNav bolt brand mark, TimeseriesPanel's two-line stacked header, the
+status-embed banner timestamp + inline component rows, the timeline-variant
+IncidentHistoryEntry, the use-case quad panels' query chips, and a 375w
+pre-overflow fix with a strengthened e2e overflow guard (checks `html` and
+`body`, not `body` alone). The analytics tracker stays hermetic in
+TEST_MODE — no events fire under Playwright/CI (api.md §3.4). The public
+status page embed is composed from the StatusPageHeader +
+StatusPageComponentRow set (§6), not a bespoke embed. Section components are
+canon at `web/src/components/home/`.
 
 Screen-state parity **[Directive 2026-07-18, carried from design.md §8.1]**:
 every data-driven screen ships default, empty, and loading states — the


### PR DESCRIPTION
## Summary
- Marks the W2 Home stage DONE in `docs/web-implementation.md` §2, as built 2026-07-19 (PR #146)
- Records as-built notes: Radix convergence complete (Modal/Sheet, Tooltip, Select type-ahead, Switch, Checkbox, NotificationPopover, IncidentComposer autocomplete → `@radix-ui` primitives; zero visual regression verified); landing A1–A16 built from the registry with six fidelity fixes (nav bolt brand mark, TimeseriesPanel two-line header, status-embed banner timestamp + inline rows, timeline-variant IncidentHistoryEntry, quad query chips, 375w pre-overflow fix with strengthened e2e guard); analytics tracker hermetic in TEST_MODE per api.md §3.4; status page embed composed from StatusPage components; section components canon at `web/src/components/home/`

## Test plan
- [ ] Docs-only change — no build/test impact; reviewer confirms the as-built notes match the shipped PR #146 diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)