### PR TITLE
docs(design): pin marketing container canon — 1152px @ 1440, rails 144/1296

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -74,6 +74,16 @@ verified in both themes) — the one extra constraint the teal brand imposes.
   class behavior), 8px gutters.
 - Radii 4px (denser than siblings); hairlines everywhere; elevation only for
   drawers/palettes.
+- Marketing container **[Decided 2026-07-19]**: all landing/marketing sections
+  share **one centered content container — 1152px at the 1440 design width**
+  (rails x 144 / x 1296), min 24px side gutters at narrower viewports. Section
+  band backgrounds (final CTA, footer) run full-bleed; their content stays on
+  the rails. Two-column sections hang right-hand blocks on a secondary column
+  line at x 816 (= right rail − 480). **As built (2026-07-19):** Figma Home
+  135:2 (landing v2) retro-aligned to these rails from a drifted 1100px/x 170
+  container (worst offenders: pillar grid ending at x 1220, how-it-works col 3
+  overflowing to x 1375.6, footer band at x −8); `MarketingNav` main component
+  widened 1100 → 1152 to span the container.
 
 
 ### Shared foundations (ecosystem parity — identical across the three products)


### PR DESCRIPTION
## What

Pins the marketing container canon in `docs/design.md` §2 Layout, decided 2026-07-19:

- **One centered content container for all landing/marketing sections: 1152px at the 1440 design width** (rails x 144 / x 1296), min 24px side gutters at narrower viewports
- Band backgrounds (final CTA, footer) full-bleed; content stays on the rails
- Secondary column line at x 816 (= right rail − 480) for right-hand blocks in two-column sections

## Why

§2 Layout previously specced only the product-app layout — the landing had no pinned container, and the Figma Home frame (135:2, landing v2) drifted per section (old 1100px/x 170 container, pillar grid ending at x 1220, how-it-works col 3 overflowing to x 1375.6, footer band at x −8). The built site mirrors whatever the frame does, so the canon needed pinning.

## As built

The Figma frame has been retro-aligned to these rails (all 15 sections audited to zero deviations; `MarketingNav` main component widened 1100 → 1152). This PR records the decision + as-built note in the doc.

Do not merge without the W3 owner's review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
