### PR TITLE
docs(design): correct marketing-container as-built note (follow-up to #149)

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -82,8 +82,11 @@ verified in both themes) — the one extra constraint the teal brand imposes.
   line at x 816 (= right rail − 480). **As built (2026-07-19):** Figma Home
   135:2 (landing v2) retro-aligned to these rails from a drifted 1100px/x 170
   container (worst offenders: pillar grid ending at x 1220, how-it-works col 3
-  overflowing to x 1375.6, footer band at x −8); `MarketingNav` main component
-  widened 1100 → 1152 to span the container.
+  overflowing to x 1375.6, footer band at x −8). The `MarketingNav` *instance*
+  on the frame widened 1100 → 1152 (auto-layout main component untouched);
+  interior grids on the container: pillar grid 4×270px cols, how-it-works
+  3×368px cols — both 24px gutters. All 15 sections re-audited to zero
+  deviation.
 
 
 ### Shared foundations (ecosystem parity — identical across the three products)


### PR DESCRIPTION
## What

Corrects the as-built note added by #149 in `docs/design.md` §2 Layout (marketing container canon):

- The `MarketingNav` **main component** was never widened — the **instance** on Figma Home 135:2 was resized 1100 → 1152 (the auto-layout main component is untouched)
- Records the interior grid geometry as built: pillar grid 4×270px cols, how-it-works 3×368px cols — both 24px gutters
- Records the zero-deviation re-audit of all 15 sections

## Why

#149's as-built paragraph was written before the Figma retro-alignment landed and described the nav change aspirationally. The retro-alignment is now complete (audited to zero deviations against rails x 144 / x 1296); this pins the doc to what actually happened so docs and file don't diverge silently.

Do not merge without the W3 owner's review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
