### PR TITLE
docs(design): NavRail goes expandable — §2 layout spec + §8.2b matrix row

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -65,9 +65,15 @@ verified in both themes) — the one extra constraint the teal brand imposes.
 
 ### Layout
 
-- Left product nav (Datadog pattern): icon rail 56px with flyout labels;
-  sections = pillars (§pages.md B). Top bar: org/env switcher · **global time
-  picker** · search (`/`) · incidents bell.
+- Left product nav (Datadog pattern) **[Directive 2026-07-19]**: expandable
+  rail — collapsed 56px icon rail (flyout labels on hover) ⇄ expanded 240px
+  with icon+label rows grouped by pillar section (Telemetry / Respond /
+  Platform); sections = pillars (§pages.md B). Chevron toggle at the rail foot
+  switches state; the choice persists per user across sessions
+  (`nav.rail.expanded` in localStorage). Default: expanded on desktop ≥1280px,
+  collapsed below. Active item = brand accent bar + brand icon in both states.
+  Top bar: org/env switcher · **global time picker** · search (`/`) ·
+  incidents bell.
 - Views: filter bar (query pills) → visualization canvas → detail drawer
   (right, 480px) for point/line/span inspection.
 - Grid dashboards: 12-col draggable/resizable widgets (react-grid-layout
@@ -331,7 +337,7 @@ project license, the copy reads **MIT**.
 | Component | Variants × states |
 | --- | --- |
 | **App chrome** | |
-| NavRail / NavRailItem | pillar icon ×12 · item: default / hover (flyout label) / active (brand accent) · rail chrome 56px: flyout-open / collapsed — **as built (2026-07-17):** NavRailItem is the variant set; NavRail ships as a single chrome component with rail states documented in its description |
+| NavRail / NavRailItem | pillar icon ×12 · item: default / hover (flyout label) / active (brand accent) · rail chrome 56px: flyout-open / collapsed — **as built (2026-07-17):** NavRailItem is the variant set; NavRail ships as a single chrome component with rail states documented in its description — **[Directive 2026-07-19]:** rail is expandable; NavRail is now a variant set `state=collapsed` (56px) / `state=expanded` (240px icon+label rows, pillar section groups, foot chevron toggle, `upstat` wordmark); NavRailItem gains a `layout=rail/expanded` axis (expanded row 228px: default / hover raised bg / active accent bar); toggle persists per user, default expanded ≥1280px; exemplar `B1 — Home (rail expanded)` |
 | TopBar | org/env switcher closed/open · global TimePicker slot · search (`/`) field · bell: idle / unread-badge / flash (MI-14) — **as built (2026-07-17):** single chrome component, switcher/bell states documented in its description; bell badge states are CountBadge instances |
 | Modal / Sheet | modal sm/lg · right sheet · header + body slot + footer actions · z `sheet/modal 40` (§2 layers) |
 | CommandPalette / SearchOverlay | empty / results / no-results · result row: icon + label + kbd hint (`/` search, MI-17) |


### PR DESCRIPTION
## What

Docs-only follow-through for the **2026-07-19 directive**: the dashboard sidebar becomes **expandable** (was: fixed 56px icon rail + flyout labels).

- **§2 Foundations → Layout** — left product nav rewritten to the expandable-rail spec: collapsed 56px icon rail (flyout labels on hover) ⇄ expanded 240px with icon+label rows grouped by pillar section (Telemetry / Respond / Platform); chevron toggle at the rail foot; per-user persistence (`nav.rail.expanded` in localStorage); default **expanded on desktop ≥1280px**, collapsed below; active item = brand accent bar + brand icon in both states.
- **§8.2b completion-pass matrix, NavRail/NavRailItem row** — appended the as-directed delta: NavRail is now a variant set `state=collapsed/expanded`; NavRailItem gains a `layout=rail/expanded` axis; exemplar frame `B1 — Home (rail expanded)`.

## Figma (already built, file `F2b1icjCmZp1MvOft6HMCV`)

- `NavRail` variant set `285:2` — `state=collapsed` (`86:1332`, untouched original) / `state=expanded` (`284:2`, 240px, section groups, foot chevron, wordmark), description documents toggle + persistence + ≥1280 default.
- `NavRailItem` set `86:1255` — new `layout=expanded` variants (default `283:2` / hover `283:12376` / active `283:12380`), all colors bound to `upstat/tokens`.
- Exemplar `B1 — Home (rail expanded)` `286:2` (duplicate; original `125:13` untouched) + light-mode QA instance `285:12401`.

Do not merge without design sign-off on the Figma masters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)