### PR TITLE
fix(web): system QA — final usability/accuracy/interaction pass

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -109,6 +109,8 @@ verified in both themes) — the one extra constraint the teal brand imposes.
 | Radii (product) | 4px |
 | Product note | data views may compress to the 4px sub-grid (2px hairline gaps in dense tables) |
 
+- **Cursor affordance**: enabled interactive controls show `cursor: pointer` — one base-layer rule on `button:not(:disabled)`, `[role="button"]:not([aria-disabled="true"])`, `select:not(:disabled)`, `summary`, `label[for]`; links use the native pointer; disabled controls keep the default cursor. [Directive 2026-07-19]
+
 These rows are standardized in the org SKILL.md — a change here is an
 ecosystem change, PR'd to all three design.md files together.
 

--- a/docs/pages.md
+++ b/docs/pages.md
@@ -9,7 +9,7 @@
 
 ## Part A — Public home page (upstat.cuesoft.io)
 
-Shared CueLABS open-source-site pattern (Discord, GitHub, preview, **Try
+Shared CueLABS™ open-source-site pattern (Discord, GitHub, preview, **Try
 Cloud** / **Self Host**) in a Datadog-style product-led execution. The
 existing Figma landing (single desktop frame; pillars "Dev-first workflows",
 "Works for your Business needs", "Open-source, Transparent and
@@ -24,7 +24,7 @@ community-driven") remains the visual base, extended for the new pillars.
 | A5 | How ingestion works | OTLP/agent diagram: your services → OTel SDK/collector → Upstat | copyable snippet tabs (Go/Python/Node/k8s) |
 | A6 | Reliability showcase | Upstat's own public status page embedded (self-referential trust, PRD §5) | |
 | A7 | Open source | compose snippet, architecture diagram, GitHub/CONTRIBUTING | |
-| A8 | Community | Discord card, roadmap, CueLABS | |
+| A8 | Community | Discord card, roadmap, CueLABS™ | |
 | A9 | Cloud vs Self-host table | per-column CTAs | |
 | A10 | Footer | standard + privacy (UPS-005) | |
 

--- a/docs/web-implementation.md
+++ b/docs/web-implementation.md
@@ -1,6 +1,6 @@
 # Upstat — Web Implementation Standard
 
-> How `web/` gets rebuilt: the **CueLABS Web Implementation Standard**
+> How `web/` gets rebuilt: the **CueLABS™ Web Implementation Standard**
 > (ratified 2026-07-18, org-wide **[Directive]**) carried in full, plus the
 > Upstat-specific addendum — stage plan, token mapping, route map, TEST_MODE
 > contract, mock server, test strategy, legacy quarantine plan. Markers as in
@@ -231,7 +231,7 @@ values, latencies, counts — per the §2 `tnum` rule.
 
 The new IA mounts at **`/dashboard`** **[Directive 2026-07-18, route
 standard]** — `/` home · `/signin` the only auth route · all app surfaces
-under `/dashboard/<area>`, canonical across the CueLABS products. The
+under `/dashboard/<area>`, canonical across the CueLABS™ products. The
 legacy dashboard tree quarantined to `src/legacy/app/dashboard` at W1 to
 free the path (§8). Rail order per pages.md Part B.
 

--- a/docs/web-implementation.md
+++ b/docs/web-implementation.md
@@ -140,6 +140,58 @@ TEST_MODE. `Select` moved to the ARIA 1.2 combobox pattern and
 serialized against the shared mock store, reset to a clean seed via
 `/v1/reset` at the start of the run for hermetic e2e.
 
+**System-QA as-built (2026-07-19).** Full-system pass over the TEST_MODE
+prod build (all journeys + MI spot-checks at 1440/390). Fixes landed:
+the app frame is now viewport-bounded (`h-dvh`, was `min-h-screen`) so
+`<main>` is the real scroll container — this is what makes MI-4's
+scroll-up pause + buffered-count reachable (the logs list previously grew
+the body and never overflowed); the home page's demo data seeds from a
+pinned epoch on first render and rebuilds with the real clock post-mount
+(static prerender + hydration text-mismatch, React #418); mock
+`parseQuery` rejects malformed pipes so MI-13's syntax-error state is
+reachable; QueryBar autocomplete filters to the typed token before Tab
+completion (MI-13); the `?` cheatsheet closes on ESC (MI-17); the status
+page publishes the check's own latency figure (`p95_ms` on the status
+component read model — it hardcoded 96 ms and disagreed with
+`/dashboard/uptime`); RUM buckets at 5m for short ranges (the 1h default
+rendered as a single bar + one-column vitals heatmap); the seeded
+dashboard wires `$service`/`$env` into widget queries and carries a
+second timeseries widget so the template-var bar governs something real
+and MI-2 cross-widget crosshair sync is observable; TimeseriesPanel
+legends label grouped series by their distinguishing tag suffix (full
+name on the title tooltip).
+
+**Expandable NavRail as-built (2026-07-19, [Directive] design.md §2).**
+Collapsed 56px icon rail (hover flyouts) ⇄ expanded 240px icon+label rows
+under the Telemetry/Respond/Platform section groups (B-order preserved;
+Home ungrouped at top). Foot chevron toggles (`aria-expanded`, focusable);
+the choice persists as `nav.rail.expanded` in localStorage; default is
+expanded ≥1280px, collapsed below, resolved after mount so SSR stays
+deterministic (server renders collapsed). NavRailItem gains an `expanded`
+prop (default false — existing call sites untouched); active items carry
+the brand accent bar + brand icon in both states. Content reflows via
+flex (`<main>` is `flex-1`); every pillar screen verified at both rail
+widths, `e2e/navrail.spec.ts` covers toggle + persistence + viewport
+defaults.
+
+**Nav/footer parity + theme toggle as-built (2026-07-19, SKILL.md
+"Marketing nav, footer & theme parity canon").** MarketingNav converged to
+the canonical shape — Features(/#pillars) · Dashboards(/dashboard) ·
+Docs(GitBook root) · GitHub(repo) + ThemeToggle + Sign in CTA; the pillar
+dropdown and standalone star badge retired (the runtime star count now
+rides the GitHub link, still never static). MarketingFooter owns the
+canonical column set (Product / Docs / Community / Legal, ratified URLs)
+plus the legal bar: verbatim "© Cuesoft Inc. 2026. Upstat. CueLABS™
+Division. MIT License." with linked marks, an English-only language
+selector (real control, no i18n yet — ratified) and the SECURITY.md
+affordance. Theme: apparule's ThemeProvider contract ported to
+`web/src/design/ThemeProvider.tsx` — `data-theme` on `<html>`,
+localStorage key `upstat.theme`, default = the design default (dark,
+attribute-less) when unset, pre-paint init script in the root layout;
+ThemeToggle lives in the marketing nav, the dashboard TopBar utility area
+and Settings ("Appearance"). Playwright asserts the canonical hrefs and
+the toggle flip/persist on home and dashboard.
+
 Screen-state parity **[Directive 2026-07-18, carried from design.md §8.1]**:
 every data-driven screen ships default, empty, and loading states — the
 three-frame rule applies to the implementation exactly as it does to the

--- a/web/e2e/dashboard.spec.ts
+++ b/web/e2e/dashboard.spec.ts
@@ -155,6 +155,31 @@ test("full journey: onboarding → B1 → dashboards → explorer → logs → t
       timeout: 10_000,
     })
     .toBeGreaterThan(tailCount);
+  // MI-4: scrolling up pauses the tail (PAUSED pill + buffered count). The
+  // list is a real overflow container (h-dvh app frame — QA 2026-07-19);
+  // a body-scrolled page could never trigger the pause.
+  // The tail starts from a small live window and grows a few lines per
+  // poll — wait until it actually overflows its container.
+  await expect
+    .poll(
+      () =>
+        page
+          .getByTestId("log-list")
+          .evaluate((el) => el.scrollHeight - el.clientHeight),
+      { timeout: 60_000 },
+    )
+    .toBeGreaterThan(200);
+  await page.getByTestId("log-list").evaluate((el) => {
+    el.scrollTop = 0; // unambiguously away from the bottom
+    el.dispatchEvent(new Event("scroll"));
+  });
+  await expect(page.getByTestId("paused-pill")).toBeVisible({ timeout: 5_000 });
+  // buffered chip appears as batches queue (dev polls every ~2s; allow a
+  // few slow cycles), click-to-resume catches up
+  const buffered = page.getByRole("button", { name: /\d+ new/ });
+  await expect(buffered).toBeVisible({ timeout: 30_000 });
+  await buffered.click();
+  await expect(page.getByTestId("paused-pill")).toBeHidden({ timeout: 5_000 });
   await liveToggle.click(); // off again
 
   /* ---- B5 traces: explorer → waterfall → span drawer → map (MI-7) ---- */

--- a/web/e2e/home.spec.ts
+++ b/web/e2e/home.spec.ts
@@ -246,3 +246,44 @@ test("home is responsive at 375w (mobile)", async ({ page }) => {
   // the table-footer copy of the CTA is display:none at 375
   await expect(page.locator("tfoot").getByRole("button", { name: "Deploy with compose" })).toBeHidden();
 });
+
+test("mobile nav is a menu-button disclosure at 390w (SKILL.md mobile clause)", async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto("/");
+
+  const nav = page.getByRole("navigation", { name: "Marketing" });
+  const menuButton = nav.getByRole("button", { name: "Menu" });
+  const panel = nav.locator("#marketing-menu");
+
+  // closed by default; the trigger advertises its state
+  await expect(menuButton).toBeVisible();
+  await expect(menuButton).toHaveAttribute("aria-expanded", "false");
+  await expect(panel).toBeHidden();
+
+  // open — retry until React's handler is attached (dev hydrates slowly)
+  await expect(async () => {
+    await menuButton.click();
+    await expect(panel).toBeVisible({ timeout: 1_000 });
+  }).toPass({ timeout: 15_000 });
+  await expect(menuButton).toHaveAttribute("aria-expanded", "true");
+
+  // every canonical link is reachable from the panel — no dead ends <md
+  for (const [label, href] of [
+    ["Features", "/#pillars"],
+    ["Dashboards", "/dashboard"],
+    ["Docs", "https://cuesoft.gitbook.io/upstat"],
+    ["GitHub", "https://github.com/cuesoftinc/upstat"],
+  ] as const) {
+    const link = panel.getByRole("link", { name: label });
+    await expect(link).toBeVisible();
+    await expect(link).toHaveAttribute("href", href);
+  }
+
+  // the theme toggle works from inside the panel
+  await panel.getByTestId("theme-toggle").click();
+  await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
+
+  // and the Sign in CTA hands off into the app
+  await panel.getByRole("button", { name: "Sign in" }).click();
+  await page.waitForURL("**/signin");
+});

--- a/web/e2e/home.spec.ts
+++ b/web/e2e/home.spec.ts
@@ -59,7 +59,7 @@ test("home renders every Part A section", async ({ page }) => {
   await expect(
     page.getByText("Go gRPC services · Next.js + React/TS · ClickHouse · OpenTelemetry"),
   ).toBeVisible();
-  await expect(page.getByText("CueLABS Discord — #upstat-lab")).toBeVisible();
+  await expect(page.getByText("CueLABS™ Discord — #upstat-lab")).toBeVisible();
 
   // A15 FAQ · A16 CTA band · A10 footer
   await expect(page.getByText("Questions, answered.")).toBeVisible();
@@ -119,7 +119,7 @@ test("nav + footer carry the canonical parity links (SKILL.md canon)", async ({ 
         ["GitHub", "https://github.com/cuesoftinc/upstat"],
         ["Discord", "https://discord.gg/CDfZxxrxbb"],
         ["Roadmap", "https://cuesoft.gitbook.io/upstat/product/roadmap"],
-        ["CueLABS", "https://cuelabs.cuesoft.io"],
+        ["CueLABS™", "https://cuelabs.cuesoft.io"],
       ],
     ],
     [

--- a/web/e2e/home.spec.ts
+++ b/web/e2e/home.spec.ts
@@ -8,6 +8,12 @@ import { expect, test } from "@playwright/test";
  */
 
 test("home renders every Part A section", async ({ page }) => {
+  // React #418 regression (QA 2026-07-19): the statically prerendered page
+  // must hydrate without page errors — demo data is clock-independent on
+  // the first render.
+  const pageErrors: string[] = [];
+  page.on("pageerror", (err) => pageErrors.push(err.message));
+
   await page.goto("/");
 
   // A2 hero — H1 + demo panels
@@ -58,10 +64,111 @@ test("home renders every Part A section", async ({ page }) => {
   // A15 FAQ · A16 CTA band · A10 footer
   await expect(page.getByText("Questions, answered.")).toBeVisible();
   await expect(page.getByText("OTLP in. Answers out.")).toBeVisible();
-  await expect(page.getByText("© 2026 Cuesoft · upstat is CueLABS open source")).toBeVisible();
+  await expect(page.getByRole("contentinfo").getByText(/CueLABS™ Division/)).toBeVisible();
 
-  // TEST_MODE: the GitHub badge stays neutral — no invented star count
-  await expect(page.getByRole("link", { name: /^Star$/ })).toBeVisible();
+  // TEST_MODE: the nav GitHub link stays neutral — no invented star count
+  await expect(
+    page.getByRole("navigation", { name: "Marketing" }).getByRole("link", { name: /^GitHub$/ }),
+  ).toBeVisible();
+
+  expect(pageErrors).toEqual([]);
+});
+
+test("nav + footer carry the canonical parity links (SKILL.md canon)", async ({ page }) => {
+  await page.goto("/");
+
+  const nav = page.getByRole("navigation", { name: "Marketing" });
+  for (const [label, href] of [
+    ["Features", "/#pillars"],
+    ["Dashboards", "/dashboard"],
+    ["Docs", "https://cuesoft.gitbook.io/upstat"],
+    ["GitHub", "https://github.com/cuesoftinc/upstat"],
+  ] as const) {
+    await expect(nav.getByRole("link", { name: label })).toHaveAttribute("href", href);
+  }
+  await expect(nav.getByTestId("theme-toggle")).toBeVisible();
+  await expect(nav.getByRole("button", { name: "Sign in" })).toBeVisible();
+
+  const footer = page.getByRole("contentinfo"); // panel legends are scoped <footer>s — the landmark is the page footer
+  const columns: [string, [string, string][]][] = [
+    [
+      "Product",
+      [
+        ["Features", "/#pillars"],
+        ["Try Cloud", "/signin"],
+        ["Self Host", "/#self-host"],
+        ["Dashboards", "/dashboard"],
+      ],
+    ],
+    [
+      "Docs",
+      [
+        ["Docs", "https://cuesoft.gitbook.io/upstat"],
+        ["Quickstart", "https://cuesoft.gitbook.io/upstat/setup"],
+        ["API reference", "https://cuesoft.gitbook.io/upstat/system/api-surface"],
+        ["Self-host guide", "https://cuesoft.gitbook.io/upstat/system/deployment"],
+      ],
+    ],
+    [
+      "Community",
+      [
+        ["GitHub", "https://github.com/cuesoftinc/upstat"],
+        ["Discord", "https://discord.gg/CDfZxxrxbb"],
+        ["Roadmap", "https://cuesoft.gitbook.io/upstat/product/roadmap"],
+        ["CueLABS", "https://cuelabs.cuesoft.io"],
+      ],
+    ],
+    [
+      "Legal",
+      [
+        ["Privacy", "https://privacy.cuesoft.io"],
+        ["Terms", "https://terms.cuesoft.io"],
+        ["Status", "https://status.cuesoft.io"],
+      ],
+    ],
+  ];
+  for (const [heading, links] of columns) {
+    const column = footer.getByRole("navigation", { name: heading });
+    for (const [label, href] of links) {
+      await expect(column.getByRole("link", { name: label })).toHaveAttribute("href", href);
+    }
+  }
+  // legal bar: verbatim line + linked marks + language + security
+  await expect(footer.getByText(/CueLABS™ Division/)).toHaveText(
+    "© Cuesoft Inc. 2026. Upstat. CueLABS™ Division. MIT License.",
+  );
+  await expect(footer.getByRole("link", { name: "Cuesoft Inc." })).toHaveAttribute(
+    "href",
+    "https://cuesoft.io",
+  );
+  await expect(footer.getByRole("link", { name: "MIT License" })).toHaveAttribute(
+    "href",
+    "https://github.com/cuesoftinc/upstat/blob/main/LICENSE",
+  );
+  await expect(footer.getByRole("combobox", { name: "Language" })).toHaveValue("en");
+  await expect(footer.getByRole("link", { name: "Security" })).toHaveAttribute(
+    "href",
+    "https://github.com/cuesoftinc/upstat/blob/main/SECURITY.md",
+  );
+});
+
+test("theme toggle flips data-theme and persists (upstat.theme)", async ({ page }) => {
+  await page.goto("/");
+  const html = page.locator("html");
+  await expect(html).not.toHaveAttribute("data-theme", "light"); // dark default
+  await page.getByTestId("theme-toggle").click();
+  await expect(html).toHaveAttribute("data-theme", "light");
+  expect(await page.evaluate(() => window.localStorage.getItem("upstat.theme"))).toBe("light");
+  // persists across reload — applied pre-paint by the init script
+  await page.reload();
+  await expect(html).toHaveAttribute("data-theme", "light");
+  // back to dark: attribute clears (the default carries none). The attr
+  // assertion above is satisfied pre-hydration (init script), so retry the
+  // click until React's handler is attached (dev hydrates slowly).
+  await expect(async () => {
+    await page.getByTestId("theme-toggle").click();
+    await expect(html).not.toHaveAttribute("data-theme", "light", { timeout: 1_000 });
+  }).toPass({ timeout: 15_000 });
 });
 
 test("FAQ is a single-open accordion (A15)", async ({ page }) => {
@@ -89,19 +196,15 @@ test("FAQ is a single-open accordion (A15)", async ({ page }) => {
 
 test("CTAs hand off into the app: Try Cloud → /signin (§8.4 cross-page)", async ({ page }) => {
   await page.goto("/");
-  // hero CTA
-  await page.getByRole("button", { name: "Try Cloud" }).nth(1).click();
+  // hero CTA (the nav's Try Cloud moved out with the parity canon — the
+  // nav now carries the Sign in CTA)
+  await page.getByRole("button", { name: "Try Cloud" }).first().click();
   await page.waitForURL("**/signin");
   await expect(page.getByTestId("signin-screen")).toBeVisible();
 
-  // nav CTA
+  // nav Sign in CTA
   await page.goto("/");
-  await page.getByRole("button", { name: "Try Cloud" }).first().click();
-  await page.waitForURL("**/signin");
-
-  // nav Sign in
-  await page.goto("/");
-  await page.getByRole("button", { name: "Sign in" }).click();
+  await page.getByRole("navigation", { name: "Marketing" }).getByRole("button", { name: "Sign in" }).click();
   await page.waitForURL("**/signin");
 
   // final CTA band
@@ -132,4 +235,14 @@ test("home is responsive at 375w (mobile)", async ({ page }) => {
   // pillar grid stacks and stays reachable
   await page.locator("#pillars").scrollIntoViewIfNeeded();
   await expect(page.locator("#pillars [data-pillar]")).toHaveCount(8);
+
+  // A9 at mobile (live-QA finding 2026-07-19): the plan table's column CTAs
+  // hide <sm; the grouped CTA pair renders above the compose snippet, and
+  // the snippet wraps before its comment — never mid-comment.
+  const cloudSection = page.getByText("Cloud when you want it. Yours when you need it.");
+  await cloudSection.scrollIntoViewIfNeeded();
+  const groupedCtas = page.getByLabel("Cloud or self-host");
+  await expect(groupedCtas.getByRole("button", { name: "Deploy with compose" })).toBeVisible();
+  // the table-footer copy of the CTA is display:none at 375
+  await expect(page.locator("tfoot").getByRole("button", { name: "Deploy with compose" })).toBeHidden();
 });

--- a/web/e2e/home.spec.ts
+++ b/web/e2e/home.spec.ts
@@ -59,17 +59,19 @@ test("home renders every Part A section", async ({ page }) => {
   await expect(
     page.getByText("Go gRPC services · Next.js + React/TS · ClickHouse · OpenTelemetry"),
   ).toBeVisible();
-  await expect(page.getByText("CueLABS Discord — #upstat")).toBeVisible();
+  await expect(page.getByText("CueLABS Discord — #upstat-lab")).toBeVisible();
 
   // A15 FAQ · A16 CTA band · A10 footer
   await expect(page.getByText("Questions, answered.")).toBeVisible();
   await expect(page.getByText("OTLP in. Answers out.")).toBeVisible();
   await expect(page.getByRole("contentinfo").getByText(/CueLABS™ Division/)).toBeVisible();
 
-  // TEST_MODE: the nav GitHub link stays neutral — no invented star count
-  await expect(
-    page.getByRole("navigation", { name: "Marketing" }).getByRole("link", { name: /^GitHub$/ }),
-  ).toBeVisible();
+  // TEST_MODE: the nav star badge stays neutral — no invented star count
+  const starBadge = page
+    .getByRole("navigation", { name: "Marketing" })
+    .getByRole("link", { name: "Star cuesoftinc/upstat on GitHub" });
+  await expect(starBadge).toBeVisible();
+  await expect(starBadge).toHaveText(/^Star$/);
 
   expect(pageErrors).toEqual([]);
 });
@@ -82,12 +84,14 @@ test("nav + footer carry the canonical parity links (SKILL.md canon)", async ({ 
     ["Features", "/#pillars"],
     ["Dashboards", "/dashboard"],
     ["Docs", "https://cuesoft.gitbook.io/upstat"],
-    ["GitHub", "https://github.com/cuesoftinc/upstat"],
+    // the GitHub item renders as the star badge (canon revision 2026-07-19)
+    ["Star cuesoftinc/upstat on GitHub", "https://github.com/cuesoftinc/upstat"],
   ] as const) {
     await expect(nav.getByRole("link", { name: label })).toHaveAttribute("href", href);
   }
   await expect(nav.getByTestId("theme-toggle")).toBeVisible();
-  await expect(nav.getByRole("button", { name: "Sign in" })).toBeVisible();
+  await expect(nav.getByRole("link", { name: "Sign in" })).toHaveAttribute("href", "/signin");
+  await expect(nav.getByRole("button", { name: "Try Cloud" })).toBeVisible();
 
   const footer = page.getByRole("contentinfo"); // panel legends are scoped <footer>s — the landmark is the page footer
   const columns: [string, [string, string][]][] = [
@@ -134,12 +138,16 @@ test("nav + footer carry the canonical parity links (SKILL.md canon)", async ({ 
     }
   }
   // legal bar: verbatim line + linked marks + language + security
-  await expect(footer.getByText(/CueLABS™ Division/)).toHaveText(
+  await expect(footer.locator("p", { hasText: "CueLABS™ Division" })).toHaveText(
     "© Cuesoft Inc. 2026. Upstat. CueLABS™ Division. MIT License.",
   );
   await expect(footer.getByRole("link", { name: "Cuesoft Inc." })).toHaveAttribute(
     "href",
     "https://cuesoft.io",
+  );
+  await expect(footer.getByRole("link", { name: "CueLABS™ Division" })).toHaveAttribute(
+    "href",
+    "https://cuelabs.cuesoft.io",
   );
   await expect(footer.getByRole("link", { name: "MIT License" })).toHaveAttribute(
     "href",
@@ -196,15 +204,21 @@ test("FAQ is a single-open accordion (A15)", async ({ page }) => {
 
 test("CTAs hand off into the app: Try Cloud → /signin (§8.4 cross-page)", async ({ page }) => {
   await page.goto("/");
-  // hero CTA (the nav's Try Cloud moved out with the parity canon — the
-  // nav now carries the Sign in CTA)
-  await page.getByRole("button", { name: "Try Cloud" }).first().click();
+  const nav = page.getByRole("navigation", { name: "Marketing" });
+
+  // nav Try Cloud primary CTA (back per the canon revision 2026-07-19)
+  await nav.getByRole("button", { name: "Try Cloud" }).click();
   await page.waitForURL("**/signin");
   await expect(page.getByTestId("signin-screen")).toBeVisible();
 
-  // nav Sign in CTA
+  // nav Sign in text link
   await page.goto("/");
-  await page.getByRole("navigation", { name: "Marketing" }).getByRole("button", { name: "Sign in" }).click();
+  await nav.getByRole("link", { name: "Sign in" }).click();
+  await page.waitForURL("**/signin");
+
+  // hero CTA
+  await page.goto("/");
+  await page.getByRole("main").getByRole("button", { name: "Try Cloud" }).first().click();
   await page.waitForURL("**/signin");
 
   // final CTA band
@@ -247,6 +261,17 @@ test("home is responsive at 375w (mobile)", async ({ page }) => {
   await expect(page.locator("tfoot").getByRole("button", { name: "Deploy with compose" })).toBeHidden();
 });
 
+test("enabled controls carry the pointer cursor (Directive 2026-07-19)", async ({ page }) => {
+  await page.goto("/");
+  const nav = page.getByRole("navigation", { name: "Marketing" });
+  const cursorOf = (locator: ReturnType<typeof page.locator>) =>
+    locator.evaluate((el) => getComputedStyle(el).cursor);
+  // a rendered button — the base-layer rule, not a per-component class
+  expect(await cursorOf(nav.getByRole("button", { name: "Try Cloud" }))).toBe("pointer");
+  // a nav link — links keep the native pointer
+  expect(await cursorOf(nav.getByRole("link", { name: "Docs" }))).toBe("pointer");
+});
+
 test("mobile nav is a menu-button disclosure at 390w (SKILL.md mobile clause)", async ({ page }) => {
   await page.setViewportSize({ width: 390, height: 844 });
   await page.goto("/");
@@ -272,7 +297,8 @@ test("mobile nav is a menu-button disclosure at 390w (SKILL.md mobile clause)", 
     ["Features", "/#pillars"],
     ["Dashboards", "/dashboard"],
     ["Docs", "https://cuesoft.gitbook.io/upstat"],
-    ["GitHub", "https://github.com/cuesoftinc/upstat"],
+    // the GitHub item renders as the star badge (canon revision 2026-07-19)
+    ["Star cuesoftinc/upstat on GitHub", "https://github.com/cuesoftinc/upstat"],
   ] as const) {
     const link = panel.getByRole("link", { name: label });
     await expect(link).toBeVisible();
@@ -283,7 +309,8 @@ test("mobile nav is a menu-button disclosure at 390w (SKILL.md mobile clause)", 
   await panel.getByTestId("theme-toggle").click();
   await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
 
-  // and the Sign in CTA hands off into the app
-  await panel.getByRole("button", { name: "Sign in" }).click();
+  // Sign in text link is present; the Try Cloud CTA hands off into the app
+  await expect(panel.getByRole("link", { name: "Sign in" })).toHaveAttribute("href", "/signin");
+  await panel.getByRole("button", { name: "Try Cloud" }).click();
   await page.waitForURL("**/signin");
 });

--- a/web/e2e/home.spec.ts
+++ b/web/e2e/home.spec.ts
@@ -305,6 +305,12 @@ test("mobile nav is a menu-button disclosure at 390w (SKILL.md mobile clause)", 
     await expect(link).toHaveAttribute("href", href);
   }
 
+  // the panel GitHub item is the SAME star badge as desktop — glyph +
+  // "Star" (+ live count when one arrives; neutral in TEST_MODE)
+  const panelBadge = panel.getByRole("link", { name: "Star cuesoftinc/upstat on GitHub" });
+  await expect(panelBadge).toHaveText(/^Star$/);
+  await expect(panelBadge.locator("svg")).toBeVisible();
+
   // the theme toggle works from inside the panel
   await panel.getByTestId("theme-toggle").click();
   await expect(page.locator("html")).toHaveAttribute("data-theme", "light");

--- a/web/e2e/navrail.spec.ts
+++ b/web/e2e/navrail.spec.ts
@@ -1,0 +1,95 @@
+import { expect, test, type Page } from "@playwright/test";
+
+/**
+ * Expandable NavRail ([Directive 2026-07-19], design.md §2): collapsed 56px
+ * ⇄ expanded 240px, foot chevron toggle, `nav.rail.expanded` persistence,
+ * viewport default (expanded ≥1280px, collapsed below).
+ */
+
+async function signIn(page: Page) {
+  await page.goto("/signin");
+  await page.getByRole("button", { name: /continue with google/i }).click();
+  await page.waitForURL("**/dashboard**");
+  await expect(page.getByTestId("dashboard-home")).toBeVisible();
+}
+
+const rail = (page: Page) => page.getByRole("navigation", { name: "Product navigation" });
+
+test("defaults expanded at ≥1280px with labels and section groups", async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await signIn(page);
+  await expect(rail(page)).toHaveAttribute("data-expanded", "true");
+  // poll: the 200ms width transition may still be running at first read
+  await expect
+    .poll(async () => Math.round((await rail(page).boundingBox())!.width))
+    .toBe(240);
+  for (const group of ["Telemetry", "Respond", "Platform"]) {
+    await expect(rail(page).getByText(group)).toBeVisible();
+  }
+  await expect(rail(page).getByText("Dashboards")).toBeVisible();
+});
+
+test("defaults collapsed below 1280px", async ({ page }) => {
+  await page.setViewportSize({ width: 1024, height: 800 });
+  await signIn(page);
+  await expect(rail(page)).toHaveAttribute("data-expanded", "false");
+  await expect
+    .poll(async () => Math.round((await rail(page).boundingBox())!.width))
+    .toBe(56);
+  await expect(rail(page).getByText("Telemetry")).toBeHidden();
+});
+
+test("foot chevron toggles and the choice persists across reloads", async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await signIn(page);
+  const toggle = page.getByTestId("rail-toggle");
+  await expect(toggle).toHaveAttribute("aria-expanded", "true");
+
+  await toggle.click();
+  await expect(rail(page)).toHaveAttribute("data-expanded", "false");
+  expect(await page.evaluate(() => window.localStorage.getItem("nav.rail.expanded"))).toBe("0");
+
+  // persisted collapsed state wins over the ≥1280 expanded default
+  await page.reload();
+  await expect(rail(page)).toHaveAttribute("data-expanded", "false");
+
+  // let the width transition settle, then retry the click until React's
+  // handler is live (the reload assertion is satisfied pre-hydration)
+  await expect(async () => {
+    await toggle.click();
+    await expect(rail(page)).toHaveAttribute("data-expanded", "true", { timeout: 1_000 });
+  }).toPass({ timeout: 15_000 });
+  await page.reload();
+  await expect(rail(page)).toHaveAttribute("data-expanded", "true");
+});
+
+test("dashboard chrome theme toggle flips + persists (theme-parity canon)", async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await signIn(page);
+  const html = page.locator("html");
+  await expect(html).not.toHaveAttribute("data-theme", "light");
+  await page.getByRole("banner").getByTestId("theme-toggle").click();
+  await expect(html).toHaveAttribute("data-theme", "light");
+  expect(await page.evaluate(() => window.localStorage.getItem("upstat.theme"))).toBe("light");
+  await page.reload();
+  await expect(html).toHaveAttribute("data-theme", "light");
+  // settings carries the same control as a labelled select
+  await page.goto("/dashboard/settings");
+  await expect(page.getByRole("combobox", { name: "Theme" })).toBeVisible();
+  // restore dark for the rest of the suite
+  await page.getByRole("banner").getByTestId("theme-toggle").click();
+  await expect(html).not.toHaveAttribute("data-theme", "light");
+});
+
+test("navigation works at both rail widths (charts unaffected)", async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await signIn(page);
+  // expanded: click by visible label row
+  await rail(page).getByRole("button", { name: "Dashboards", exact: true }).click();
+  await page.waitForURL("**/dashboard/dashboards");
+  // collapse and navigate by icon (aria-label)
+  await page.getByTestId("rail-toggle").click();
+  await rail(page).getByRole("button", { name: "Metrics", exact: true }).click();
+  await page.waitForURL("**/dashboard/metrics");
+  await expect(page.getByTestId("timeseries-plot")).toBeVisible();
+});

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -6,6 +6,11 @@ const nextConfig: NextConfig = {
     // Enable the styled-components SWC transform (SSR class matching, display names).
     styledComponents: true,
   },
+  // The dev indicator's default bottom-LEFT position sits exactly on the
+  // expandable rail's foot toggle ([Directive 2026-07-19]) — it intercepts
+  // pointer events over the collapsed-rail chevron (dev + e2e). Bottom-right
+  // is empty app chrome.
+  devIndicators: { position: "bottom-right" },
 };
 
 export default nextConfig;

--- a/web/src/app/dashboard/dashboards/[id]/page.tsx
+++ b/web/src/app/dashboard/dashboards/[id]/page.tsx
@@ -11,7 +11,7 @@ import { WidgetShell, type WidgetShellMode } from "@/components/ui/WidgetShell";
 import { WidgetTypePicker } from "@/components/ui/WidgetTypePicker";
 import type { Widget, WidgetLayout, WidgetType } from "@/models";
 import { useDashboardController } from "@/controllers/dashboards";
-import { defaultWidget } from "@/controllers/widgets";
+import { defaultWidget, substituteVars } from "@/controllers/widgets";
 import { useTimeRange } from "@/controllers/time-range";
 import { WidgetBody } from "./widget-body";
 
@@ -218,7 +218,9 @@ export default function DashboardViewPage() {
                 }}
               >
                 <WidgetShell
-                  title={widget.title}
+                  // titles resolve template vars like queries do ("Error
+                  // rate — $service" reads as the picked service)
+                  title={substituteVars(widget.title, effectiveVars)}
                   query={widget.query_string}
                   mode={mode}
                   onModeChange={(m) => setFullscreenId(m === "fullscreen" ? widget.id : null)}

--- a/web/src/app/dashboard/metrics/page.tsx
+++ b/web/src/app/dashboard/metrics/page.tsx
@@ -44,9 +44,12 @@ export default function MetricsExplorerPage() {
       text: `service:${s.service}`,
       cardinality: Math.round(s.req_per_s * 60),
     }));
-    return [...metricSuggestions, ...serviceSuggestions]
-      .sort((a, b) => (b.cardinality ?? 0) - (a.cardinality ?? 0))
-      .slice(0, 8);
+    // full ranked list — QueryBar filters to the typed token and caps the
+    // display; pre-slicing here hid every match outside the global top-8
+    // (typing "metric:http.err" surfaced nothing — QA 2026-07-19)
+    return [...metricSuggestions, ...serviceSuggestions].sort(
+      (a, b) => (b.cardinality ?? 0) - (a.cardinality ?? 0),
+    );
   }, [summary.data, services.data]);
 
   // ranked by count (MI-13's cardinality discipline applies to facets too)

--- a/web/src/app/dashboard/settings/page.tsx
+++ b/web/src/app/dashboard/settings/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+  AppearanceSection,
   IntegrationsSection,
   KeysSection,
   MembersSection,
@@ -26,6 +27,7 @@ export default function SettingsPage() {
         <div className="flex min-w-0 flex-col gap-10">
           <IntegrationsSection />
           <RetentionSection />
+          <AppearanceSection />
           <PrivacySection />
         </div>
       </div>

--- a/web/src/app/dashboard/settings/sections.tsx
+++ b/web/src/app/dashboard/settings/sections.tsx
@@ -21,6 +21,7 @@ import type { ApiKeyWithSecret, KeyScope, MemberRole } from "@/models";
 import { useAlertsController } from "@/controllers/alerts";
 import { useOrgController } from "@/controllers/onboarding";
 import { useSettingsController } from "@/controllers/settings";
+import { useTheme, type Theme } from "@/design/ThemeProvider";
 
 function SectionHeading({ id, children }: { id: string; children: React.ReactNode }) {
   return (
@@ -368,6 +369,32 @@ const PRIVACY_ROWS = [
   { label: "Raw IP addresses", value: "never stored" },
   { label: "Export & delete", value: "self-serve via API, org-scoped" },
 ];
+
+/* ------------------------------------------------------------------ */
+/* Appearance (theme-parity canon, SKILL.md 2026-07-19)                 */
+/* ------------------------------------------------------------------ */
+
+export function AppearanceSection() {
+  const { theme, setTheme } = useTheme();
+  return (
+    <section aria-labelledby="appearance-heading" className="flex flex-col gap-3">
+      <SectionHeading id="appearance-heading">Appearance</SectionHeading>
+      <div className="flex items-center justify-between gap-4 rounded-(--radius) border border-border bg-bg-elev px-3 py-2">
+        <span className="text-[13px] font-medium text-text">Theme</span>
+        <Select
+          options={[
+            { value: "dark", label: "Dark (default)" },
+            { value: "light", label: "Light" },
+          ]}
+          value={theme}
+          onValueChange={(v) => setTheme(v as Theme)}
+          aria-label="Theme"
+          className="min-w-36"
+        />
+      </div>
+    </section>
+  );
+}
 
 export function PrivacySection() {
   return (

--- a/web/src/app/dashboard/shell.tsx
+++ b/web/src/app/dashboard/shell.tsx
@@ -98,7 +98,11 @@ function ShellChrome({ children }: { children: ReactNode }) {
   const banner = shell.bannerIncident;
 
   return (
-    <div className="font-ui flex min-h-screen bg-bg text-text">
+    // h-dvh (not min-h-screen): the app frame is viewport-bounded so <main>
+    // is the one scroll container — pillar views with internal scroll areas
+    // (the logs live-tail list, MI-4 pause-on-scroll) get a real overflow
+    // boundary instead of growing the body.
+    <div className="font-ui flex h-dvh bg-bg text-text">
       <NavRail
         activeKey={activeKeyFor(pathname)}
         onNavigate={(key) => router.push(PILLAR_ROUTES[key] ?? "/dashboard")}

--- a/web/src/app/dev/components/gallery.tsx
+++ b/web/src/app/dev/components/gallery.tsx
@@ -883,7 +883,7 @@ function GalleryAll() {
       </Section>
 
       <Section title="Marketing (Stage-5 kit)">
-        <Cell label="MarketingNav (parity canon: 4 links · theme toggle · Sign in)" grow>
+        <Cell label="MarketingNav (parity canon rev: 4 links · star badge · theme toggle · Sign in · Try Cloud)" grow>
           <div className="overflow-hidden rounded-(--radius) border border-border">
             <MarketingNav starCount={1284} />
           </div>

--- a/web/src/app/dev/components/gallery.tsx
+++ b/web/src/app/dev/components/gallery.tsx
@@ -883,7 +883,7 @@ function GalleryAll() {
       </Section>
 
       <Section title="Marketing (Stage-5 kit)">
-        <Cell label="MarketingNav (badge neutral · dropdown = pillar map)" grow>
+        <Cell label="MarketingNav (parity canon: 4 links · theme toggle · Sign in)" grow>
           <div className="overflow-hidden rounded-(--radius) border border-border">
             <MarketingNav starCount={1284} />
           </div>

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -168,7 +168,19 @@
     text-decoration: none;
   }
 
-  button { cursor: pointer; }
+  /*
+   * Cursor affordance [Directive 2026-07-19]: enabled interactive controls
+   * show the pointer; disabled controls keep the default cursor; links keep
+   * the native pointer (the `a` rule above). One base-layer rule — the
+   * ecosystem line lives in design.md "Shared foundations".
+   */
+  button:not(:disabled),
+  [role="button"]:not([aria-disabled="true"]),
+  select:not(:disabled),
+  summary,
+  label[for] {
+    cursor: pointer;
+  }
 
   html, body {
     overflow-x: hidden;

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata, Viewport } from "next";
 import { Inter, JetBrains_Mono } from "next/font/google";
+import { ThemeProvider, themeInitScript } from "@/design/ThemeProvider";
 import "./globals.css";
 
 // Design-system fonts (design.md §2): Inter for UI, JetBrains Mono for
@@ -30,7 +31,12 @@ export const viewport: Viewport = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" className={`${inter.variable} ${jetbrainsMono.variable}`}>
-      <body>{children}</body>
+      <body>
+        {/* pre-paint: applies the persisted `upstat.theme` override before
+            first paint (theme-parity canon) — a static literal script */}
+        <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
+        <ThemeProvider>{children}</ThemeProvider>
+      </body>
     </html>
   );
 }

--- a/web/src/app/status/[slug]/page.tsx
+++ b/web/src/app/status/[slug]/page.tsx
@@ -85,7 +85,7 @@ export default function StatusPage() {
             name={`${first.name} — 90 day history`}
             days={first.days}
             uptimePct={first.uptime_pct}
-            p95Ms={96}
+            p95Ms={first.p95_ms ?? undefined}
           />
         </section>
       )}

--- a/web/src/components/home/HomeView.test.tsx
+++ b/web/src/components/home/HomeView.test.tsx
@@ -58,7 +58,7 @@ describe("HomeView (pages.md Part A — Figma frame 135:2)", () => {
       screen.getByText("Go gRPC services · Next.js + React/TS · ClickHouse · OpenTelemetry"),
     ).toBeInTheDocument();
     // A8 community
-    expect(screen.getByText("CueLABS Discord — #upstat-lab")).toBeInTheDocument();
+    expect(screen.getByText("CueLABS™ Discord — #upstat-lab")).toBeInTheDocument();
     // A15 FAQ + A16 CTA band
     expect(screen.getByText("Questions, answered.")).toBeInTheDocument();
     expect(screen.getByText("OTLP in. Answers out.")).toBeInTheDocument();

--- a/web/src/components/home/HomeView.test.tsx
+++ b/web/src/components/home/HomeView.test.tsx
@@ -58,7 +58,7 @@ describe("HomeView (pages.md Part A — Figma frame 135:2)", () => {
       screen.getByText("Go gRPC services · Next.js + React/TS · ClickHouse · OpenTelemetry"),
     ).toBeInTheDocument();
     // A8 community
-    expect(screen.getByText("CueLABS Discord — #upstat")).toBeInTheDocument();
+    expect(screen.getByText("CueLABS Discord — #upstat-lab")).toBeInTheDocument();
     // A15 FAQ + A16 CTA band
     expect(screen.getByText("Questions, answered.")).toBeInTheDocument();
     expect(screen.getByText("OTLP in. Answers out.")).toBeInTheDocument();
@@ -68,12 +68,12 @@ describe("HomeView (pages.md Part A — Figma frame 135:2)", () => {
     );
   });
 
-  it("keeps the nav GitHub link neutral in TEST_MODE (no invented count)", () => {
+  it("keeps the nav star badge neutral in TEST_MODE (no invented count)", () => {
     renderHome();
     const navigation = screen.getByRole("navigation", { name: "Marketing" });
-    expect(within(navigation).getByRole("link", { name: "GitHub" })).toHaveTextContent(
-      /^GitHub$/,
-    );
+    expect(
+      within(navigation).getByRole("link", { name: "Star cuesoftinc/upstat on GitHub" }),
+    ).toHaveTextContent(/^Star$/);
     expect(within(navigation).getByTestId("theme-toggle")).toBeInTheDocument();
   });
 

--- a/web/src/components/home/HomeView.test.tsx
+++ b/web/src/components/home/HomeView.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "@/design/ThemeProvider";
 import { HomeView } from "./HomeView";
 import { FAQ_ITEMS } from "./content";
 
@@ -9,9 +10,16 @@ vi.mock("next/navigation", () => ({
   useRouter: () => ({ push }),
 }));
 
+const renderHome = () =>
+  render(
+    <ThemeProvider>
+      <HomeView />
+    </ThemeProvider>,
+  );
+
 describe("HomeView (pages.md Part A — Figma frame 135:2)", () => {
   it("renders every section of the landing", () => {
-    render(<HomeView />);
+    renderHome();
     // A2 hero
     expect(
       screen.getByRole("heading", { level: 1, name: /All your telemetry\./ }),
@@ -42,7 +50,9 @@ describe("HomeView (pages.md Part A — Figma frame 135:2)", () => {
     // A14 self-host + A9 table
     expect(screen.getByText("Self-host — own your telemetry.")).toBeInTheDocument();
     expect(screen.getByText("Cloud when you want it. Yours when you need it.")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Deploy with compose" })).toBeInTheDocument();
+    // ×2: the table's sm+ CTA footer and the <sm grouped CTA block (the
+    // pair is exclusive via CSS breakpoints, which jsdom doesn't apply)
+    expect(screen.getAllByRole("button", { name: "Deploy with compose" })).toHaveLength(2);
     // A13 developers — the ratified stack line, verbatim
     expect(
       screen.getByText("Go gRPC services · Next.js + React/TS · ClickHouse · OpenTelemetry"),
@@ -52,18 +62,23 @@ describe("HomeView (pages.md Part A — Figma frame 135:2)", () => {
     // A15 FAQ + A16 CTA band
     expect(screen.getByText("Questions, answered.")).toBeInTheDocument();
     expect(screen.getByText("OTLP in. Answers out.")).toBeInTheDocument();
-    // A10 footer
-    expect(screen.getByText("© 2026 Cuesoft · upstat is CueLABS open source")).toBeInTheDocument();
+    // A10 footer — the canonical legal bar (parity canon 2026-07-19)
+    expect(screen.getByText(/CueLABS™ Division/).closest("p")).toHaveTextContent(
+      "© Cuesoft Inc. 2026. Upstat. CueLABS™ Division. MIT License.",
+    );
   });
 
-  it("keeps the star badge neutral in TEST_MODE (no invented count)", () => {
-    render(<HomeView />);
-    const badge = screen.getByRole("link", { name: /Star/ });
-    expect(badge).toHaveTextContent(/^Star$/);
+  it("keeps the nav GitHub link neutral in TEST_MODE (no invented count)", () => {
+    renderHome();
+    const navigation = screen.getByRole("navigation", { name: "Marketing" });
+    expect(within(navigation).getByRole("link", { name: "GitHub" })).toHaveTextContent(
+      /^GitHub$/,
+    );
+    expect(within(navigation).getByTestId("theme-toggle")).toBeInTheDocument();
   });
 
   it("FAQ is single-open: opening one closes the other (A15)", async () => {
-    render(<HomeView />);
+    renderHome();
     // first item open by default
     expect(screen.getByText(FAQ_ITEMS[0].answer)).toBeInTheDocument();
     await userEvent.click(screen.getByRole("button", { name: FAQ_ITEMS[1].question }));
@@ -73,15 +88,15 @@ describe("HomeView (pages.md Part A — Figma frame 135:2)", () => {
 
   it("Try Cloud CTAs route to /signin", async () => {
     push.mockClear();
-    render(<HomeView />);
+    renderHome();
     const ctas = screen.getAllByRole("button", { name: "Try Cloud" });
-    expect(ctas.length).toBeGreaterThanOrEqual(3); // nav + hero + table + band
+    expect(ctas.length).toBeGreaterThanOrEqual(3); // hero + table + mobile group + band
     await userEvent.click(ctas[0]);
     expect(push).toHaveBeenCalledWith("/signin");
   });
 
   it("accuracy: MIT copy present, no fabricated pricing", () => {
-    render(<HomeView />);
+    renderHome();
     expect(screen.getByText(/MIT · CONTRIBUTING\.md · roadmap/)).toBeInTheDocument();
     expect(
       screen.getByText("Self-hosting is free forever — cloud pricing will be announced at GA."),
@@ -89,7 +104,7 @@ describe("HomeView (pages.md Part A — Figma frame 135:2)", () => {
   });
 
   it("renders the use-case quads with their Read more anchors (§8.4 SCROLL_TO)", () => {
-    render(<HomeView />);
+    renderHome();
     const links = screen.getAllByRole("link", { name: "Read more →" });
     expect(links.map((l) => l.getAttribute("href"))).toEqual([
       "#demo",
@@ -100,7 +115,7 @@ describe("HomeView (pages.md Part A — Figma frame 135:2)", () => {
   });
 
   it("demo band renders the seeded panels (uptime strip + query values)", () => {
-    render(<HomeView />);
+    renderHome();
     const demo = document.getElementById("demo")!;
     expect(within(demo).getByText("availability · api-common")).toBeInTheDocument();
     expect(within(demo).getByText("99.98%")).toBeInTheDocument();

--- a/web/src/components/home/HomeView.tsx
+++ b/web/src/components/home/HomeView.tsx
@@ -12,7 +12,6 @@
 import { MarketingFooter } from "@/components/ui/MarketingFooter";
 import { MarketingNav } from "@/components/ui/MarketingNav";
 import { useHomeController } from "@/controllers/home";
-import { FOOTER_COLUMNS, FOOTER_COPYRIGHT } from "./content";
 import {
   CloudSelfHostSection,
   CommunitySection,
@@ -47,7 +46,7 @@ export function HomeView() {
 
   return (
     <div className="font-ui min-h-screen bg-bg text-text">
-      <MarketingNav starCount={stars} onSignIn={onSignIn} onTryCloud={onTryCloud} />
+      <MarketingNav starCount={stars} onSignIn={onSignIn} />
 
       <main>
         <HeroSection
@@ -91,12 +90,9 @@ export function HomeView() {
         <FinalCtaSection onTryCloud={onTryCloud} onSelfHost={onSelfHost} />
       </main>
 
-      <MarketingFooter
-        inline
-        showBrand={false}
-        columns={FOOTER_COLUMNS}
-        copyright={FOOTER_COPYRIGHT}
-      />
+      {/* A10 footer — the canonical parity shape (brand block + 4 columns +
+          legal bar) is the component default (SKILL.md canon 2026-07-19) */}
+      <MarketingFooter />
     </div>
   );
 }

--- a/web/src/components/home/HomeView.tsx
+++ b/web/src/components/home/HomeView.tsx
@@ -46,7 +46,7 @@ export function HomeView() {
 
   return (
     <div className="font-ui min-h-screen bg-bg text-text">
-      <MarketingNav starCount={stars} onSignIn={onSignIn} />
+      <MarketingNav starCount={stars} onSignIn={onSignIn} onTryCloud={onTryCloud} />
 
       <main>
         <HeroSection

--- a/web/src/components/home/content.ts
+++ b/web/src/components/home/content.ts
@@ -6,7 +6,6 @@
 
 import type { CodeSnippetTab } from "@/components/ui/CodeSnippet";
 import type { PlanFeatureRow } from "@/components/ui/CloudVsSelfHostTable";
-import type { FooterColumn } from "@/components/ui/MarketingFooter";
 
 /** A5 — OTel section snippet (Figma 135:281; endpoint copy from the frame). */
 export const OTEL_SNIPPETS: CodeSnippetTab[] = [
@@ -120,37 +119,9 @@ export const ARCHITECTURE_FLOW = [
 ];
 
 export const GITHUB_URL = "https://github.com/cuesoftinc/upstat";
-export const DISCORD_URL = "https://discord.gg/cuelabs";
+// canonical invite (SKILL.md parity canon 2026-07-19, verified live)
+export const DISCORD_URL = "https://discord.gg/CDfZxxrxbb";
 export const DOCS_URL = "https://docs.upstat.cuesoft.io";
 
-/** A10 — landing footer columns (Figma 135:770). */
-export const FOOTER_COLUMNS: FooterColumn[] = [
-  {
-    heading: "Product",
-    links: [
-      { label: "Uptime", href: "/#pillars" },
-      { label: "Logs", href: "/#pillars" },
-      { label: "Traces", href: "/#pillars" },
-      { label: "RUM", href: "/#pillars" },
-      { label: "Dashboards", href: "/#pillars" },
-    ],
-  },
-  {
-    heading: "Open source",
-    links: [
-      { label: "GitHub", href: GITHUB_URL },
-      { label: "Self-host guide", href: `${DOCS_URL}/self-host` },
-      { label: "Roadmap", href: `${GITHUB_URL}#roadmap` },
-    ],
-  },
-  {
-    heading: "Company",
-    links: [
-      { label: "CueLABS", href: "https://cuesoft.io" },
-      { label: "Privacy", href: "/privacy" },
-      { label: "Status", href: "https://status.upstat.cuesoft.io/upstat" },
-    ],
-  },
-];
-
-export const FOOTER_COPYRIGHT = "© 2026 Cuesoft · upstat is CueLABS open source";
+// A10 footer columns/copyright: superseded by the canonical parity footer
+// (SKILL.md 2026-07-19) — MarketingFooter now owns the column set + legal bar.

--- a/web/src/components/home/sections-bottom.tsx
+++ b/web/src/components/home/sections-bottom.tsx
@@ -110,7 +110,9 @@ export function CloudSelfHostSection({
 }: CloudSelfHostSectionProps) {
   return (
     <Section title="Cloud when you want it. Yours when you need it.">
-      <div className="grid items-start gap-12 lg:grid-cols-[1fr_480px]">
+      {/* gap-6 below lg: the stacked table → CTA → snippet must read as one
+          group at 390 (live-QA finding 2026-07-19); desktop keeps the rails */}
+      <div className="grid items-start gap-6 lg:grid-cols-[1fr_480px] lg:gap-12">
         <CloudVsSelfHostTable
           rows={PLAN_ROWS}
           featureHeader=""
@@ -120,10 +122,23 @@ export function CloudSelfHostSection({
           onSelfHost={onSelfHost}
           className="w-full"
         />
+        {/* <sm: the table's column-aligned CTA footer is hidden — the pair
+            renders here instead, directly above the compose snippet the
+            self-host CTA refers to */}
+        <div className="flex items-center gap-3 sm:hidden" aria-label="Cloud or self-host">
+          <Button kind="brand" className="flex-1 whitespace-nowrap" onClick={onTryCloud}>
+            Try Cloud
+          </Button>
+          <Button kind="quiet" className="flex-1 whitespace-nowrap" onClick={onSelfHost}>
+            Deploy with compose
+          </Button>
+        </div>
         <div className="min-w-0 flex flex-col gap-5 lg:pt-2">
-          <code className="font-data text-[13px]">
-            <span className="text-brand">docker compose up -d</span>{" "}
-            <span className="text-text-2"># the whole platform, one file</span>
+          {/* flex-wrap of two nowrap runs: at 390 the comment wraps as a
+              whole line instead of mid-comment (CodeSnippet convention) */}
+          <code className="font-data flex flex-wrap gap-x-2 text-[13px]">
+            <span className="whitespace-nowrap text-brand">docker compose up -d</span>
+            <span className="whitespace-nowrap text-text-2"># the whole platform, one file</span>
           </code>
           <a
             href={GITHUB_URL}

--- a/web/src/components/home/sections-bottom.tsx
+++ b/web/src/components/home/sections-bottom.tsx
@@ -214,7 +214,7 @@ export function DevelopersSection({ onGithub }: DevelopersSectionProps) {
             >
               {/* Discord blurple — brand-glyph color exception (design.md §8.1) */}
               <DiscordIcon className="size-4 shrink-0 text-[#5865F2]" />
-              Discord — #upstat-dev on the CueLABS server
+              Discord — #upstat-lab on the CueLABS server
             </a>
           </div>
         </div>
@@ -248,7 +248,7 @@ export function CommunitySection() {
           <DiscordIcon className="mt-1 size-7 shrink-0 text-[#5865F2]" />
           <span className="flex min-w-0 flex-1 flex-col gap-1">
             <span className="text-[14px] font-semibold text-text">
-              CueLABS Discord — #upstat
+              CueLABS Discord — #upstat-lab
             </span>
             <span className="text-[13px] text-text-2">
               Get help, share dashboards, talk to the maintainers.

--- a/web/src/components/home/sections-bottom.tsx
+++ b/web/src/components/home/sections-bottom.tsx
@@ -155,7 +155,7 @@ export function CloudSelfHostSection({
             {/* Discord blurple — brand-glyph color exception (design.md §8.1),
                 like the Google 'G' */}
             <DiscordIcon className="size-6 shrink-0 text-[#5865F2]" />
-            Discord — CueLABS community
+            Discord — CueLABS™ community
           </a>
         </div>
       </div>
@@ -214,7 +214,7 @@ export function DevelopersSection({ onGithub }: DevelopersSectionProps) {
             >
               {/* Discord blurple — brand-glyph color exception (design.md §8.1) */}
               <DiscordIcon className="size-4 shrink-0 text-[#5865F2]" />
-              Discord — #upstat-lab on the CueLABS server
+              Discord — #upstat-lab on the CueLABS™ server
             </a>
           </div>
         </div>
@@ -248,7 +248,7 @@ export function CommunitySection() {
           <DiscordIcon className="mt-1 size-7 shrink-0 text-[#5865F2]" />
           <span className="flex min-w-0 flex-1 flex-col gap-1">
             <span className="text-[14px] font-semibold text-text">
-              CueLABS Discord — #upstat-lab
+              CueLABS™ Discord — #upstat-lab
             </span>
             <span className="text-[13px] text-text-2">
               Get help, share dashboards, talk to the maintainers.
@@ -267,7 +267,7 @@ export function CommunitySection() {
             href="https://cuesoft.io"
             className="flex items-center gap-1.5 text-[13px] font-medium text-brand transition-colors duration-[var(--duration-fast)] hover:text-brand-deep"
           >
-            CueLABS — more open source from Cuesoft
+            CueLABS™ — more open source from Cuesoft
             <ExternalLink aria-hidden="true" className="size-3.5" />
           </a>
         </div>

--- a/web/src/components/ui/CloudVsSelfHostTable.tsx
+++ b/web/src/components/ui/CloudVsSelfHostTable.tsx
@@ -84,16 +84,19 @@ export function CloudVsSelfHostTable({
           </tr>
         ))}
       </tbody>
-      <tfoot>
+      {/* CTA footer rides the plan columns from sm up; below sm the section
+          composes its own grouped CTA block (the column-aligned buttons read
+          detached from their snippet at 390 — live-QA finding 2026-07-19). */}
+      <tfoot className="hidden sm:table-footer-group">
         <tr>
           <td className="p-3" />
           <td className="p-3 text-center">
-            <Button kind="brand" size="sm" onClick={onTryCloud}>
+            <Button kind="brand" size="sm" className="whitespace-nowrap" onClick={onTryCloud}>
               Try Cloud
             </Button>
           </td>
           <td className="p-3 text-center">
-            <Button kind="quiet" size="sm" onClick={onSelfHost}>
+            <Button kind="quiet" size="sm" className="whitespace-nowrap" onClick={onSelfHost}>
               {selfHostCta}
             </Button>
           </td>

--- a/web/src/components/ui/GoogleAuthButton.tsx
+++ b/web/src/components/ui/GoogleAuthButton.tsx
@@ -41,7 +41,7 @@ export interface GoogleAuthButtonProps {
 
 /**
  * GoogleAuthButton — the product's single auth CTA (X-1; design.md §8.2b:
- * default / hover / loading). Same name in every CueLABS product.
+ * default / hover / loading). Same name in every CueLABS™ product.
  * Google brand button colors are brand-mandated raw values (white /
  * #1F1F1F / #D9D9D9 — Figma 92:1449), NOT token-bound, in both modes.
  */

--- a/web/src/components/ui/MarketingFooter.test.tsx
+++ b/web/src/components/ui/MarketingFooter.test.tsx
@@ -1,31 +1,87 @@
 import { describe, expect, it } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import { MarketingFooter } from "./MarketingFooter";
 
-describe("MarketingFooter", () => {
-  it("links privacy per UPS-005", () => {
-    render(<MarketingFooter />);
-    expect(screen.getByRole("link", { name: "Privacy (cookieless)" })).toHaveAttribute(
-      "href",
-      "/privacy",
-    );
-    expect(screen.getByText(/MIT licensed/)).toBeInTheDocument();
-  });
-});
+/** The ratified column/link set (SKILL.md parity canon, 2026-07-19). */
+const CANON: Record<string, [string, string][]> = {
+  Product: [
+    ["Features", "/#pillars"],
+    ["Try Cloud", "/signin"],
+    ["Self Host", "/#self-host"],
+    ["Dashboards", "/dashboard"],
+  ],
+  Docs: [
+    ["Docs", "https://cuesoft.gitbook.io/upstat"],
+    ["Quickstart", "https://cuesoft.gitbook.io/upstat/setup"],
+    ["API reference", "https://cuesoft.gitbook.io/upstat/system/api-surface"],
+    ["Self-host guide", "https://cuesoft.gitbook.io/upstat/system/deployment"],
+  ],
+  Community: [
+    ["GitHub", "https://github.com/cuesoftinc/upstat"],
+    ["Discord", "https://discord.gg/CDfZxxrxbb"],
+    ["Roadmap", "https://cuesoft.gitbook.io/upstat/product/roadmap"],
+    ["CueLABS", "https://cuelabs.cuesoft.io"],
+  ],
+  Legal: [
+    ["Privacy", "https://privacy.cuesoft.io"],
+    ["Terms", "https://terms.cuesoft.io"],
+    ["Status", "https://status.cuesoft.io"],
+  ],
+};
 
-describe("MarketingFooter — landing variant (Figma 135:770)", () => {
-  it("renders inline dot-joined columns + copyright, no brand block", () => {
+describe("MarketingFooter (parity canon, SKILL.md 2026-07-19)", () => {
+  it("renders the brand block and every canonical column link", () => {
+    render(<MarketingFooter />);
+    expect(screen.getByText(/MIT licensed/)).toBeInTheDocument();
+    for (const [heading, links] of Object.entries(CANON)) {
+      const column = screen.getByRole("navigation", { name: heading });
+      for (const [label, href] of links) {
+        expect(within(column).getByRole("link", { name: label })).toHaveAttribute("href", href);
+      }
+    }
+  });
+
+  it("legal bar: verbatim copyright with linked marks", () => {
+    render(<MarketingFooter />);
+    const bar = screen.getByText(/CueLABS™ Division/).closest("p")!;
+    expect(bar).toHaveTextContent("© Cuesoft Inc. 2026. Upstat. CueLABS™ Division. MIT License.");
+    expect(within(bar).getByRole("link", { name: "Cuesoft Inc." })).toHaveAttribute(
+      "href",
+      "https://cuesoft.io",
+    );
+    expect(within(bar).getByRole("link", { name: "MIT License" })).toHaveAttribute(
+      "href",
+      "https://github.com/cuesoftinc/upstat/blob/main/LICENSE",
+    );
+  });
+
+  it("legal bar: language selector (English-only, real control) + security affordance", () => {
+    render(<MarketingFooter />);
+    const language = screen.getByRole("combobox", { name: "Language" });
+    expect(language).toHaveValue("en");
+    expect(within(language).getAllByRole("option")).toHaveLength(1);
+    expect(screen.getByRole("link", { name: "Security" })).toHaveAttribute(
+      "href",
+      "https://github.com/cuesoftinc/upstat/blob/main/SECURITY.md",
+    );
+  });
+
+  it("keeps the inline landing variant rendering for custom columns", () => {
     render(
       <MarketingFooter
         inline
         showBrand={false}
-        copyright="© 2026 Cuesoft · upstat is CueLABS open source"
         columns={[
-          { heading: "Product", links: [{ label: "Uptime", href: "/#pillars" }, { label: "Logs", href: "/#pillars" }] },
+          {
+            heading: "Product",
+            links: [
+              { label: "Uptime", href: "/#pillars" },
+              { label: "Logs", href: "/#pillars" },
+            ],
+          },
         ]}
       />,
     );
-    expect(screen.getByText("© 2026 Cuesoft · upstat is CueLABS open source")).toBeInTheDocument();
     expect(screen.queryByText(/MIT licensed/)).toBeNull();
     expect(screen.getByRole("link", { name: "Uptime" })).toHaveAttribute("href", "/#pillars");
   });

--- a/web/src/components/ui/MarketingFooter.test.tsx
+++ b/web/src/components/ui/MarketingFooter.test.tsx
@@ -20,7 +20,7 @@ const CANON: Record<string, [string, string][]> = {
     ["GitHub", "https://github.com/cuesoftinc/upstat"],
     ["Discord", "https://discord.gg/CDfZxxrxbb"],
     ["Roadmap", "https://cuesoft.gitbook.io/upstat/product/roadmap"],
-    ["CueLABS", "https://cuelabs.cuesoft.io"],
+    ["CueLABS™", "https://cuelabs.cuesoft.io"],
   ],
   Legal: [
     ["Privacy", "https://privacy.cuesoft.io"],

--- a/web/src/components/ui/MarketingFooter.test.tsx
+++ b/web/src/components/ui/MarketingFooter.test.tsx
@@ -49,6 +49,10 @@ describe("MarketingFooter (parity canon, SKILL.md 2026-07-19)", () => {
       "href",
       "https://cuesoft.io",
     );
+    expect(within(bar).getByRole("link", { name: "CueLABS™ Division" })).toHaveAttribute(
+      "href",
+      "https://cuelabs.cuesoft.io",
+    );
     expect(within(bar).getByRole("link", { name: "MIT License" })).toHaveAttribute(
       "href",
       "https://github.com/cuesoftinc/upstat/blob/main/LICENSE",

--- a/web/src/components/ui/MarketingFooter.tsx
+++ b/web/src/components/ui/MarketingFooter.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { clsx } from "clsx";
+import { ShieldCheck } from "lucide-react";
 import { Fragment } from "react";
 
 export interface FooterLink {
@@ -14,64 +15,82 @@ export interface FooterColumn {
 }
 
 export interface MarketingFooterProps {
-  /** Column set — defaults to the standard A10 columns. */
+  /** Column set — defaults to the canonical parity columns (SKILL.md). */
   columns?: FooterColumn[];
   /**
-   * Landing v2 rendering (Figma 135:770): links inline, dot-joined,
-   * no brand block, copyright line below. Defaults keep the W1 shape.
+   * Landing v2 rendering (Figma 135:770): links inline, dot-joined.
+   * Defaults keep the stacked-column shape.
    */
   inline?: boolean;
   showBrand?: boolean;
-  copyright?: string;
   className?: string;
 }
 
+/**
+ * Canonical footer columns (SKILL.md "Marketing nav, footer & theme parity
+ * canon", ratified 2026-07-19) — Product / Docs / Community / Legal.
+ */
 const COLUMNS: FooterColumn[] = [
   {
     heading: "Product",
     links: [
-      { label: "Platform", href: "/#platform" },
-      { label: "Status page", href: "https://status.upstat.cuesoft.io/upstat" },
-      { label: "Docs", href: "https://docs.upstat.cuesoft.io" },
+      { label: "Features", href: "/#pillars" },
+      { label: "Try Cloud", href: "/signin" },
+      { label: "Self Host", href: "/#self-host" },
+      { label: "Dashboards", href: "/dashboard" },
     ],
   },
   {
-    heading: "Open source",
+    heading: "Docs",
     links: [
-      { label: "GitHub", href: "https://github.com/cuesoftinc/upstat" },
-      { label: "Contributing", href: "https://github.com/cuesoftinc/upstat/blob/main/CONTRIBUTING.md" },
-      { label: "Roadmap", href: "https://github.com/cuesoftinc/upstat#roadmap" },
+      { label: "Docs", href: "https://cuesoft.gitbook.io/upstat" },
+      { label: "Quickstart", href: "https://cuesoft.gitbook.io/upstat/setup" },
+      { label: "API reference", href: "https://cuesoft.gitbook.io/upstat/system/api-surface" },
+      { label: "Self-host guide", href: "https://cuesoft.gitbook.io/upstat/system/deployment" },
     ],
   },
   {
     heading: "Community",
     links: [
-      { label: "Discord", href: "https://discord.gg/cuelabs" },
-      { label: "CueLABS", href: "https://cuesoft.io" },
+      { label: "GitHub", href: "https://github.com/cuesoftinc/upstat" },
+      { label: "Discord", href: "https://discord.gg/CDfZxxrxbb" },
+      { label: "Roadmap", href: "https://cuesoft.gitbook.io/upstat/product/roadmap" },
+      { label: "CueLABS", href: "https://cuelabs.cuesoft.io" },
     ],
   },
   {
     heading: "Legal",
-    links: [{ label: "Privacy (cookieless)", href: "/privacy" }],
+    links: [
+      { label: "Privacy", href: "https://privacy.cuesoft.io" },
+      { label: "Terms", href: "https://terms.cuesoft.io" },
+      { label: "Status", href: "https://status.cuesoft.io" },
+    ],
   },
 ];
 
-/** MarketingFooter — pages.md A10: standard + privacy (UPS-005). */
+const SECURITY_URL = "https://github.com/cuesoftinc/upstat/blob/main/SECURITY.md";
+const LICENSE_URL = "https://github.com/cuesoftinc/upstat/blob/main/LICENSE";
+
+/**
+ * MarketingFooter — parity canon (SKILL.md 2026-07-19, supersedes the A10
+ * ad-hoc columns): brand block + Product/Docs/Community/Legal columns +
+ * legal bar (verbatim copyright with linked "Cuesoft Inc." and "MIT
+ * License", language selector — English-only for now, ratified — and the
+ * security-policy affordance), in upstat's visual idiom.
+ */
 export function MarketingFooter({
   columns = COLUMNS,
   inline = false,
   showBrand = true,
-  copyright,
   className,
 }: MarketingFooterProps) {
   return (
     <footer className={clsx("font-ui border-t border-border bg-bg px-6 py-10", className)}>
       {/* marketing container (design.md §2): footer band is full-bleed, its
-          content sits on the 1152 rails (outer px-6 supplies the gutters —
-          the old generic max-w-5xl (1024) drifted 64px off the rail). */}
+          content sits on the 1152 rails (outer px-6 supplies the gutters) */}
       <div className="mx-auto flex max-w-[1152px] flex-wrap justify-between gap-8">
         {showBrand && (
-          <div className="flex flex-col gap-2">
+          <div className="flex max-w-56 flex-col gap-2">
             <span className="flex items-center gap-2 text-[16px] font-semibold text-text">
               <span
                 aria-hidden="true"
@@ -81,7 +100,7 @@ export function MarketingFooter({
               </span>
               Upstat
             </span>
-            <span className="text-[12px] text-text-2">
+            <span className="text-[12px] leading-[1.45] text-text-2">
               Open-source observability by CueLABS. MIT licensed.
             </span>
           </div>
@@ -126,9 +145,47 @@ export function MarketingFooter({
           </nav>
         ))}
       </div>
-      {copyright && (
-        <p className="mx-auto mt-8 max-w-[1152px] text-[12px] text-text-2">{copyright}</p>
-      )}
+
+      {/* legal bar — verbatim copyright (linked marks), language selector
+          (English-only, a real control — no i18n yet, ratified) and the
+          security-policy affordance */}
+      <div className="mx-auto mt-8 flex max-w-[1152px] flex-wrap items-center gap-x-6 gap-y-3 border-t border-border pt-4">
+        <p className="text-[12px] text-text-2">
+          ©{" "}
+          <a
+            href="https://cuesoft.io"
+            className="transition-colors duration-[var(--duration-fast)] hover:text-text"
+          >
+            Cuesoft Inc.
+          </a>{" "}
+          2026. Upstat. CueLABS™ Division.{" "}
+          <a
+            href={LICENSE_URL}
+            className="transition-colors duration-[var(--duration-fast)] hover:text-text"
+          >
+            MIT License
+          </a>
+          .
+        </p>
+        <span className="flex-1" />
+        <a
+          href={SECURITY_URL}
+          className="flex items-center gap-1.5 text-[12px] text-text-2 transition-colors duration-[var(--duration-fast)] hover:text-text"
+        >
+          <ShieldCheck aria-hidden="true" className="size-3.5" />
+          Security
+        </a>
+        <label className="flex items-center gap-1.5 text-[12px] text-text-2">
+          <span className="sr-only">Language</span>
+          <select
+            aria-label="Language"
+            defaultValue="en"
+            className="rounded-(--radius) border border-border bg-bg-elev px-1.5 py-0.5 text-[12px] text-text-2"
+          >
+            <option value="en">English</option>
+          </select>
+        </label>
+      </div>
     </footer>
   );
 }

--- a/web/src/components/ui/MarketingFooter.tsx
+++ b/web/src/components/ui/MarketingFooter.tsx
@@ -55,7 +55,7 @@ const COLUMNS: FooterColumn[] = [
       { label: "GitHub", href: "https://github.com/cuesoftinc/upstat" },
       { label: "Discord", href: "https://discord.gg/CDfZxxrxbb" },
       { label: "Roadmap", href: "https://cuesoft.gitbook.io/upstat/product/roadmap" },
-      { label: "CueLABS", href: "https://cuelabs.cuesoft.io" },
+      { label: "CueLABS™", href: "https://cuelabs.cuesoft.io" },
     ],
   },
   {
@@ -101,7 +101,7 @@ export function MarketingFooter({
               Upstat
             </span>
             <span className="text-[12px] leading-[1.45] text-text-2">
-              Open-source observability by CueLABS. MIT licensed.
+              Open-source observability by CueLABS™. MIT licensed.
             </span>
           </div>
         )}

--- a/web/src/components/ui/MarketingFooter.tsx
+++ b/web/src/components/ui/MarketingFooter.tsx
@@ -158,7 +158,14 @@ export function MarketingFooter({
           >
             Cuesoft Inc.
           </a>{" "}
-          2026. Upstat. CueLABS™ Division.{" "}
+          2026. Upstat.{" "}
+          <a
+            href="https://cuelabs.cuesoft.io"
+            className="transition-colors duration-[var(--duration-fast)] hover:text-text"
+          >
+            CueLABS™ Division
+          </a>
+          .{" "}
           <a
             href={LICENSE_URL}
             className="transition-colors duration-[var(--duration-fast)] hover:text-text"

--- a/web/src/components/ui/MarketingNav.test.tsx
+++ b/web/src/components/ui/MarketingNav.test.tsx
@@ -10,7 +10,7 @@ const renderNav = (props: Parameters<typeof MarketingNav>[0] = {}) =>
     </ThemeProvider>,
   );
 
-describe("MarketingNav (parity canon, SKILL.md 2026-07-19)", () => {
+describe("MarketingNav (parity canon, SKILL.md 2026-07-19, revised same day)", () => {
   it("renders the four canonical links with the ratified hrefs", () => {
     renderNav();
     expect(NAV_LINKS.map((l) => l.label)).toEqual(["Features", "Dashboards", "Docs", "GitHub"]);
@@ -20,25 +20,31 @@ describe("MarketingNav (parity canon, SKILL.md 2026-07-19)", () => {
       "href",
       "https://cuesoft.gitbook.io/upstat",
     );
-    expect(screen.getByRole("link", { name: "GitHub" })).toHaveAttribute(
+    // the GitHub item renders as the star badge (canon revision 2026-07-19)
+    expect(screen.getByRole("link", { name: "Star cuesoftinc/upstat on GitHub" })).toHaveAttribute(
       "href",
       "https://github.com/cuesoftinc/upstat",
     );
   });
 
-  it("carries the theme toggle and the Sign in CTA", () => {
+  it("carries the theme toggle, the Sign in link and the Try Cloud CTA", () => {
     renderNav();
     expect(screen.getByTestId("theme-toggle")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Sign in" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Sign in" })).toHaveAttribute("href", "/signin");
+    expect(screen.getByRole("button", { name: "Try Cloud" })).toBeInTheDocument();
   });
 
-  it("shows the runtime star count on the GitHub link when provided (never static)", () => {
+  it("shows the runtime star count on the star badge when provided (never static)", () => {
     renderNav({ starCount: 1284 });
-    expect(screen.getByRole("link", { name: /GitHub/ })).toHaveTextContent("1,284");
+    expect(screen.getByRole("link", { name: "Star cuesoftinc/upstat on GitHub" })).toHaveTextContent(
+      "1,284",
+    );
   });
 
-  it("keeps the GitHub link neutral without a runtime count", () => {
+  it("keeps the star badge neutral without a runtime count", () => {
     renderNav();
-    expect(screen.getByRole("link", { name: "GitHub" })).toHaveTextContent(/^GitHub$/);
+    expect(screen.getByRole("link", { name: "Star cuesoftinc/upstat on GitHub" })).toHaveTextContent(
+      /^Star$/,
+    );
   });
 });

--- a/web/src/components/ui/MarketingNav.test.tsx
+++ b/web/src/components/ui/MarketingNav.test.tsx
@@ -1,24 +1,44 @@
 import { describe, expect, it } from "vitest";
 import { render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
-import { MarketingNav } from "./MarketingNav";
+import { ThemeProvider } from "@/design/ThemeProvider";
+import { MarketingNav, NAV_LINKS } from "./MarketingNav";
 
-describe("MarketingNav", () => {
-  it("keeps the star badge neutral without a runtime count (A13)", () => {
-    render(<MarketingNav />);
-    const badge = screen.getByRole("link", { name: /Star/ });
-    expect(badge).toHaveTextContent(/^Star$/);
+const renderNav = (props: Parameters<typeof MarketingNav>[0] = {}) =>
+  render(
+    <ThemeProvider>
+      <MarketingNav {...props} />
+    </ThemeProvider>,
+  );
+
+describe("MarketingNav (parity canon, SKILL.md 2026-07-19)", () => {
+  it("renders the four canonical links with the ratified hrefs", () => {
+    renderNav();
+    expect(NAV_LINKS.map((l) => l.label)).toEqual(["Features", "Dashboards", "Docs", "GitHub"]);
+    expect(screen.getByRole("link", { name: "Features" })).toHaveAttribute("href", "/#pillars");
+    expect(screen.getByRole("link", { name: "Dashboards" })).toHaveAttribute("href", "/dashboard");
+    expect(screen.getByRole("link", { name: "Docs" })).toHaveAttribute(
+      "href",
+      "https://cuesoft.gitbook.io/upstat",
+    );
+    expect(screen.getByRole("link", { name: "GitHub" })).toHaveAttribute(
+      "href",
+      "https://github.com/cuesoftinc/upstat",
+    );
   });
 
-  it("shows the runtime star count when provided", () => {
-    render(<MarketingNav starCount={1284} />);
-    expect(screen.getByText("1,284")).toBeInTheDocument();
+  it("carries the theme toggle and the Sign in CTA", () => {
+    renderNav();
+    expect(screen.getByTestId("theme-toggle")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Sign in" })).toBeInTheDocument();
   });
 
-  it("opens the pillar dropdown as a mini feature map ×8 (A1)", async () => {
-    render(<MarketingNav />);
-    await userEvent.click(screen.getByRole("button", { name: "Platform" }));
-    const menu = screen.getByRole("menu", { name: "Platform pillars" });
-    expect(menu.querySelectorAll("[data-pillar]")).toHaveLength(8);
+  it("shows the runtime star count on the GitHub link when provided (never static)", () => {
+    renderNav({ starCount: 1284 });
+    expect(screen.getByRole("link", { name: /GitHub/ })).toHaveTextContent("1,284");
+  });
+
+  it("keeps the GitHub link neutral without a runtime count", () => {
+    renderNav();
+    expect(screen.getByRole("link", { name: "GitHub" })).toHaveTextContent(/^GitHub$/);
   });
 });

--- a/web/src/components/ui/MarketingNav.tsx
+++ b/web/src/components/ui/MarketingNav.tsx
@@ -3,12 +3,13 @@
 import { useState } from "react";
 import { clsx } from "clsx";
 import Link from "next/link";
-import { Menu, X, Zap } from "lucide-react";
+import { Menu, Star, X, Zap } from "lucide-react";
 import { Button } from "./Button";
 import { ThemeToggle } from "./ThemeToggle";
 
 export interface MarketingNavProps {
   onSignIn?: () => void;
+  onTryCloud?: () => void;
   /** Live GitHub star count — populated at runtime, never a static number (A13). */
   starCount?: number | null;
   className?: string;
@@ -23,10 +24,45 @@ export const NAV_LINKS = [
 ] as const;
 
 /**
- * MarketingNav — nav-parity canon (SKILL.md, 2026-07-19; supersedes the A1
- * pillar-dropdown shape): logo · Features · Dashboards · Docs · GitHub ·
- * ThemeToggle · Sign in CTA (/signin). The GitHub link carries the runtime
- * star count when one arrives — never a static number (§8.2b).
+ * StarBadge — the GitHub nav item as a compact star chip (canon revision
+ * 2026-07-19): star glyph + "Star" + the live runtime count when one
+ * arrives. Neutral "Star" in TEST_MODE or on fetch failure — never a
+ * static number (§8.2b).
+ */
+function StarBadge({
+  starCount,
+  onClick,
+  className,
+}: {
+  starCount: number | null;
+  onClick?: () => void;
+  className?: string;
+}) {
+  return (
+    <a
+      href="https://github.com/cuesoftinc/upstat"
+      target="_blank"
+      rel="noreferrer"
+      aria-label="Star cuesoftinc/upstat on GitHub"
+      onClick={onClick}
+      className={clsx(
+        "items-center gap-1.5 font-medium text-text-2 transition-colors duration-[var(--duration-fast)]",
+        className,
+      )}
+    >
+      <Star aria-hidden="true" className="size-3.5" />
+      Star
+      {typeof starCount === "number" && (
+        <span className="tabular-nums text-text">{starCount.toLocaleString()}</span>
+      )}
+    </a>
+  );
+}
+
+/**
+ * MarketingNav — nav-parity canon (SKILL.md 2026-07-19, revised same day):
+ * logo · Features · Dashboards · Docs · GitHub star badge · ThemeToggle ·
+ * Sign in text link · Try Cloud primary CTA (both → /signin).
  *
  * The bar (border/background) is full-bleed, but the ROW sits on the
  * marketing container (design.md §2: 1152px content at 1440, rails
@@ -34,10 +70,15 @@ export const NAV_LINKS = [
  *
  * Mobile (SKILL.md mobile clause): below `md` the text links collapse into
  * a menu-button disclosure (hamburger, `aria-expanded`) opening a panel
- * with the same 4 links + ThemeToggle + Sign in — no canonical link may be
- * unreachable at any viewport.
+ * with the same 4 links + ThemeToggle + Sign in + Try Cloud — no canonical
+ * link may be unreachable at any viewport.
  */
-export function MarketingNav({ onSignIn, starCount = null, className }: MarketingNavProps) {
+export function MarketingNav({
+  onSignIn,
+  onTryCloud,
+  starCount = null,
+  className,
+}: MarketingNavProps) {
   const [menuOpen, setMenuOpen] = useState(false);
   return (
     <nav
@@ -66,27 +107,39 @@ export function MarketingNav({ onSignIn, starCount = null, className }: Marketin
           upstat
         </Link>
 
-        {NAV_LINKS.map((link) => (
-          <a
-            key={link.label}
-            href={link.href}
-            {...(link.external ? { target: "_blank", rel: "noreferrer" } : {})}
-            className="hidden text-[13px] font-medium text-text-2 transition-colors duration-[var(--duration-fast)] hover:text-text md:block"
-          >
-            {link.label}
-            {link.label === "GitHub" && typeof starCount === "number" && (
-              <span className="ml-1.5 tabular-nums text-text">
-                {starCount.toLocaleString()}
-              </span>
-            )}
-          </a>
-        ))}
+        {NAV_LINKS.map((link) =>
+          link.label === "GitHub" ? (
+            <StarBadge
+              key={link.label}
+              starCount={starCount}
+              className="hidden h-7 rounded-(--radius) border border-border px-2 text-[12px] hover:border-text-2 hover:text-text md:flex"
+            />
+          ) : (
+            <a
+              key={link.label}
+              href={link.href}
+              {...(link.external ? { target: "_blank", rel: "noreferrer" } : {})}
+              className="hidden text-[13px] font-medium text-text-2 transition-colors duration-[var(--duration-fast)] hover:text-text md:block"
+            >
+              {link.label}
+            </a>
+          ),
+        )}
 
         <div className="flex-1" />
 
         <ThemeToggle className="hidden md:block" />
-        <Button kind="brand" onClick={onSignIn} className="hidden md:inline-flex">
+        {/* href carries the semantics (middle-click, copy link); onClick
+            halts the hero rAF loop before the transition (useHomeController) */}
+        <Link
+          href="/signin"
+          onClick={onSignIn}
+          className="hidden text-[13px] font-medium text-text-2 transition-colors duration-[var(--duration-fast)] hover:text-text md:block"
+        >
           Sign in
+        </Link>
+        <Button kind="brand" onClick={onTryCloud} className="hidden md:inline-flex">
+          Try Cloud
         </Button>
 
         {/* mobile disclosure trigger — the panel below carries the links */}
@@ -108,27 +161,49 @@ export function MarketingNav({ onSignIn, starCount = null, className }: Marketin
 
       {menuOpen && (
         <div id="marketing-menu" className="border-t border-border px-6 pt-2 pb-4 md:hidden">
-          {NAV_LINKS.map((link) => (
-            <a
-              key={link.label}
-              href={link.href}
-              {...(link.external ? { target: "_blank", rel: "noreferrer" } : {})}
-              onClick={() => setMenuOpen(false)}
-              className="block py-2.5 text-[14px] font-medium text-text-2 transition-colors duration-[var(--duration-fast)] hover:text-text"
-            >
-              {link.label}
-              {link.label === "GitHub" && typeof starCount === "number" && (
-                <span className="ml-1.5 tabular-nums text-text">
-                  {starCount.toLocaleString()}
-                </span>
-              )}
-            </a>
-          ))}
+          {NAV_LINKS.map((link) =>
+            link.label === "GitHub" ? (
+              <StarBadge
+                key={link.label}
+                starCount={starCount}
+                onClick={() => setMenuOpen(false)}
+                className="flex py-2.5 text-[14px] hover:text-text"
+              />
+            ) : (
+              <a
+                key={link.label}
+                href={link.href}
+                {...(link.external ? { target: "_blank", rel: "noreferrer" } : {})}
+                onClick={() => setMenuOpen(false)}
+                className="block py-2.5 text-[14px] font-medium text-text-2 transition-colors duration-[var(--duration-fast)] hover:text-text"
+              >
+                {link.label}
+              </a>
+            ),
+          )}
           <div className="mt-2 flex items-center justify-between border-t border-border pt-3">
             <ThemeToggle />
-            <Button kind="brand" onClick={onSignIn}>
-              Sign in
-            </Button>
+            <div className="flex items-center gap-4">
+              <Link
+                href="/signin"
+                onClick={() => {
+                  setMenuOpen(false);
+                  onSignIn?.();
+                }}
+                className="text-[14px] font-medium text-text-2 transition-colors duration-[var(--duration-fast)] hover:text-text"
+              >
+                Sign in
+              </Link>
+              <Button
+                kind="brand"
+                onClick={() => {
+                  setMenuOpen(false);
+                  onTryCloud?.();
+                }}
+              >
+                Try Cloud
+              </Button>
+            </div>
           </div>
         </div>
       )}

--- a/web/src/components/ui/MarketingNav.tsx
+++ b/web/src/components/ui/MarketingNav.tsx
@@ -2,38 +2,36 @@
 
 import { clsx } from "clsx";
 import Link from "next/link";
-import { ChevronDown, Star, Zap } from "lucide-react";
-import { useState } from "react";
+import { Zap } from "lucide-react";
 import { Button } from "./Button";
-import { MARKETING_PILLARS, PillarCard } from "./PillarCard";
+import { ThemeToggle } from "./ThemeToggle";
 
 export interface MarketingNavProps {
   onSignIn?: () => void;
-  onTryCloud?: () => void;
   /** Live GitHub star count — populated at runtime, never a static number (A13). */
   starCount?: number | null;
   className?: string;
 }
 
+/** The canonical nav links (SKILL.md nav-parity canon, 2026-07-19). */
+export const NAV_LINKS = [
+  { label: "Features", href: "/#pillars", external: false },
+  { label: "Dashboards", href: "/dashboard", external: false },
+  { label: "Docs", href: "https://cuesoft.gitbook.io/upstat", external: true },
+  { label: "GitHub", href: "https://github.com/cuesoftinc/upstat", external: true },
+] as const;
+
 /**
- * MarketingNav — pages.md A1: logo · Platform (pillar dropdown = mini
- * feature map ×8) · Docs · Community · GitHub badge · Sign in · Try Cloud.
- * Star badge is neutral ("Star") unless a runtime count arrives (§8.2b).
+ * MarketingNav — nav-parity canon (SKILL.md, 2026-07-19; supersedes the A1
+ * pillar-dropdown shape): logo · Features · Dashboards · Docs · GitHub ·
+ * ThemeToggle · Sign in CTA (/signin). The GitHub link carries the runtime
+ * star count when one arrives — never a static number (§8.2b).
  *
  * The bar (border/background) is full-bleed, but the ROW sits on the
- * marketing container (design.md §2, decided 2026-07-19: 1152px content at
- * 1440, rails x144/x1296) — the Figma master spans the container, it is not
- * pinned to the viewport edges. Without the cap, nav items hugged the
- * viewport on ultra-wide screens while every section stayed centered.
+ * marketing container (design.md §2: 1152px content at 1440, rails
+ * x144/x1296).
  */
-export function MarketingNav({
-  onSignIn,
-  onTryCloud,
-  starCount = null,
-  className,
-}: MarketingNavProps) {
-  const [dropdownOpen, setDropdownOpen] = useState(false);
-
+export function MarketingNav({ onSignIn, starCount = null, className }: MarketingNavProps) {
   return (
     <nav
       aria-label="Marketing"
@@ -61,83 +59,27 @@ export function MarketingNav({
           upstat
         </Link>
 
-        <div
-          className="relative hidden md:block"
-          onMouseEnter={() => setDropdownOpen(true)}
-          onMouseLeave={() => setDropdownOpen(false)}
-        >
-          <button
-            type="button"
-            aria-expanded={dropdownOpen}
-            // Open-only: hover already opened it — a toggle would close on the
-            // very click that follows the hover. Escape / mouse-leave close.
-            onClick={() => setDropdownOpen(true)}
-            onKeyDown={(e) => {
-              if (e.key === "Escape") setDropdownOpen(false);
-            }}
-            className="flex items-center gap-1 rounded-(--radius) px-2 py-1.5 text-[13px] font-medium text-text-2 transition-colors duration-[var(--duration-fast)] hover:text-text"
+        {NAV_LINKS.map((link) => (
+          <a
+            key={link.label}
+            href={link.href}
+            {...(link.external ? { target: "_blank", rel: "noreferrer" } : {})}
+            className="hidden text-[13px] font-medium text-text-2 transition-colors duration-[var(--duration-fast)] hover:text-text md:block"
           >
-            Platform
-            <ChevronDown
-              aria-hidden="true"
-              className={clsx(
-                "size-3.5 transition-transform duration-[var(--duration-fast)]",
-                dropdownOpen && "rotate-180",
-              )}
-            />
-          </button>
-          {dropdownOpen && (
-            <div
-              role="menu"
-              aria-label="Platform pillars"
-              className="absolute left-0 top-full z-[var(--z-dropdown)] grid w-[560px] grid-cols-2 gap-2 rounded-(--radius) border border-border bg-bg-elev p-3 shadow-xl"
-            >
-              {MARKETING_PILLARS.map((pillar) => (
-                <PillarCard key={pillar.pillar} {...pillar} compact />
-              ))}
-            </div>
-          )}
-        </div>
-
-        <a
-          href="https://docs.upstat.cuesoft.io"
-          className="hidden text-[13px] font-medium text-text-2 hover:text-text md:block"
-        >
-          Docs
-        </a>
-        <a
-          href="#community"
-          className="hidden text-[13px] font-medium text-text-2 hover:text-text md:block"
-        >
-          Community
-        </a>
+            {link.label}
+            {link.label === "GitHub" && typeof starCount === "number" && (
+              <span className="ml-1.5 tabular-nums text-text">
+                {starCount.toLocaleString()}
+              </span>
+            )}
+          </a>
+        ))}
 
         <div className="flex-1" />
 
-        <a
-          href="https://github.com/cuesoftinc/upstat"
-          target="_blank"
-          rel="noreferrer"
-          className="flex h-7 items-center gap-1.5 rounded-(--radius) border border-border px-2 text-[12px] font-medium text-text-2 transition-colors duration-[var(--duration-fast)] hover:border-text-2 hover:text-text"
-        >
-          <Star aria-hidden="true" className="size-3.5" />
-          Star
-          {typeof starCount === "number" && (
-            <span className="tabular-nums text-text">
-              {starCount.toLocaleString()}
-            </span>
-          )}
-        </a>
-
-        <button
-          type="button"
-          onClick={onSignIn}
-          className="text-[13px] font-medium text-text-2 transition-colors duration-[var(--duration-fast)] hover:text-text"
-        >
+        <ThemeToggle />
+        <Button kind="brand" onClick={onSignIn}>
           Sign in
-        </button>
-        <Button kind="brand" onClick={onTryCloud}>
-          Try Cloud
         </Button>
       </div>
     </nav>

--- a/web/src/components/ui/MarketingNav.tsx
+++ b/web/src/components/ui/MarketingNav.tsx
@@ -1,8 +1,9 @@
 "use client";
 
+import { useState } from "react";
 import { clsx } from "clsx";
 import Link from "next/link";
-import { Zap } from "lucide-react";
+import { Menu, X, Zap } from "lucide-react";
 import { Button } from "./Button";
 import { ThemeToggle } from "./ThemeToggle";
 
@@ -30,8 +31,14 @@ export const NAV_LINKS = [
  * The bar (border/background) is full-bleed, but the ROW sits on the
  * marketing container (design.md §2: 1152px content at 1440, rails
  * x144/x1296).
+ *
+ * Mobile (SKILL.md mobile clause): below `md` the text links collapse into
+ * a menu-button disclosure (hamburger, `aria-expanded`) opening a panel
+ * with the same 4 links + ThemeToggle + Sign in — no canonical link may be
+ * unreachable at any viewport.
  */
 export function MarketingNav({ onSignIn, starCount = null, className }: MarketingNavProps) {
+  const [menuOpen, setMenuOpen] = useState(false);
   return (
     <nav
       aria-label="Marketing"
@@ -77,11 +84,54 @@ export function MarketingNav({ onSignIn, starCount = null, className }: Marketin
 
         <div className="flex-1" />
 
-        <ThemeToggle />
-        <Button kind="brand" onClick={onSignIn}>
+        <ThemeToggle className="hidden md:block" />
+        <Button kind="brand" onClick={onSignIn} className="hidden md:inline-flex">
           Sign in
         </Button>
+
+        {/* mobile disclosure trigger — the panel below carries the links */}
+        <button
+          type="button"
+          aria-label="Menu"
+          aria-expanded={menuOpen}
+          aria-controls="marketing-menu"
+          onClick={() => setMenuOpen((open) => !open)}
+          className="rounded-(--radius) p-1.5 text-text-2 transition-colors duration-[var(--duration-fast)] ease-standard hover:bg-bg-elev hover:text-text md:hidden"
+        >
+          {menuOpen ? (
+            <X aria-hidden="true" className="size-4.5" />
+          ) : (
+            <Menu aria-hidden="true" className="size-4.5" />
+          )}
+        </button>
       </div>
+
+      {menuOpen && (
+        <div id="marketing-menu" className="border-t border-border px-6 pt-2 pb-4 md:hidden">
+          {NAV_LINKS.map((link) => (
+            <a
+              key={link.label}
+              href={link.href}
+              {...(link.external ? { target: "_blank", rel: "noreferrer" } : {})}
+              onClick={() => setMenuOpen(false)}
+              className="block py-2.5 text-[14px] font-medium text-text-2 transition-colors duration-[var(--duration-fast)] hover:text-text"
+            >
+              {link.label}
+              {link.label === "GitHub" && typeof starCount === "number" && (
+                <span className="ml-1.5 tabular-nums text-text">
+                  {starCount.toLocaleString()}
+                </span>
+              )}
+            </a>
+          ))}
+          <div className="mt-2 flex items-center justify-between border-t border-border pt-3">
+            <ThemeToggle />
+            <Button kind="brand" onClick={onSignIn}>
+              Sign in
+            </Button>
+          </div>
+        </div>
+      )}
     </nav>
   );
 }

--- a/web/src/components/ui/NavRail.test.tsx
+++ b/web/src/components/ui/NavRail.test.tsx
@@ -1,10 +1,14 @@
-import { describe, expect, it, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { House } from "lucide-react";
-import { NavRail, NavRailItem, NAV_PILLARS } from "./NavRail";
+import { NavRail, NavRailItem, NAV_PILLARS, NAV_SECTIONS } from "./NavRail";
 
 describe("NavRail", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
   it("renders the 12 pillars with the active one marked", () => {
     render(<NavRail activeKey="logs" />);
     expect(NAV_PILLARS).toHaveLength(12);
@@ -20,6 +24,48 @@ describe("NavRail", () => {
     await userEvent.click(screen.getByRole("button", { name: "Monitors" }));
     expect(onNavigate).toHaveBeenCalledWith("monitors");
   });
+
+  /* [Directive 2026-07-19] expandable rail — design.md §2 */
+
+  it("sections cover every pillar in B order (Telemetry/Respond/Platform)", () => {
+    expect(NAV_SECTIONS.map((s) => s.title)).toEqual([null, "Telemetry", "Respond", "Platform"]);
+    expect(NAV_SECTIONS.flatMap((s) => s.keys)).toEqual(NAV_PILLARS.map((p) => p.key));
+  });
+
+  it("foot toggle expands the rail: aria-expanded, labels + group headers", async () => {
+    render(<NavRail activeKey="home" />);
+    const toggle = screen.getByTestId("rail-toggle");
+    // jsdom matchMedia is non-matching → collapsed default (viewport <1280)
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByText("Telemetry")).toBeNull();
+
+    await userEvent.click(toggle);
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+    for (const title of ["Telemetry", "Respond", "Platform"]) {
+      expect(screen.getByText(title)).toBeInTheDocument();
+    }
+    // labels render inline (visible text, not just the aria-label)
+    expect(screen.getByText("Dashboards")).toBeInTheDocument();
+  });
+
+  it("persists the expansion choice under nav.rail.expanded", async () => {
+    const { unmount } = render(<NavRail activeKey="home" />);
+    await userEvent.click(screen.getByTestId("rail-toggle"));
+    expect(window.localStorage.getItem("nav.rail.expanded")).toBe("1");
+    unmount();
+
+    render(<NavRail activeKey="home" />);
+    // stored choice resolves a tick after mount (deferred effect)
+    await waitFor(() =>
+      expect(screen.getByTestId("rail-toggle")).toHaveAttribute("aria-expanded", "true"),
+    );
+  });
+
+  it("honors a stored collapsed choice over the viewport default", () => {
+    window.localStorage.setItem("nav.rail.expanded", "0");
+    render(<NavRail activeKey="home" />);
+    expect(screen.getByTestId("rail-toggle")).toHaveAttribute("aria-expanded", "false");
+  });
 });
 
 describe("NavRailItem", () => {
@@ -28,5 +74,12 @@ describe("NavRailItem", () => {
     expect(screen.queryByRole("tooltip")).toBeNull();
     await userEvent.hover(screen.getByRole("button", { name: "Home" }));
     expect(screen.getByRole("tooltip")).toHaveTextContent("Home");
+  });
+
+  it("expanded rows carry the inline label and never the flyout", async () => {
+    render(<NavRailItem icon={House} label="Home" expanded />);
+    expect(screen.getByText("Home")).toBeInTheDocument();
+    await userEvent.hover(screen.getByRole("button", { name: "Home" }));
+    expect(screen.queryByRole("tooltip")).toBeNull();
   });
 });

--- a/web/src/components/ui/NavRail.tsx
+++ b/web/src/components/ui/NavRail.tsx
@@ -7,6 +7,8 @@ import {
   BarChart3,
   Bell,
   BookOpen,
+  ChevronsLeft,
+  ChevronsRight,
   Flame,
   Gauge,
   House,
@@ -16,7 +18,7 @@ import {
   Settings,
   Target,
 } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 export interface NavRailItemProps {
   icon: LucideIcon;
@@ -24,10 +26,24 @@ export interface NavRailItemProps {
   active?: boolean;
   href?: string;
   onClick?: () => void;
+  /** layout=expanded — icon + inline label row, no flyout (design.md §2
+   *  [Directive 2026-07-19] expandable rail). Default stays the 56px rail
+   *  behavior, so existing call sites are untouched. */
+  expanded?: boolean;
 }
 
-/** NavRailItem — §8.2b: default / hover (flyout label) / active (brand accent). */
-export function NavRailItem({ icon: Icon, label, active = false, onClick }: NavRailItemProps) {
+/**
+ * NavRailItem — §8.2b: default / hover (flyout label) / active (brand
+ * accent bar + brand icon, both layouts). `expanded` renders the 228px
+ * icon+label row ([Directive 2026-07-19]); collapsed keeps the flyout.
+ */
+export function NavRailItem({
+  icon: Icon,
+  label,
+  active = false,
+  onClick,
+  expanded = false,
+}: NavRailItemProps) {
   const [hover, setHover] = useState(false);
   return (
     <div className="relative">
@@ -39,16 +55,27 @@ export function NavRailItem({ icon: Icon, label, active = false, onClick }: NavR
         onMouseEnter={() => setHover(true)}
         onMouseLeave={() => setHover(false)}
         className={clsx(
-          "flex size-10 items-center justify-center rounded-(--radius)",
+          "relative flex h-10 items-center rounded-(--radius)",
+          expanded ? "w-full gap-3 px-2.5 text-left" : "size-10 justify-center",
           "transition-colors duration-[var(--duration-fast)] ease-standard",
           active
             ? "bg-brand/15 text-brand"
             : "text-text-2 hover:bg-bg-elev hover:text-text",
         )}
       >
-        <Icon className="size-5" strokeWidth={active ? 2.2 : 2} />
+        {/* active = brand accent bar + brand icon in both states (§2) */}
+        {active && (
+          <span
+            aria-hidden="true"
+            className="absolute inset-y-2 left-0 w-0.5 rounded-full bg-brand"
+          />
+        )}
+        <Icon className="size-5 shrink-0" strokeWidth={active ? 2.2 : 2} />
+        {expanded && (
+          <span className="truncate text-[13px] font-medium">{label}</span>
+        )}
       </button>
-      {hover && (
+      {!expanded && hover && (
         <span
           role="tooltip"
           className={clsx(
@@ -80,38 +107,158 @@ export const NAV_PILLARS: { key: string; label: string; icon: LucideIcon }[] = [
   { key: "settings", label: "Settings", icon: Settings },
 ];
 
+/**
+ * Pillar section groups (design.md §2 Telemetry / Respond / Platform,
+ * [Directive 2026-07-19]) — B-order preserved; Home stays ungrouped at
+ * the top of the rail.
+ */
+export const NAV_SECTIONS: { title: string | null; keys: string[] }[] = [
+  { title: null, keys: ["home"] },
+  { title: "Telemetry", keys: ["dashboards", "metrics", "logs", "traces", "rum", "uptime"] },
+  { title: "Respond", keys: ["monitors", "incidents", "slos"] },
+  { title: "Platform", keys: ["catalog", "settings"] },
+];
+
+/** design.md §2: the persisted expansion choice. */
+const EXPANDED_STORAGE_KEY = "nav.rail.expanded";
+/** Expanded is the default at ≥1280px; collapsed below (design.md §2). */
+const EXPAND_DEFAULT_QUERY = "(min-width: 1280px)";
+
+/**
+ * Rail expansion state — persisted per user (localStorage), defaulting by
+ * viewport. Resolved after mount: SSR renders collapsed, so hydration
+ * stays deterministic.
+ */
+function useRailExpanded(): [boolean, () => void] {
+  const [expanded, setExpanded] = useState(false);
+
+  // Deferred a tick (use-request pattern): setState stays out of the
+  // synchronous effect body.
+  useEffect(() => {
+    const t = window.setTimeout(() => {
+      try {
+        const stored = window.localStorage.getItem(EXPANDED_STORAGE_KEY);
+        if (stored !== null) {
+          setExpanded(stored === "1");
+          return;
+        }
+      } catch {
+        /* storage unavailable (private mode) — fall through to viewport */
+      }
+      setExpanded(window.matchMedia(EXPAND_DEFAULT_QUERY).matches);
+    }, 0);
+    return () => window.clearTimeout(t);
+  }, []);
+
+  const toggle = () => {
+    setExpanded((prev) => {
+      const next = !prev;
+      try {
+        window.localStorage.setItem(EXPANDED_STORAGE_KEY, next ? "1" : "0");
+      } catch {
+        /* non-persistent environments still toggle in-memory */
+      }
+      return next;
+    });
+  };
+
+  return [expanded, toggle];
+}
+
 export interface NavRailProps {
   activeKey: string;
   onNavigate?: (key: string) => void;
   className?: string;
 }
 
-/** NavRail — 56px icon rail with flyout labels (§2 layout; §8.2b chrome). */
+/**
+ * NavRail — product nav (design.md §2, [Directive 2026-07-19] expandable
+ * rail supersedes flyout-only): collapsed 56px icon rail ⇄ expanded 240px
+ * icon+label rows in Telemetry/Respond/Platform groups. Foot chevron
+ * toggles; the choice persists (`nav.rail.expanded`); expanded is the
+ * ≥1280px default.
+ */
 export function NavRail({ activeKey, onNavigate, className }: NavRailProps) {
+  const [expanded, toggleExpanded] = useRailExpanded();
+  const byKey = new Map(NAV_PILLARS.map((p) => [p.key, p]));
   return (
     <nav
       aria-label="Product navigation"
+      data-expanded={expanded}
       className={clsx(
-        "sticky top-0 z-[var(--z-sticky)] flex h-screen w-14 flex-col items-center gap-1",
+        "sticky top-0 z-[var(--z-sticky)] flex h-dvh flex-col gap-1",
         "border-r border-border bg-bg py-2",
+        "transition-[width] duration-[var(--duration-base)] ease-standard motion-reduce:transition-none",
+        expanded ? "w-60 items-stretch px-1.5" : "w-14 items-center",
         className,
       )}
     >
       <span
         aria-hidden="true"
-        className="font-ui mb-2 flex size-8 items-center justify-center rounded-(--radius) bg-brand text-[14px] font-semibold text-on-brand"
+        className={clsx(
+          "font-ui mb-2 flex h-8 items-center gap-2",
+          expanded ? "px-1" : "justify-center",
+        )}
       >
-        U
+        <span className="flex size-8 shrink-0 items-center justify-center rounded-(--radius) bg-brand text-[14px] font-semibold text-on-brand">
+          U
+        </span>
+        {expanded && <span className="text-[14px] font-semibold text-text">upstat</span>}
       </span>
-      {NAV_PILLARS.map((pillar) => (
-        <NavRailItem
-          key={pillar.key}
-          icon={pillar.icon}
-          label={pillar.label}
-          active={pillar.key === activeKey}
-          onClick={() => onNavigate?.(pillar.key)}
-        />
+
+      {NAV_SECTIONS.map((section) => (
+        <div
+          key={section.title ?? "top"}
+          className={clsx("flex flex-col gap-1", expanded ? "items-stretch" : "items-center")}
+        >
+          {section.title ? (
+            expanded ? (
+              <span className="mt-3 px-2.5 pb-1 text-[11px] font-medium uppercase tracking-wide text-text-2">
+                {section.title}
+              </span>
+            ) : (
+              // collapsed keeps the grouping legible as hairline breaks
+              <span aria-hidden="true" className="my-1.5 h-px w-6 bg-border" />
+            )
+          ) : null}
+          {section.keys.map((key) => {
+            const pillar = byKey.get(key);
+            if (!pillar) return null;
+            return (
+              <NavRailItem
+                key={pillar.key}
+                icon={pillar.icon}
+                label={pillar.label}
+                active={pillar.key === activeKey}
+                expanded={expanded}
+                onClick={() => onNavigate?.(pillar.key)}
+              />
+            );
+          })}
+        </div>
       ))}
+
+      <button
+        type="button"
+        data-testid="rail-toggle"
+        aria-label={expanded ? "Collapse navigation" : "Expand navigation"}
+        aria-expanded={expanded}
+        onClick={toggleExpanded}
+        className={clsx(
+          "mt-auto flex h-9 items-center rounded-(--radius) text-text-2",
+          "transition-colors duration-[var(--duration-fast)] ease-standard hover:bg-bg-elev hover:text-text",
+          expanded ? "w-full gap-3 px-2.5" : "size-9 justify-center",
+        )}
+      >
+        {expanded ? (
+          <>
+            <ChevronsLeft aria-hidden="true" className="size-4.5 shrink-0" />
+            <span className="truncate text-[12px]">Collapse</span>
+          </>
+        ) : (
+          <ChevronsRight aria-hidden="true" className="size-4.5" />
+        )}
+      </button>
     </nav>
   );
 }

--- a/web/src/components/ui/QueryBar.test.tsx
+++ b/web/src/components/ui/QueryBar.test.tsx
@@ -33,4 +33,28 @@ describe("QueryBar", () => {
     await userEvent.click(screen.getByRole("button", { name: /service:\s*7/ }));
     expect(onPick).toHaveBeenCalledWith({ text: "service:", cardinality: 7 });
   });
+
+  it("filters suggestions to the typed token and Tab-completes the best match (MI-13)", async () => {
+    const onPick = vi.fn();
+    render(
+      <QueryBar
+        pills={[]}
+        text="metric:http.err"
+        onTextChange={() => undefined}
+        suggestions={[
+          { text: "service:clickhouse", cardinality: 7133 },
+          { text: "metric:http.request.duration_ms", cardinality: 1240 },
+          { text: "metric:http.errors_total", cardinality: 412 },
+        ]}
+        onPickSuggestion={onPick}
+      />,
+    );
+    await userEvent.click(screen.getByLabelText("Query"));
+    // non-matching, higher-cardinality entries stay out of the list — an
+    // unfiltered list made Tab insert an unrelated pill (QA 2026-07-19)
+    expect(screen.queryByText("service:clickhouse")).toBeNull();
+    expect(screen.getByText("metric:http.errors_total")).toBeInTheDocument();
+    await userEvent.keyboard("{Tab}");
+    expect(onPick).toHaveBeenCalledWith({ text: "metric:http.errors_total", cardinality: 412 });
+  });
 });

--- a/web/src/components/ui/QueryBar.tsx
+++ b/web/src/components/ui/QueryBar.tsx
@@ -48,7 +48,15 @@ export function QueryBar({
 }: QueryBarProps) {
   const [focused, setFocused] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
-  const open = focused && suggestions.length > 0 && text.length > 0;
+  // MI-13: suggestions match what's being typed (last whitespace-separated
+  // token), keeping the caller's cardinality ranking — an unfiltered list
+  // makes Tab complete something unrelated to the input. Display caps at 8
+  // AFTER filtering (a pre-filter cap hides valid matches).
+  const token = text.split(/\s+/).pop()?.toLowerCase() ?? "";
+  const matching = (
+    token ? suggestions.filter((s) => s.text.toLowerCase().includes(token)) : suggestions
+  ).slice(0, 8);
+  const open = focused && matching.length > 0 && text.length > 0;
 
   return (
     <div className={clsx("font-ui relative w-full", className)}>
@@ -83,9 +91,9 @@ export function QueryBar({
           onBlur={() => setFocused(false)}
           onKeyDown={(e) => {
             if (e.key === "Enter") onSubmit?.();
-            if (e.key === "Tab" && open && suggestions[0]) {
+            if (e.key === "Tab" && open && matching[0]) {
               e.preventDefault();
-              onPickSuggestion?.(suggestions[0]);
+              onPickSuggestion?.(matching[0]);
             }
           }}
           placeholder={pills.length === 0 ? placeholder : undefined}
@@ -111,7 +119,7 @@ export function QueryBar({
           aria-label="Query suggestions"
           className="absolute left-0 top-full z-[var(--z-dropdown)] mt-1 w-full rounded-(--radius) border border-border bg-bg-elev py-1 shadow-lg"
         >
-          {suggestions.map((s) => (
+          {matching.map((s) => (
             <li key={s.text}>
               <button
                 type="button"

--- a/web/src/components/ui/SettingsRow.test.tsx
+++ b/web/src/components/ui/SettingsRow.test.tsx
@@ -22,4 +22,22 @@ describe("SettingsRow", () => {
     );
     expect(container.querySelector('[data-disabled="true"]')).not.toBeNull();
   });
+
+  it("disabled gates the control slot — embedded controls go inert (review class 2026-07-19)", () => {
+    // browsers enforce `inert` (unfocusable, unclickable, out of the a11y
+    // tree); the assertion pins the attribute on the slot wrapper
+    render(
+      <SettingsRow
+        label="Retention override"
+        control={<button type="button">change</button>}
+        disabled
+      />,
+    );
+    expect(screen.getByText("change").closest("[inert]")).not.toBeNull();
+  });
+
+  it("keeps the control slot live when enabled", () => {
+    render(<SettingsRow label="Digest" control={<button type="button">edit</button>} />);
+    expect(screen.getByRole("button", { name: "edit" }).closest("[inert]")).toBeNull();
+  });
 });

--- a/web/src/components/ui/SettingsRow.tsx
+++ b/web/src/components/ui/SettingsRow.tsx
@@ -29,7 +29,12 @@ export function SettingsRow({ label, description, control, disabled = false, cla
           <span className="text-[12px] leading-[1.45] text-text-2">{description}</span>
         )}
       </div>
-      <div className="shrink-0">{control}</div>
+      {/* inert gates the WHOLE slot: a disabled composite must disable its
+          embedded controls too, not just dim them (review class 2026-07-19 —
+          apparule's disabled Chip left its ✕ live). */}
+      <div className="shrink-0" inert={disabled || undefined}>
+        {control}
+      </div>
     </div>
   );
 }

--- a/web/src/components/ui/ShortcutCheatsheet.test.tsx
+++ b/web/src/components/ui/ShortcutCheatsheet.test.tsx
@@ -1,5 +1,6 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { ShortcutCheatsheet } from "./ShortcutCheatsheet";
 
 describe("ShortcutCheatsheet", () => {
@@ -12,5 +13,12 @@ describe("ShortcutCheatsheet", () => {
   it("renders nothing when closed", () => {
     const { container } = render(<ShortcutCheatsheet open={false} />);
     expect(container).toBeEmptyDOMElement();
+  });
+
+  it("closes on Escape (MI-17 — keyboard users aren't trapped)", async () => {
+    const onClose = vi.fn();
+    render(<ShortcutCheatsheet open onClose={onClose} />);
+    await userEvent.keyboard("{Escape}");
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 });

--- a/web/src/components/ui/ShortcutCheatsheet.tsx
+++ b/web/src/components/ui/ShortcutCheatsheet.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { clsx } from "clsx";
+import { useEffect } from "react";
 import { KbdChip } from "./KbdChip";
 
 export interface ShortcutEntry {
@@ -34,6 +35,17 @@ export function ShortcutCheatsheet({
   shortcuts = DEFAULT_SHORTCUTS,
   className,
 }: ShortcutCheatsheetProps) {
+  // ESC dismisses the overlay (MI-17 — the `?` sheet trapped keyboard
+  // users behind a click-only backdrop; system-QA finding 2026-07-19)
+  useEffect(() => {
+    if (!open) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose?.();
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [open, onClose]);
+
   if (!open) return null;
   return (
     <div

--- a/web/src/components/ui/ThemeToggle.test.tsx
+++ b/web/src/components/ui/ThemeToggle.test.tsx
@@ -1,0 +1,27 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "@/design/ThemeProvider";
+import { ThemeToggle } from "./ThemeToggle";
+
+describe("ThemeToggle", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    document.documentElement.removeAttribute("data-theme");
+  });
+
+  it("flips dark ⇄ light with a labelled control", async () => {
+    render(
+      <ThemeProvider>
+        <ThemeToggle />
+      </ThemeProvider>,
+    );
+    const toggle = screen.getByTestId("theme-toggle");
+    expect(toggle).toHaveAccessibleName("Switch to light theme");
+    await userEvent.click(toggle);
+    expect(document.documentElement).toHaveAttribute("data-theme", "light");
+    expect(toggle).toHaveAccessibleName("Switch to dark theme");
+    await userEvent.click(toggle);
+    expect(document.documentElement).not.toHaveAttribute("data-theme");
+  });
+});

--- a/web/src/components/ui/ThemeToggle.tsx
+++ b/web/src/components/ui/ThemeToggle.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { clsx } from "clsx";
+import { Moon, Sun } from "lucide-react";
+import { useTheme } from "@/design/ThemeProvider";
+
+export interface ThemeToggleProps {
+  className?: string;
+}
+
+/**
+ * ThemeToggle — light/dark flip (SKILL.md theme-parity canon). Lives in the
+ * marketing nav, the dashboard TopBar utility area and Settings; the choice
+ * persists via ThemeProvider (`upstat.theme`).
+ */
+export function ThemeToggle({ className }: ThemeToggleProps) {
+  const { theme, setTheme } = useTheme();
+  const next = theme === "dark" ? "light" : "dark";
+  return (
+    <button
+      type="button"
+      data-testid="theme-toggle"
+      aria-label={`Switch to ${next} theme`}
+      onClick={() => setTheme(next)}
+      className={clsx(
+        "rounded-(--radius) p-1.5 text-text-2",
+        "transition-colors duration-[var(--duration-fast)] ease-standard hover:bg-bg-elev hover:text-text",
+        className,
+      )}
+    >
+      {theme === "dark" ? (
+        <Sun aria-hidden="true" className="size-4.5" />
+      ) : (
+        <Moon aria-hidden="true" className="size-4.5" />
+      )}
+    </button>
+  );
+}

--- a/web/src/components/ui/TimeseriesPanel.test.tsx
+++ b/web/src/components/ui/TimeseriesPanel.test.tsx
@@ -41,4 +41,24 @@ describe("TimeseriesPanel", () => {
     rerender(<TimeseriesPanel title="t" series={SERIES} mode="area" />);
     expect(container.querySelector('[data-mode="area"]')).not.toBeNull();
   });
+
+  it("legend shows the distinguishing tag part of grouped names (QA 2026-07-19)", () => {
+    const grouped: Series[] = ["api-common", "web"].map((service) => ({
+      name: `p95(http.request.duration_ms) service:${service}`,
+      tags: { service },
+      points: SERIES[0].points,
+    }));
+    render(<TimeseriesPanel title="t" series={grouped} />);
+    // right-truncating the full names rendered N identical legend entries;
+    // the discriminating suffix is the label, the full name is the tooltip
+    const label = screen.getByText("service:api-common");
+    expect(label).toBeInTheDocument();
+    expect(label.closest("button")).toHaveAttribute(
+      "title",
+      "p95(http.request.duration_ms) service:api-common",
+    );
+    // ungrouped names still render in full
+    render(<TimeseriesPanel title="u" series={SERIES} />);
+    expect(screen.getByText("p95(http.request.duration_ms)")).toBeInTheDocument();
+  });
 });

--- a/web/src/components/ui/TimeseriesPanel.tsx
+++ b/web/src/components/ui/TimeseriesPanel.tsx
@@ -63,6 +63,18 @@ function formatTime(ts: string): string {
 }
 
 /**
+ * Legend label — the DISTINGUISHING part of a series name. Grouped query
+ * names ("p95(http.request.duration_ms) service:api-common") all share the
+ * fn(metric) prefix; truncating from the right rendered eight identical
+ * legend entries (system-QA finding 2026-07-19). Prefer the tag suffix;
+ * the full name stays on the title tooltip.
+ */
+function legendLabel(name: string): string {
+  const idx = name.indexOf(") ");
+  return idx === -1 ? name : name.slice(idx + 2);
+}
+
+/**
  * TimeseriesPanel — §3/§8.2: bespoke SVG line/area/bars, legend with
  * per-series toggle, synced crosshair (MI-2), loading (axis-first) and
  * empty (radar MI-16) states. Bars inset clear of the axis labels
@@ -355,11 +367,16 @@ export function TimeseriesPanel({
       {!loading && !empty && cursorIndex !== null && (
         <div className="font-data flex flex-wrap gap-x-4 gap-y-0.5 text-[11px] tabular-nums text-text-2">
           {visible.map((s) => (
-            <span key={s.name} className="inline-flex items-center gap-1">
+            <span key={s.name} className="inline-flex items-center gap-1" title={s.name}>
               <span
                 className="size-1.5 rounded-full"
                 style={{ background: seriesColor(series.indexOf(s)) }}
               />
+              {/* MI-2 "per-series values" — a bare number row wasn't
+                  attributable to a series; carry the short label */}
+              {visible.length > 1 && (
+                <span className="max-w-32 truncate">{legendLabel(s.name)}</span>
+              )}
               {s.points[cursorIndex]?.value === null
                 ? "—"
                 : formatValue(s.points[cursorIndex]?.value ?? 0)}
@@ -383,13 +400,14 @@ export function TimeseriesPanel({
                   return next;
                 })
               }
+              title={s.name}
               className={clsx(
                 "inline-flex items-center gap-1.5 text-[11px] transition-opacity duration-[var(--duration-fast)]",
                 hidden.has(s.name) ? "opacity-40" : "opacity-100",
               )}
             >
               <span className="size-2 rounded-[1px]" style={{ background: seriesColor(i) }} />
-              <span className="font-data max-w-48 truncate text-text-2">{s.name}</span>
+              <span className="font-data max-w-48 truncate text-text-2">{legendLabel(s.name)}</span>
             </button>
           ))}
         </footer>

--- a/web/src/components/ui/TopBar.test.tsx
+++ b/web/src/components/ui/TopBar.test.tsx
@@ -1,10 +1,18 @@
 import { describe, expect, it } from "vitest";
 import { render, screen } from "@testing-library/react";
+import { ThemeProvider } from "@/design/ThemeProvider";
 import { TopBar } from "./TopBar";
+
+const renderBar = (props: Parameters<typeof TopBar>[0]) =>
+  render(
+    <ThemeProvider>
+      <TopBar {...props} />
+    </ThemeProvider>,
+  );
 
 describe("TopBar", () => {
   it("carries org switcher, search hint and unread bell (MI-14)", () => {
-    render(<TopBar orgName="Upstat" unreadCount={3} />);
+    renderBar({ orgName: "Upstat", unreadCount: 3 });
     expect(screen.getByText("Upstat")).toBeInTheDocument();
     expect(screen.getByText("Search…")).toBeInTheDocument();
     expect(screen.getByLabelText("Notifications (3 unread)")).toBeInTheDocument();
@@ -12,7 +20,12 @@ describe("TopBar", () => {
   });
 
   it("keeps the bell calm without unread alerts", () => {
-    render(<TopBar orgName="Upstat" />);
+    renderBar({ orgName: "Upstat" });
     expect(screen.getByLabelText("Notifications")).toBeInTheDocument();
+  });
+
+  it("carries the theme toggle in the utility area (parity canon)", () => {
+    renderBar({ orgName: "Upstat" });
+    expect(screen.getByTestId("theme-toggle")).toBeInTheDocument();
   });
 });

--- a/web/src/components/ui/TopBar.tsx
+++ b/web/src/components/ui/TopBar.tsx
@@ -5,6 +5,7 @@ import { Bell, ChevronDown, Search } from "lucide-react";
 import type { ReactNode } from "react";
 import { CountBadge } from "./CountBadge";
 import { KbdChip } from "./KbdChip";
+import { ThemeToggle } from "./ThemeToggle";
 
 export interface TopBarProps {
   orgName: string;
@@ -66,6 +67,10 @@ export function TopBar({
         <span className="flex-1 text-left">Search…</span>
         <KbdChip keys="/" />
       </button>
+
+      {/* theme-parity canon (SKILL.md 2026-07-19): the toggle lives in the
+          chrome utility area, next to the bell */}
+      <ThemeToggle />
 
       <button
         type="button"

--- a/web/src/controllers/home.test.ts
+++ b/web/src/controllers/home.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from "vitest";
-import { buildHomeDemoData } from "./home";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { buildHomeDemoData, useHomeDemoData } from "./home";
 
 const NOW = Date.parse("2026-07-18T12:03:21Z");
 
@@ -46,5 +47,41 @@ describe("home demo data (A4 — synthetic, from the §8.3 mock seeds)", () => {
     expect(alertRule.signal).toBe("log");
     expect(alertRule.thresholds).toEqual({ warn: null, crit: 50, window: "5m" });
     expect(alertRule.state).toBe("alert");
+  });
+});
+
+describe("useHomeDemoData hydration determinism (React #418 regression, QA 2026-07-19)", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("first render is clock-independent (static prerender === hydration)", () => {
+    // The home page is prerendered at BUILD time; a Date.now()-seeded first
+    // render baked stale chart axis labels into the HTML and hydration threw
+    // React #418. The initial state must not depend on the system clock.
+    // Full fake timers: the deferred post-mount rebuild never fires, so
+    // result.current IS the first-render state.
+    const firstRenderAt = (epoch: string) => {
+      vi.useFakeTimers();
+      vi.setSystemTime(Date.parse(epoch));
+      const { result, unmount } = renderHook(() => useHomeDemoData());
+      const data = result.current;
+      unmount();
+      vi.useRealTimers();
+      return data;
+    };
+    const atBuildTime = firstRenderAt("2026-07-10T08:00:00Z");
+    const daysLater = firstRenderAt("2026-07-19T21:42:00Z");
+    expect(atBuildTime).toEqual(daysLater);
+  });
+
+  it("rebuilds with the real clock after mount (the '2m ago' label stays honest)", async () => {
+    // fake only Date: the deferred rebuild still runs on real timers
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(Date.parse("2026-07-19T21:42:00Z"));
+    const { result } = renderHook(() => useHomeDemoData());
+    await waitFor(() =>
+      expect(result.current.statusUpdatedAt).toBe("2026-07-19T21:40:00Z"),
+    );
   });
 });

--- a/web/src/controllers/home.ts
+++ b/web/src/controllers/home.ts
@@ -195,10 +195,24 @@ export function buildHomeDemoData(now: number): HomeDemoData {
   };
 }
 
+/**
+ * Pinned demo epoch for the FIRST render. The home page is statically
+ * prerendered at build time — seeding the demo with `Date.now()` bakes
+ * build-time chart axis labels into the HTML, and hydration (a different
+ * 5m bucket) then throws React #418 (text mismatch). First render is
+ * deterministic on both sides; a post-mount effect rebuilds with real now.
+ */
+const DEMO_EPOCH_MS = Date.parse("2026-07-18T09:00:00Z");
+
 export function useHomeDemoData(): HomeDemoData {
-  // lazy initializer: Date.now() runs once per mount (5m-snapped inside
-  // the builder, so SSR + hydration land in the same bucket)
-  const [data] = useState(() => buildHomeDemoData(Date.now()));
+  const [data, setData] = useState(() => buildHomeDemoData(DEMO_EPOCH_MS));
+  // real clock after hydration — "Last updated 2m ago" stays honest.
+  // Deferred a tick (use-request pattern): setState stays out of the
+  // synchronous effect body.
+  useEffect(() => {
+    const t = window.setTimeout(() => setData(buildHomeDemoData(Date.now())), 0);
+    return () => window.clearTimeout(t);
+  }, []);
   return data;
 }
 

--- a/web/src/design/ThemeProvider.test.tsx
+++ b/web/src/design/ThemeProvider.test.tsx
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  DEFAULT_THEME,
+  THEME_STORAGE_KEY,
+  ThemeProvider,
+  themeInitScript,
+  useTheme,
+} from "./ThemeProvider";
+
+function Probe() {
+  const { theme, setTheme } = useTheme();
+  return (
+    <button type="button" onClick={() => setTheme(theme === "dark" ? "light" : "dark")}>
+      theme:{theme}
+    </button>
+  );
+}
+
+describe("ThemeProvider (theme-parity canon, upstat.theme)", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    document.documentElement.removeAttribute("data-theme");
+  });
+
+  it("defaults to upstat's design default (dark) when unset", () => {
+    render(
+      <ThemeProvider>
+        <Probe />
+      </ThemeProvider>,
+    );
+    expect(DEFAULT_THEME).toBe("dark");
+    expect(screen.getByRole("button")).toHaveTextContent("theme:dark");
+    expect(document.documentElement).not.toHaveAttribute("data-theme");
+  });
+
+  it("light: sets data-theme on <html> and persists under upstat.theme", async () => {
+    render(
+      <ThemeProvider>
+        <Probe />
+      </ThemeProvider>,
+    );
+    await userEvent.click(screen.getByRole("button"));
+    expect(screen.getByRole("button")).toHaveTextContent("theme:light");
+    expect(document.documentElement).toHaveAttribute("data-theme", "light");
+    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe("light");
+
+    // and back: dark clears the attribute (the default needs none)
+    await userEvent.click(screen.getByRole("button"));
+    expect(document.documentElement).not.toHaveAttribute("data-theme");
+    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe("dark");
+  });
+
+  it("reads a persisted light preference", () => {
+    window.localStorage.setItem(THEME_STORAGE_KEY, "light");
+    render(
+      <ThemeProvider>
+        <Probe />
+      </ThemeProvider>,
+    );
+    expect(screen.getByRole("button")).toHaveTextContent("theme:light");
+  });
+
+  it("init script uses the literal storage key (pre-paint bootstrap)", () => {
+    expect(THEME_STORAGE_KEY).toBe("upstat.theme");
+    expect(themeInitScript).toContain('localStorage.getItem("upstat.theme")');
+    expect(themeInitScript).toContain('setAttribute("data-theme","light")');
+  });
+});

--- a/web/src/design/ThemeProvider.tsx
+++ b/web/src/design/ThemeProvider.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+/**
+ * Theme provider — manual light/dark override (SKILL.md "Marketing nav,
+ * footer & theme parity canon", ported from apparule's contract):
+ *
+ * - unset (default): no `data-theme` attribute → tokens.css `:root` renders
+ *   the design default, which for upstat is DARK (design.md §2 — there is
+ *   deliberately no prefers-color-scheme auto-switch).
+ * - `light`: `data-theme="light"` on <html>, persisted in localStorage
+ *   under `upstat.theme`.
+ *
+ * The preference lives in an external module store (localStorage-backed,
+ * read via useSyncExternalStore) so no state syncs through effects; a tiny
+ * inline script in the root layout applies the persisted override before
+ * first paint to avoid a theme flash.
+ */
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useSyncExternalStore,
+  type ReactNode,
+} from "react";
+
+export type Theme = "light" | "dark";
+
+export const THEME_STORAGE_KEY = "upstat.theme";
+
+/** upstat's design default (design.md §2: dark-primary product). */
+export const DEFAULT_THEME: Theme = "dark";
+
+// -- external preference store ----------------------------------------------
+
+const listeners = new Set<() => void>();
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+function emit(): void {
+  for (const listener of listeners) listener();
+}
+
+function readStoredTheme(): Theme {
+  try {
+    const stored = window.localStorage.getItem(THEME_STORAGE_KEY);
+    if (stored === "light" || stored === "dark") return stored;
+  } catch {
+    // storage unavailable (private mode etc.) — fall through to the default
+  }
+  return DEFAULT_THEME;
+}
+
+function getServerSnapshot(): Theme {
+  return DEFAULT_THEME;
+}
+
+function applyTheme(theme: Theme): void {
+  const root = document.documentElement;
+  if (theme === DEFAULT_THEME) {
+    // the default carries no attribute — tokens.css `:root` IS dark
+    root.removeAttribute("data-theme");
+  } else {
+    root.setAttribute("data-theme", theme);
+  }
+}
+
+// -- context ------------------------------------------------------------------
+
+interface ThemeContextValue {
+  /** The resolved theme ("dark" unless the user chose light). */
+  theme: Theme;
+  /** Set + persist the theme. */
+  setTheme: (theme: Theme) => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const theme = useSyncExternalStore(subscribe, readStoredTheme, getServerSnapshot);
+
+  const setTheme = useCallback((next: Theme) => {
+    applyTheme(next);
+    try {
+      window.localStorage.setItem(THEME_STORAGE_KEY, next);
+    } catch {
+      // non-fatal: preference just won't persist
+    }
+    emit();
+  }, []);
+
+  const value = useMemo(() => ({ theme, setTheme }), [theme, setTheme]);
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+export function useTheme(): ThemeContextValue {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) throw new Error("useTheme must be used within <ThemeProvider>");
+  return ctx;
+}
+
+/**
+ * Pre-paint theme bootstrap (inlined by the root layout). A fully static
+ * string — no runtime code construction (CodeQL js/bad-code-sanitization);
+ * the literal storage key must match THEME_STORAGE_KEY (unit-tested).
+ * Only "light" needs applying — dark is the attribute-less default.
+ */
+export const themeInitScript =
+  '(function(){try{var t=localStorage.getItem("upstat.theme");if(t==="light"){document.documentElement.setAttribute("data-theme","light");}}catch(e){}})();';

--- a/web/src/mocks/rum-data.test.ts
+++ b/web/src/mocks/rum-data.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { DAY, HOUR, MINUTE } from "./util";
+import { rumBucketMs, rumSummary, rumVitals } from "./rum-data";
+
+const NOW = Date.parse("2026-07-18T12:00:00Z");
+
+describe("rum bucketing (B6)", () => {
+  it("short ranges get 5m buckets — a 1h view is a real series, not one bar (QA 2026-07-19)", () => {
+    expect(rumBucketMs(HOUR)).toBe(5 * MINUTE);
+    expect(rumBucketMs(6 * HOUR)).toBe(5 * MINUTE);
+    expect(rumBucketMs(DAY)).toBe(HOUR);
+    expect(rumBucketMs(7 * DAY)).toBe(DAY);
+  });
+
+  it("1h summary and vitals series carry ~12 buckets", () => {
+    const summary = rumSummary(NOW - HOUR, NOW);
+    expect(summary.series.length).toBe(12);
+    const vitals = rumVitals(NOW - HOUR, NOW);
+    expect(vitals.series.length).toBe(12);
+  });
+
+  it("stays deterministic per bucket", () => {
+    expect(rumSummary(NOW - HOUR, NOW)).toEqual(rumSummary(NOW - HOUR, NOW));
+  });
+});

--- a/web/src/mocks/rum-data.test.ts
+++ b/web/src/mocks/rum-data.test.ts
@@ -23,3 +23,29 @@ describe("rum bucketing (B6)", () => {
     expect(rumSummary(NOW - HOUR, NOW)).toEqual(rumSummary(NOW - HOUR, NOW));
   });
 });
+
+describe("uniques_daily_avg (analytics-math.md §4, #156)", () => {
+  const DAY_START = Date.parse("2026-07-18T00:00:00Z");
+
+  it("is independent of the presentation bucket width", () => {
+    // a 1h view (5m buckets) and the full-day view (1h buckets) over the
+    // same UTC day must agree — averaging presentation buckets made the
+    // stat track bucket width (~12x drop when buckets went 1h → 5m)
+    const hour = rumSummary(NOW - HOUR, NOW);
+    const day = rumSummary(DAY_START, DAY_START + DAY);
+    expect(hour.uniques_daily_avg).toBe(day.uniques_daily_avg);
+
+    // and it is a day-scale figure, not a per-bucket mean
+    const bucketMean =
+      hour.series.reduce((s, b) => s + b.uniques, 0) / hour.series.length;
+    expect(hour.uniques_daily_avg).toBeGreaterThan(bucketMean * 12);
+  });
+
+  it("averages exact per-day uniques over multi-day ranges (never a sum)", () => {
+    const d1 = rumSummary(DAY_START - DAY, DAY_START).uniques_daily_avg;
+    const d2 = rumSummary(DAY_START, DAY_START + DAY).uniques_daily_avg;
+    const twoDays = rumSummary(DAY_START - DAY, DAY_START + DAY);
+    expect(twoDays.uniques_daily_avg).toBe(Math.round((d1 + d2) / 2));
+    expect(twoDays.uniques_additive).toBe(false);
+  });
+});

--- a/web/src/mocks/rum-data.ts
+++ b/web/src/mocks/rum-data.ts
@@ -1,14 +1,25 @@
 /** RUM aggregates — deterministic, honoring analytics-math.md honesty rules. */
 
 import type { RumSummary, RumVitals } from "@/models";
-import { DAY, HOUR, hashSeed, iso, mulberry32, unitFor } from "./util";
+import { DAY, HOUR, MINUTE, hashSeed, iso, mulberry32, unitFor } from "./util";
 
 const TOP_PAGES = ["/", "/pricing", "/docs", "/blog/cookieless-analytics", "/changelog"];
 const REFERRERS = ["google.com", "github.com", "news.ycombinator.com", "x.com", "duckduckgo.com"];
 const COUNTRIES = ["NG", "US", "GB", "DE", "IN"];
 
+/**
+ * Bucket width by range. Short ranges get 5m buckets — day/hour-only
+ * bucketing rendered the default 1h view as ONE bar (and a one-column
+ * vitals heatmap) on /dashboard/rum (QA 2026-07-19).
+ */
+export function rumBucketMs(rangeMs: number): number {
+  if (rangeMs > 2 * DAY) return DAY;
+  if (rangeMs > 6 * HOUR) return HOUR;
+  return 5 * MINUTE;
+}
+
 export function rumSummary(fromMs: number, toMs: number): RumSummary {
-  const bucketMs = toMs - fromMs > 2 * DAY ? DAY : HOUR;
+  const bucketMs = rumBucketMs(toMs - fromMs);
   const series: RumSummary["series"] = [];
   let pageViews = 0;
   let uniquesSum = 0;
@@ -16,7 +27,7 @@ export function rumSummary(fromMs: number, toMs: number): RumSummary {
 
   for (let t = fromMs; t < toMs; t += bucketMs) {
     const r = mulberry32(hashSeed(`rum:${t}`));
-    const base = bucketMs === DAY ? 5200 : 240;
+    const base = bucketMs === DAY ? 5200 : bucketMs === HOUR ? 240 : 20;
     const count = Math.round(base * (0.7 + r() * 0.6));
     const uniques = Math.round(count * (0.55 + r() * 0.15));
     series.push({ bucket: iso(t), count, uniques });
@@ -57,7 +68,7 @@ export function rumSummary(fromMs: number, toMs: number): RumSummary {
 }
 
 export function rumVitals(fromMs: number, toMs: number): RumVitals {
-  const bucketMs = toMs - fromMs > 2 * DAY ? DAY : HOUR;
+  const bucketMs = rumBucketMs(toMs - fromMs);
   const series: RumVitals["series"] = [];
   for (let t = fromMs; t < toMs; t += bucketMs) {
     const u = unitFor(`vitals:${t}`);

--- a/web/src/mocks/rum-data.ts
+++ b/web/src/mocks/rum-data.ts
@@ -18,12 +18,22 @@ export function rumBucketMs(rangeMs: number): number {
   return 5 * MINUTE;
 }
 
+/**
+ * Exact uniques for the UTC day containing `tMs` — the day-rollup value
+ * (analytics-math.md §2), independent of the presentation bucket width.
+ * Same recipe as a DAY-bucket series bucket, so day-aligned series agree.
+ */
+function utcDayUniques(tMs: number): number {
+  const dayStart = tMs - (tMs % DAY);
+  const r = mulberry32(hashSeed(`rum:${dayStart}`));
+  const count = Math.round(5200 * (0.7 + r() * 0.6));
+  return Math.round(count * (0.55 + r() * 0.15));
+}
+
 export function rumSummary(fromMs: number, toMs: number): RumSummary {
   const bucketMs = rumBucketMs(toMs - fromMs);
   const series: RumSummary["series"] = [];
   let pageViews = 0;
-  let uniquesSum = 0;
-  let bucketCount = 0;
 
   for (let t = fromMs; t < toMs; t += bucketMs) {
     const r = mulberry32(hashSeed(`rum:${t}`));
@@ -32,8 +42,16 @@ export function rumSummary(fromMs: number, toMs: number): RumSummary {
     const uniques = Math.round(count * (0.55 + r() * 0.15));
     series.push({ bucket: iso(t), count, uniques });
     pageViews += count;
-    uniquesSum += uniques;
-    bucketCount++;
+  }
+
+  // §4 honesty: "visitors · daily avg" averages EXACT per-UTC-day uniques.
+  // Averaging presentation buckets tied the stat to bucket width — the 5m
+  // buckets cut it ~12x while page views held steady (PR #156 review).
+  let dayUniquesSum = 0;
+  let dayCount = 0;
+  for (let d = fromMs - (fromMs % DAY); d < toMs; d += DAY) {
+    dayUniquesSum += utcDayUniques(d);
+    dayCount++;
   }
 
   const visits = Math.round(pageViews / 2.6);
@@ -44,7 +62,7 @@ export function rumSummary(fromMs: number, toMs: number): RumSummary {
     visits,
     bounce_rate: visits === 0 ? null : Math.round((bounceVisits / visits) * 1000) / 1000,
     avg_visit_seconds: visits - bounceVisits === 0 ? null : 184,
-    uniques_daily_avg: bucketCount === 0 ? 0 : Math.round(uniquesSum / bucketCount),
+    uniques_daily_avg: dayCount === 0 ? 0 : Math.round(dayUniquesSum / dayCount),
     uniques_additive: false,
     series,
     top_pages: TOP_PAGES.map((value, i) => ({

--- a/web/src/mocks/seed.ts
+++ b/web/src/mocks/seed.ts
@@ -112,9 +112,24 @@ export function buildSeed(now: number): MockDb {
           type: "query_value",
           title: "Requests /s",
           query: null,
-          query_string: "metric:http.requests_total | rate()",
+          // $service: the template-var bar must govern at least the seeded
+          // widgets — an all-static seed made the picker a dead control
+          // (system-QA finding 2026-07-19)
+          query_string: "metric:http.requests_total service:$service | rate()",
           viz_options: { precision: 0, sparkline: true },
           layout: { x: 8, y: 0, w: 4, h: 3 },
+        },
+        {
+          id: "wid_err_rate",
+          dashboard_id: "dash_overview",
+          type: "timeseries",
+          title: "Error rate — $service",
+          query: null,
+          query_string: "metric:http.errors_total service:$service env:$env | rate()",
+          viz_options: { display: "area" },
+          // second timeseries widget: makes the MI-2 cross-widget crosshair
+          // sync observable on the seeded dashboard
+          layout: { x: 0, y: 6, w: 12, h: 2 },
         },
         {
           id: "wid_top",

--- a/web/src/mocks/series.test.ts
+++ b/web/src/mocks/series.test.ts
@@ -29,6 +29,14 @@ describe("parseQuery", () => {
     expect(parsed).toHaveProperty("error");
   });
 
+  it("rejects malformed pipes instead of silently succeeding (MI-13)", () => {
+    // split-on-every-pipe used to drop the garbage and parse clean, so the
+    // QueryBar's syntax-error state was unreachable (QA 2026-07-19)
+    expect(parseQuery("metric:http.requests_total ||| nonsense((")).toHaveProperty("error");
+    expect(parseQuery("service:web |")).toHaveProperty("error");
+    expect(parseQuery("service:web | nonsense((")).toHaveProperty("error");
+  });
+
   it("accepts negation and free text", () => {
     const parsed = parseQuery("-level:debug timeout service:web");
     if ("error" in parsed) throw new Error(parsed.error);

--- a/web/src/mocks/series.test.ts
+++ b/web/src/mocks/series.test.ts
@@ -37,6 +37,16 @@ describe("parseQuery", () => {
     expect(parseQuery("service:web | nonsense((")).toHaveProperty("error");
   });
 
+  it("rejects EVERY additional pipe — one | segment max (grammar §1, #156)", () => {
+    // `a | rate() | nonsense` used to sail through on the first segment
+    // alone, silently ignoring the second pipe and trailing text
+    expect(parseQuery("service:web | rate() | nonsense")).toHaveProperty("error");
+    expect(parseQuery("service:web | rate() | sum()")).toHaveProperty("error");
+    expect(parseQuery("service:web | rate() |")).toHaveProperty("error");
+    // the single-pipe form still parses clean
+    expect(parseQuery("service:web | rate()")).not.toHaveProperty("error");
+  });
+
   it("accepts negation and free text", () => {
     const parsed = parseQuery("-level:debug timeout service:web");
     if ("error" in parsed) throw new Error(parsed.error);
@@ -87,6 +97,36 @@ describe("buildTimeseries", () => {
     if ("error" in parsed) throw new Error(parsed.error);
     const result = buildTimeseries(parsed, NOW - HOUR, NOW, OUTAGE);
     expect(result.series).toHaveLength(7);
+  });
+
+  it("consumes env — switching $env observably changes series, INC-42 stays prod-only (#156)", () => {
+    const q = (env: string) =>
+      parseQuery(`metric:http.errors_total service:checkout env:${env} | rate()`);
+    const prod = q("prod");
+    const staging = q("staging");
+    if ("error" in prod || "error" in staging) throw new Error("parse failed");
+    const rProd = buildTimeseries(prod, NOW - 6 * HOUR, NOW, OUTAGE);
+    const rStaging = buildTimeseries(staging, NOW - 6 * HOUR, NOW, OUTAGE);
+
+    // different data, tagged with the env it was filtered to
+    expect(rStaging.series[0].points).not.toEqual(rProd.series[0].points);
+    expect(rStaging.series[0].tags.env).toBe("staging");
+
+    // staging runs a deterministic fraction of prod traffic
+    const total = (r: typeof rProd) =>
+      r.series[0].points.reduce((s, p) => s + (p.value ?? 0), 0);
+    expect(total(rStaging)).toBeLessThan(total(rProd) * 0.6);
+
+    // the prod outage spike does not leak into staging
+    const mid = (OUTAGE.start + OUTAGE.end) / 2;
+    const avgWhere = (r: typeof rProd, pred: (t: number) => boolean) => {
+      const xs = r.series[0].points.filter((p) => pred(Date.parse(p.ts)));
+      return xs.reduce((s, p) => s + (p.value ?? 0), 0) / Math.max(xs.length, 1);
+    };
+    const during = (t: number) => Math.abs(t - mid) < 20 * MINUTE;
+    const before = (t: number) => t < OUTAGE.start - HOUR;
+    expect(avgWhere(rProd, during)).toBeGreaterThan(avgWhere(rProd, before) * 5);
+    expect(avgWhere(rStaging, during)).toBeLessThan(avgWhere(rStaging, before) * 2);
   });
 });
 

--- a/web/src/mocks/series.ts
+++ b/web/src/mocks/series.ts
@@ -145,7 +145,15 @@ const FNS: QueryFn[] = ["count", "rate", "sum", "avg", "min", "max", "p50", "p95
  * per §3 "errors, not empty results".
  */
 export function parseQuery(q: string): ParsedQuery | { error: string } {
-  const [filterPart, aggPart] = q.split("|").map((s) => s.trim());
+  // One pipe max (grammar §1). Splitting on EVERY pipe silently dropped
+  // everything after the second one — `a ||| garbage((` parsed clean, so
+  // MI-13's syntax-error state could never surface (QA 2026-07-19).
+  const pipeIdx = q.indexOf("|");
+  const filterPart = (pipeIdx === -1 ? q : q.slice(0, pipeIdx)).trim();
+  const aggPart = pipeIdx === -1 ? "" : q.slice(pipeIdx + 1).trim();
+  if (pipeIdx !== -1 && (aggPart === "" || aggPart.startsWith("|"))) {
+    return { error: "aggregation expected after |" };
+  }
   const parsed: ParsedQuery = {
     metric: "http.requests_total",
     filters: {},

--- a/web/src/mocks/series.ts
+++ b/web/src/mocks/series.ts
@@ -74,6 +74,17 @@ function baseRate(service: string): number {
 }
 
 /**
+ * Traffic dampening per environment — non-prod envs run a deterministic
+ * fraction of prod load, so the `$env` template var observably changes
+ * series (`env` was parsed but never consumed; PR #156 review). INC-42 is
+ * a prod incident, so non-prod also skips the outage shapes.
+ */
+function envScale(env: string | undefined): number {
+  if (!env || env === "prod") return 1;
+  return 0.15 + unitFor(`env:${env}`) * 0.3; // staging-class envs ≈ 15–45%
+}
+
+/**
  * Value generator for a (metric, fn, service) triple at a time bucket.
  * Shapes: duration metrics honor p50/p95/p99 ordering; count/rate metrics
  * follow the daily cycle; the INC-42 window spikes latency ~8x (checkout
@@ -86,9 +97,12 @@ export function metricValue(
   service: string,
   tMs: number,
   outage: OutageWindow,
+  env?: string,
 ): number {
   const cycle = dailyCycle(tMs);
-  const outageHit = inOutage(tMs, outage, service);
+  const scale = envScale(env);
+  // scale === 1 ⇔ prod (or no env filter) — only prod sees INC-42
+  const outageHit = scale === 1 && inOutage(tMs, outage, service);
   // ramp the spike in/out over 5 minutes so charts look organic
   const ramp = outageHit
     ? Math.min(1, (tMs - outage.start) / (5 * MINUTE), (outage.end - tMs) / (5 * MINUTE))
@@ -100,30 +114,35 @@ export function metricValue(
       fn === "p99" ? spread * 2.6 : fn === "p95" ? spread : fn === "p50" || fn === "avg" ? 1 : 1;
     let v = p50 * quantile * (0.9 + 0.2 * cycle) + noise(`${metric}:${fn}:${service}`, tMs, p50 * 0.08);
     if (ramp > 0) v *= 1 + 7 * ramp; // ~8x at peak (over the 1.5s crit line)
+    v *= 0.85 + 0.15 * scale; // lighter non-prod load runs a touch faster
     return Math.max(1, Math.round(v * 100) / 100);
   }
 
   if (metric.includes("error")) {
     let v = baseRate(service) * 0.004 * cycle + Math.abs(noise(`${metric}:${service}`, tMs, 0.2));
     if (ramp > 0) v = baseRate(service) * 0.1 * ramp; // ~25x error spike
+    v *= scale;
     return Math.round(v * 1000) / 1000;
   }
 
   if (metric.includes("cpu")) {
     let v = 22 + 30 * (cycle - 0.55) + noise(`cpu:${service}`, tMs, 4);
     if (ramp > 0) v += 35 * ramp;
+    v *= scale;
     return Math.min(99, Math.max(2, Math.round(v * 10) / 10));
   }
 
   if (metric.includes("queue")) {
     let v = 40 * cycle + Math.abs(noise(`queue:${service}`, tMs, 15));
     if (ramp > 0) v += 900 * ramp; // the ingest retry-storm backlog
+    v *= scale;
     return Math.round(v);
   }
 
   // request/throughput style metrics
   let v = baseRate(service) * cycle + noise(`${metric}:${service}`, tMs, baseRate(service) * 0.06);
   if (ramp > 0 && fn !== "count") v *= 1 - 0.35 * ramp; // throughput dips during the incident
+  v *= scale;
   return Math.max(0, Math.round(v * 100) / 100);
 }
 
@@ -145,13 +164,18 @@ const FNS: QueryFn[] = ["count", "rate", "sum", "avg", "min", "max", "p50", "p95
  * per §3 "errors, not empty results".
  */
 export function parseQuery(q: string): ParsedQuery | { error: string } {
-  // One pipe max (grammar §1). Splitting on EVERY pipe silently dropped
-  // everything after the second one — `a ||| garbage((` parsed clean, so
-  // MI-13's syntax-error state could never surface (QA 2026-07-19).
+  // One pipe max (grammar §1): EVERY additional pipe is a syntax error.
+  // Splitting on every pipe silently dropped everything after the second
+  // one — `a ||| garbage((` parsed clean, and `a | rate() | nonsense`
+  // sailed through on the first segment alone, so MI-13's syntax-error
+  // state could never surface (QA 2026-07-19; PR #156 review).
   const pipeIdx = q.indexOf("|");
+  if (pipeIdx !== -1 && q.indexOf("|", pipeIdx + 1) !== -1) {
+    return { error: "only one | segment allowed" };
+  }
   const filterPart = (pipeIdx === -1 ? q : q.slice(0, pipeIdx)).trim();
   const aggPart = pipeIdx === -1 ? "" : q.slice(pipeIdx + 1).trim();
-  if (pipeIdx !== -1 && (aggPart === "" || aggPart.startsWith("|"))) {
+  if (pipeIdx !== -1 && aggPart === "") {
     return { error: "aggregation expected after |" };
   }
   const parsed: ParsedQuery = {
@@ -221,6 +245,7 @@ export function buildTimeseries(
 ): TimeseriesResult {
   const stepMs = stepOverrideMs ?? snapStepMs(toMs - fromMs);
   const agg = parsed.agg.length > 0 ? parsed.agg : [{ fn: "avg" as QueryFn }];
+  const env = parsed.filters.env;
   const groupServices =
     parsed.groupBy.includes("service") || !parsed.filters.service
       ? parsed.groupBy.includes("service")
@@ -236,14 +261,14 @@ export function buildTimeseries(
       for (let t = fromMs; t <= toMs; t += stepMs) {
         points.push({
           ts: iso(t),
-          value: metricValue(parsed.metric, fn, service, t, outage),
+          value: metricValue(parsed.metric, fn, service, t, outage, env),
         });
       }
       const name =
         groupServices.length > 1
           ? `${fn}(${parsed.metric}) service:${service}`
           : `${fn}(${parsed.metric})`;
-      series.push({ name, tags: { service }, points });
+      series.push({ name, tags: env ? { service, env } : { service }, points });
     }
   }
 

--- a/web/src/mocks/status-page.test.ts
+++ b/web/src/mocks/status-page.test.ts
@@ -20,6 +20,16 @@ describe("buildStatusPage (B7 public read)", () => {
     expect(homepage?.uptime_pct).toBeGreaterThan(99);
   });
 
+  it("publishes the pillar's latency figure, not its own (accuracy QA 2026-07-19)", () => {
+    const db = buildSeed(NOW);
+    const page = buildStatusPage(db, "upstat", NOW);
+    for (const component of page.components) {
+      const monitor = db.monitors.find((m) => m.name === component.name);
+      // same source as /dashboard/uptime cards — the page hardcoded 96ms
+      expect(component.p95_ms).toBe(monitor?.last_response_time_ms ?? null);
+    }
+  });
+
   it("reflects a freshly declared sev1 immediately (B9 linkage)", () => {
     const db = buildSeed(NOW);
     db.incidents.unshift({

--- a/web/src/mocks/status-page.ts
+++ b/web/src/mocks/status-page.ts
@@ -30,6 +30,9 @@ export function buildStatusPage(db: MockDb, slug: string, now = Date.now()): Sta
         status: m.status,
         days: history.days,
         uptime_pct: history.uptime_90d_pct,
+        // same latency source as the uptime pillar's cards — the page
+        // previously hardcoded 96ms and disagreed with /dashboard/uptime
+        p95_ms: m.last_response_time_ms,
       };
     });
 

--- a/web/src/models/repositories/github.ts
+++ b/web/src/models/repositories/github.ts
@@ -11,16 +11,23 @@ import { TEST_MODE } from "./client";
  * repo resolves `null` without touching the network (badge stays neutral;
  * Playwright/CI stay hermetic).
  */
+/** Session cache — remounts reuse the count instead of refetching. */
+const starCache = new Map<string, number>();
+
 export const githubRepo = {
   async stars(repo = "cuesoftinc/upstat"): Promise<number | null> {
     if (TEST_MODE) return null;
+    const cached = starCache.get(repo);
+    if (cached !== undefined) return cached;
     try {
       const res = await fetch(`https://api.github.com/repos/${repo}`, {
         headers: { accept: "application/vnd.github+json" },
       });
       if (!res.ok) return null;
       const body = (await res.json()) as { stargazers_count?: number };
-      return typeof body.stargazers_count === "number" ? body.stargazers_count : null;
+      if (typeof body.stargazers_count !== "number") return null;
+      starCache.set(repo, body.stargazers_count);
+      return body.stargazers_count;
     } catch {
       return null;
     }

--- a/web/src/models/status.ts
+++ b/web/src/models/status.ts
@@ -19,6 +19,9 @@ export interface StatusPageComponent {
   /** 90-day strip (UptimeCard technique). */
   days: UptimeDay[];
   uptime_pct: number | null;
+  /** Latency figure from the owning check — the SAME source the uptime
+   *  pillar shows, so list/detail/status page agree (QA 2026-07-19). */
+  p95_ms: number | null;
 }
 
 export interface StatusPageIncident {

--- a/web/vitest.setup.ts
+++ b/web/vitest.setup.ts
@@ -17,6 +17,24 @@ if (typeof Element !== "undefined") {
   Element.prototype.scrollIntoView ??= () => undefined;
 }
 
+// This jsdom build ships no localStorage (sessionStorage exists) — the
+// NavRail expansion + theme persistence paths need one. Minimal in-memory
+// Storage, reset between files like the real thing on a fresh origin.
+if (typeof window !== "undefined" && typeof window.localStorage === "undefined") {
+  const store = new Map<string, string>();
+  const storage: Storage = {
+    get length() {
+      return store.size;
+    },
+    clear: () => store.clear(),
+    getItem: (key) => (store.has(key) ? store.get(key)! : null),
+    key: (index) => [...store.keys()][index] ?? null,
+    removeItem: (key) => void store.delete(key),
+    setItem: (key, value) => void store.set(key, String(value)),
+  };
+  Object.defineProperty(window, "localStorage", { value: storage, configurable: true });
+}
+
 // jsdom has no matchMedia. Tests run as reduced-motion: animation loops
 // (hero crosshair, MI pulses) stay off, keeping renders deterministic.
 if (typeof window !== "undefined" && typeof window.matchMedia !== "function") {


### PR DESCRIPTION
## What

Final gate of the web phase: a full-system QA walk of the TEST_MODE prod build (every journey, MI spot-checks, 1440/390, dark + the light status page) — findings fixed on this branch with regression tests — plus two directives folded in mid-pass.

### System-QA fixes (audit → fix → verify)

| Lens | Finding | Fix |
| --- | --- | --- |
| Interaction (MI-4) | Live-tail scroll-up pause + buffered count unreachable: the app frame was `min-h-screen`, so the logs list never overflowed — the page grew the body instead | App frame is `h-dvh`; `<main>` is the one scroll container. e2e now walks pause → "n new" chip → resume |
| Polish | React #418 on `/` (prod build only): `Date.now()`-seeded demo data baked build-time axis labels into the static prerender | First render seeds from a pinned epoch; post-mount rebuild uses the real clock. Home e2e asserts zero page errors |
| Usability (user-reported) | A9 cloud-vs-self-host at 390: "Deploy with compose" floated detached from its snippet; snippet wrapped mid-comment; desktop CTAs wrapped inside `w-32` columns | `<sm`: table CTA footer hides, a grouped CTA pair renders directly above the snippet; snippet wraps before the comment (CodeSnippet convention); CTAs `whitespace-nowrap` |
| Interaction (MI-13) | Syntax errors unreachable (mock `parseQuery` split on every pipe — `a ||| garbage((` parsed clean); autocomplete unfiltered, Tab completed an unrelated pill | First-pipe split + empty-agg error; QueryBar filters to the typed token, caps display post-filter |
| Interaction (MI-17) | `?` cheatsheet only closed via backdrop click | Escape closes |
| Accuracy | Status page hardcoded `p95Ms={96}` vs 142 ms on `/dashboard/uptime` for the same check | `p95_ms` added to the status component read model, sourced from the same monitor figure — list/detail/status page agree |
| Accuracy | RUM at the 1h default: one giant sessions bar + one-column vitals heatmap (hour/day-only bucketing) | 5m buckets for short ranges |
| Accuracy | Template-var bar was a dead control on the seed (no widget used `$service`/`$env`); only one timeseries widget, so MI-2 sync was unobservable | Seed wires `$service`/`$env` into widget queries + a second timeseries widget; widget titles resolve vars |
| Polish | Grouped-series legends truncated to N identical entries | Legends label the distinguishing tag suffix; full name on the title tooltip; crosshair tooltip carries labels |

### Directive: expandable NavRail (design.md §2, spec in #154)

Collapsed 56px (icons + flyouts) ⇄ expanded 240px (icon+label rows, Telemetry/Respond/Platform groups, `upstat` wordmark). Foot chevron (focusable, `aria-expanded`); persists as `nav.rail.expanded`; default expanded ≥1280px / collapsed below (post-mount resolution keeps SSR deterministic); active = brand accent bar + brand icon in both states. `NavRailItem` props stay backward-compatible. All pillar screens verified at both widths; `e2e/navrail.spec.ts` covers defaults, toggle + persistence, navigation at both widths. Note: the Next dev indicator moved bottom-right — its default corner sat exactly on the rail's foot toggle and intercepted pointer events.

### Directive: nav/footer link parity + theme toggle (SKILL.md canon)

- Nav: Features · Dashboards · Docs (GitBook) · GitHub + ThemeToggle + Sign in CTA (pillar dropdown + star badge retired; runtime star count rides the GitHub link, never static).
- Footer: brand block + canonical Product/Docs/Community/Legal columns (ratified URLs, live Discord invite) + legal bar — verbatim "© Cuesoft Inc. 2026. Upstat. CueLABS™ Division. MIT License." with linked marks, English-only language selector (real control), SECURITY.md affordance.
- Theme: apparule's ThemeProvider contract ported (`data-theme` on `<html>`, `upstat.theme`, unset = dark design default, pre-paint init script). Toggle in marketing nav, dashboard TopBar, Settings → Appearance. Both themes screenshot-verified on every surface at 1440/390.

### Verification

- `lint` (incl. `check:boundaries`, 311 files) ✓ · `typecheck` ✓ · unit **210 passed** (was 186) ✓ · Playwright e2e **18 passed** (4 specs, incl. new `navrail.spec.ts`) ✓
- TEST_MODE prod build walked end-to-end: signin → onboarding (create org → first-data → radar) → B1 → all twelve pillars → status page; org-switch isolation, reduced-motion (0 running animations), keyboard map, incident lifecycle → status-page reflection → resolve — all green.
- Live spot-checks at upstat.cuesoft.io (home/signin/status/dashboard all 200); every canonical URL verified 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)