### PR TITLE
fix(web): floating layers never overflow the viewport — collision sweep

### DIFF
--- a/web/e2e/dashboard.spec.ts
+++ b/web/e2e/dashboard.spec.ts
@@ -62,6 +62,40 @@ test("semantic landmarks: one main, nav rail, banner, single h1", async ({ page 
   await expect(page.getByRole("list", { name: "Dashboards" }).first()).toBeVisible();
 });
 
+test("right-anchored TopBar layers stay inside the viewport (review class 2026-07-19)", async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await signIn(page);
+
+  const withinViewport = async (dialog: ReturnType<typeof page.locator>, width: number) => {
+    const box = (await dialog.boundingBox())!;
+    expect(box.x).toBeGreaterThanOrEqual(0);
+    expect(box.y).toBeGreaterThanOrEqual(0);
+    expect(box.x + box.width).toBeLessThanOrEqual(width);
+  };
+
+  // 1440 = canonical dashboard width; 1024 = narrowest QA'd chrome width
+  // (navrail collapse threshold) — the squeeze case for anchored-right layers
+  for (const width of [1440, 1024]) {
+    await page.setViewportSize({ width, height: 900 });
+
+    // global TimePicker: the anchored-right custom-range popover
+    await page.getByRole("banner").getByRole("button", { name: "Custom range" }).click();
+    const customRange = page.getByRole("dialog", { name: "Absolute range" });
+    await expect(customRange).toBeVisible();
+    await withinViewport(customRange, width);
+    await page.keyboard.press("Escape");
+    await expect(customRange).toBeHidden();
+
+    // notifications bell popover (anchored right-2)
+    await page.getByRole("banner").getByRole("button", { name: /Notifications/ }).click();
+    const notifications = page.getByRole("dialog", { name: "Notifications" });
+    await expect(notifications).toBeVisible();
+    await withinViewport(notifications, width);
+    await page.getByRole("banner").getByRole("button", { name: /Notifications/ }).click();
+    await expect(notifications).toBeHidden();
+  }
+});
+
 test("full journey: onboarding → B1 → dashboards → explorer → logs → trace → monitor → incident → status page", async ({ page }) => {
   test.setTimeout(300_000); // dev-mode route compiles dominate; generous budget
   // dev-persistent mock store: names must be unique per run (reused server)

--- a/web/e2e/home.spec.ts
+++ b/web/e2e/home.spec.ts
@@ -231,6 +231,15 @@ test("Self Host CTA scrolls to the self-host section (A14)", async ({ page }) =>
   await page.goto("/");
   await page.getByRole("button", { name: "Self Host" }).first().click();
   await expect(page.locator("#self-host")).toBeInViewport();
+  // the section's guide link points at the REAL GitBook deployment guide —
+  // docs.upstat.cuesoft.io was NXDOMAIN (user-reported dead link 2026-07-19)
+  await expect(
+    page.locator("#self-host").getByRole("link", { name: /Self-host guide/ }),
+  ).toHaveAttribute("href", "https://cuesoft.gitbook.io/upstat/system/deployment");
+  // A6: the status link is the in-app public status page, not an invented host
+  await expect(
+    page.locator("#status").getByRole("link", { name: /our own public status page/ }),
+  ).toHaveAttribute("href", "/status/upstat");
 });
 
 test("home is responsive at 375w (mobile)", async ({ page }) => {

--- a/web/e2e/home.spec.ts
+++ b/web/e2e/home.spec.ts
@@ -292,6 +292,11 @@ test("mobile nav is a menu-button disclosure at 390w (SKILL.md mobile clause)", 
   }).toPass({ timeout: 15_000 });
   await expect(menuButton).toHaveAttribute("aria-expanded", "true");
 
+  // the panel never overflows the viewport (floating-layer collision sweep)
+  const panelBox = (await panel.boundingBox())!;
+  expect(panelBox.x).toBeGreaterThanOrEqual(0);
+  expect(panelBox.x + panelBox.width).toBeLessThanOrEqual(390);
+
   // every canonical link is reachable from the panel — no dead ends <md
   for (const [label, href] of [
     ["Features", "/#pillars"],

--- a/web/src/app/dashboard/logs/page.tsx
+++ b/web/src/app/dashboard/logs/page.tsx
@@ -130,7 +130,7 @@ export default function LogsPage() {
                 ))}
               </div>
             ) : empty ? (
-              <EmptyState pillar="logs" waiting={ctrl.live} docsHref="https://docs.upstat.cuesoft.io" />
+              <EmptyState pillar="logs" waiting={ctrl.live} />
             ) : (
               <ul aria-label="Log lines">
                 {ascending.map((event) => (

--- a/web/src/app/dashboard/onboarding/page.tsx
+++ b/web/src/app/dashboard/onboarding/page.tsx
@@ -102,7 +102,7 @@ export default function OnboardingPage() {
             ]}
           />
 
-          <EmptyState pillar="metrics" waiting docsHref="https://docs.upstat.cuesoft.io" />
+          <EmptyState pillar="metrics" waiting />
         </section>
       ) : (
         <section aria-labelledby="create-org-heading" className="flex flex-col gap-4">

--- a/web/src/app/dashboard/rum/page.tsx
+++ b/web/src/app/dashboard/rum/page.tsx
@@ -90,7 +90,7 @@ export default function RumPage() {
       </header>
 
       {noData ? (
-        <EmptyState pillar="rum" docsHref="https://docs.upstat.cuesoft.io" />
+        <EmptyState pillar="rum" />
       ) : (
         <>
           {/* stat tiles */}

--- a/web/src/app/dev/components/gallery.tsx
+++ b/web/src/app/dev/components/gallery.tsx
@@ -201,7 +201,7 @@ const CATALOG_ENTRY: ServiceCatalogEntry = {
   id: "svc_checkout",
   name: "checkout",
   owner: "Sade",
-  links: { repo: "https://github.com/cuesoftinc/upstat", runbook: "https://docs.upstat.cuesoft.io/runbooks/checkout" },
+  links: { repo: "https://github.com/cuesoftinc/upstat", runbook: "https://cuesoft.gitbook.io/upstat" },
   environments: ["prod", "staging"],
   telemetry: { metrics: true, logs: true, traces: true, rum: false },
 };

--- a/web/src/components/home/HomeView.test.tsx
+++ b/web/src/components/home/HomeView.test.tsx
@@ -45,7 +45,7 @@ describe("HomeView (pages.md Part A — Figma frame 135:2)", () => {
     // A6 status embed
     expect(screen.getByText("We run on it. Publicly.")).toBeInTheDocument();
     expect(
-      screen.getByText(/status\.upstat\.cuesoft\.io\/upstat — our own public status page/),
+      screen.getByText(/\/status\/upstat — our own public status page/),
     ).toBeInTheDocument();
     // A14 self-host + A9 table
     expect(screen.getByText("Self-host — own your telemetry.")).toBeInTheDocument();

--- a/web/src/components/home/content.ts
+++ b/web/src/components/home/content.ts
@@ -121,7 +121,10 @@ export const ARCHITECTURE_FLOW = [
 export const GITHUB_URL = "https://github.com/cuesoftinc/upstat";
 // canonical invite (SKILL.md parity canon 2026-07-19, verified live)
 export const DISCORD_URL = "https://discord.gg/CDfZxxrxbb";
-export const DOCS_URL = "https://docs.upstat.cuesoft.io";
+// real GitBook destinations (docs.upstat.cuesoft.io was NXDOMAIN —
+// user-reported dead link 2026-07-19; canon hrefs, verified 200)
+export const DOCS_URL = "https://cuesoft.gitbook.io/upstat";
+export const SELF_HOST_DOCS_URL = "https://cuesoft.gitbook.io/upstat/system/deployment";
 
 // A10 footer columns/copyright: superseded by the canonical parity footer
 // (SKILL.md 2026-07-19) — MarketingFooter now owns the column set + legal bar.

--- a/web/src/components/home/sections-bottom.tsx
+++ b/web/src/components/home/sections-bottom.tsx
@@ -15,7 +15,7 @@ import {
   ARCHITECTURE_FLOW,
   COMPOSE_OUTPUT,
   DISCORD_URL,
-  DOCS_URL,
+  SELF_HOST_DOCS_URL,
   FAQ_ITEMS,
   GITHUB_URL,
   GOOD_FIRST_ISSUES,
@@ -52,11 +52,11 @@ export function SelfHostSection({ onSelfHostDocs }: SelfHostSectionProps) {
             ))}
           </ul>
           <a
-            href={`${DOCS_URL}/self-host`}
+            href={SELF_HOST_DOCS_URL}
             onClick={onSelfHostDocs}
             className="text-[13px] font-medium text-brand transition-colors duration-[var(--duration-fast)] hover:text-brand-deep"
           >
-            Self-host docs: docs.upstat.cuesoft.io/self-host →
+            Self-host guide: cuesoft.gitbook.io/upstat/system/deployment →
           </a>
         </div>
 

--- a/web/src/components/home/sections-demo.tsx
+++ b/web/src/components/home/sections-demo.tsx
@@ -252,11 +252,13 @@ export function StatusEmbedSection({ rows, updatedAt }: StatusEmbedSectionProps)
           ))}
         </div>
       </div>
+      {/* the REAL status page is the in-app B7 route — the imagined
+          status.upstat.cuesoft.io host was a dead link (sweep 2026-07-19) */}
       <a
-        href="https://status.upstat.cuesoft.io/upstat"
+        href="/status/upstat"
         className="mt-4 inline-block font-data text-[12px] text-text-2 transition-colors duration-[var(--duration-fast)] hover:text-text"
       >
-        status.upstat.cuesoft.io/upstat — our own public status page
+        /status/upstat — our own public status page
       </a>
     </Section>
   );

--- a/web/src/components/home/sections-demo.tsx
+++ b/web/src/components/home/sections-demo.tsx
@@ -5,6 +5,7 @@
  * embed (A6). Render-only; data from the home controller.
  */
 
+import Link from "next/link";
 import type { AlertRule, Series } from "@/models";
 import { AlertRuleCard } from "@/components/ui/AlertRuleCard";
 import {
@@ -254,12 +255,12 @@ export function StatusEmbedSection({ rows, updatedAt }: StatusEmbedSectionProps)
       </div>
       {/* the REAL status page is the in-app B7 route — the imagined
           status.upstat.cuesoft.io host was a dead link (sweep 2026-07-19) */}
-      <a
+      <Link
         href="/status/upstat"
         className="mt-4 inline-block font-data text-[12px] text-text-2 transition-colors duration-[var(--duration-fast)] hover:text-text"
       >
         /status/upstat — our own public status page
-      </a>
+      </Link>
     </Section>
   );
 }

--- a/web/src/components/ui/AlertFeedRow.tsx
+++ b/web/src/components/ui/AlertFeedRow.tsx
@@ -88,7 +88,9 @@ function NotificationPanel({
       role="dialog"
       aria-label="Notifications"
       className={clsx(
-        "font-ui z-[var(--z-dropdown)] w-96 overflow-hidden rounded-(--radius) border border-border bg-bg-elev shadow-lg",
+        // max-w clamp: right-anchored near the viewport edge, the panel must
+        // never overflow the screen (review class 2026-07-19, expendit)
+        "font-ui z-[var(--z-dropdown)] w-96 max-w-[calc(100vw-16px)] overflow-hidden rounded-(--radius) border border-border bg-bg-elev shadow-lg",
         className,
       )}
     >
@@ -126,7 +128,7 @@ export function NotificationPopover({
     <Popover.Root open={open} onOpenChange={onOpenChange}>
       <Popover.Trigger asChild>{trigger}</Popover.Trigger>
       <Popover.Portal>
-        <Popover.Content side="bottom" align="end" sideOffset={4} asChild>
+        <Popover.Content side="bottom" align="end" sideOffset={4} collisionPadding={8} asChild>
           <NotificationPanel events={events} onEventClick={onEventClick} className={className} />
         </Popover.Content>
       </Popover.Portal>

--- a/web/src/components/ui/EmptyState.tsx
+++ b/web/src/components/ui/EmptyState.tsx
@@ -32,7 +32,7 @@ export interface EmptyStateProps {
  */
 export function EmptyState({
   pillar,
-  docsHref = "https://docs.upstat.cuesoft.io",
+  docsHref = "https://cuesoft.gitbook.io/upstat",
   waiting = true,
   compact = false,
   className,

--- a/web/src/components/ui/IncidentComposer.tsx
+++ b/web/src/components/ui/IncidentComposer.tsx
@@ -92,6 +92,7 @@ export function IncidentComposer({ onSubmit, posting = false, className }: Incid
             side="top"
             align="start"
             sideOffset={4}
+            collisionPadding={8}
             onOpenAutoFocus={(e) => e.preventDefault()}
             asChild
           >

--- a/web/src/components/ui/Select.tsx
+++ b/web/src/components/ui/Select.tsx
@@ -130,6 +130,7 @@ export function Select({
             side="bottom"
             align="start"
             sideOffset={4}
+            collisionPadding={8}
             onOpenAutoFocus={(e) => {
               // non-typeahead keeps focus on the trigger (W1 keyboard model);
               // typeahead focuses the filter field, as before

--- a/web/src/components/ui/TimePicker.tsx
+++ b/web/src/components/ui/TimePicker.tsx
@@ -75,7 +75,9 @@ export function TimePicker({ value, onChange, live = false, onLiveChange, classN
           <div
             role="dialog"
             aria-label="Absolute range"
-            className="absolute right-0 top-full z-[var(--z-dropdown)] mt-1 flex w-64 flex-col gap-2 rounded-(--radius) border border-border bg-bg-elev p-3 shadow-lg"
+            // max-w clamp: right-anchored in the TopBar — the panel must
+            // never overflow the screen (review class 2026-07-19, expendit)
+            className="absolute right-0 top-full z-[var(--z-dropdown)] mt-1 flex w-64 max-w-[calc(100vw-16px)] flex-col gap-2 rounded-(--radius) border border-border bg-bg-elev p-3 shadow-lg"
           >
             <label className="flex flex-col gap-1 text-[12px] text-text-2">
               From

--- a/web/src/mocks/seed.ts
+++ b/web/src/mocks/seed.ts
@@ -299,7 +299,7 @@ export function buildSeed(now: number): MockDb {
     {
       id: "mon_docs",
       name: "Docs",
-      target: "https://docs.upstat.cuesoft.io",
+      target: "https://cuesoft.gitbook.io/upstat",
       type: "website",
       active: true,
       status: "pending",
@@ -581,7 +581,7 @@ export function buildSeed(now: number): MockDb {
     links: {
       repo: `https://github.com/cuesoftinc/upstat`,
       ...(name === "checkout" || name === "ingest-gw"
-        ? { runbook: `https://docs.upstat.cuesoft.io/runbooks/${name}` }
+        ? { runbook: "https://cuesoft.gitbook.io/upstat" }
         : {}),
     },
     environments: name === "status-page" ? ["prod"] : ["prod", "staging"],


### PR DESCRIPTION
## Summary

Review class found live on expendit (the dashboard period-picker popover clipped off the right edge): floating layers anchored near viewport edges must not overflow the screen. This PR sweeps every popover/dropdown/menu in upstat and adds collision clamping + e2e coverage.

### Fixes

- **Radix layers** — `Select` trigger menu, bell `NotificationPopover` (trigger variant), `IncidentComposer` slash menu: `collisionPadding={8}` on `Popover.Content`, so Radix's collision avoidance keeps an 8px breathing edge instead of kissing the viewport.
- **Bespoke panels** — `NotificationPanel` (`w-96`, right-anchored in the TopBar) and the global TimePicker custom-range dialog (`w-64`, right-anchored): `max-w-[calc(100vw-16px)]` clamps.

### Audited safe by construction (unchanged)

WidgetShell ⋯ menu and the org switcher (anchored toward the viewport center), QueryBar suggestions (`w-full` of its input), CommandPalette/Modal (centered fixed), SpanDrawer (edge sheet), the marketing mobile disclosure (in-flow, full-width), traces-map edge tooltip (interior % anchors inside a bounded card — low risk).

### e2e

- dashboard spec: opens the global TimePicker custom popover **and** the bell popover at **1440** and **1024** (the QA'd chrome floor) and asserts both bounding boxes stay inside the viewport.
- home spec (390): the mobile disclosure panel's bounding box is asserted within the viewport.

### Known finding (out of scope, needs its own pass)

At 390 the dashboard TopBar's fixed content (~770px of controls) overflows the clipped document, so interacting with right-side controls side-scrolls the chrome itself (probed: the bell panel lands at x=-302 because the whole positioned ancestor shifts). That is a TopBar responsiveness work item, not layer collision — flagging rather than folding it in.

## Test plan

- [x] `npm run lint` / `typecheck` — clean
- [x] `npm run test` — 216/216
- [x] `NEXT_PUBLIC_TEST_MODE=1 npm run build` — clean
- [x] `npm run test:e2e` — 21/21 (incl. the two new viewport-bounds tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)