### PR TITLE
docs: marketing content revision — Platform nav slot + community-CTA placement canon

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -98,8 +98,9 @@ verified in both themes) — the one extra constraint the teal brand imposes.
   "Marketing nav, footer & theme parity canon", ratified 2026-07-19): all
   three products share ONE link inventory — same sections, counts and
   destinations; upstat renders it in its own dark visual design.
-  - **Nav** **[Revised 2026-07-19]**: 4 text links Features · Dashboards
-    (upstat product slot) · Docs (GitBook root) · GitHub — the GitHub item
+  - **Nav** **[Revised 2026-07-19]**: 4 text links Features · Platform
+    (upstat product slot — anchors to the landing pillar-grid section) ·
+    Docs (GitBook root) · GitHub — the GitHub item
     renders as a compact star badge (star glyph + neutral "Star" label; no
     count on canvas — the live star count is runtime behavior) — +
     ThemeToggle control + **"Sign in" text link** (`/signin`) + **"Try
@@ -107,7 +108,7 @@ verified in both themes) — the one extra constraint the teal brand imposes.
     mini feature map survives only as the dropdown-open preview under
     Features.)
   - **Footer**: brand block (wordmark + tagline) + 4 pinned columns — Product
-    (Features · Try Cloud · Self Host · Dashboards) / Docs (Docs · Quickstart
+    (Features · Try Cloud · Self Host · Platform) / Docs (Docs · Quickstart
     · API reference · Self-host guide) / Community (GitHub · Discord ·
     Roadmap · CueLABS™) / Legal (Privacy · Terms · Status) — + legal bar
     verbatim **"© Cuesoft Inc. 2026. Upstat. CueLABS™ Division. MIT
@@ -392,7 +393,7 @@ project license, the copy reads **MIT**.
 | WidgetTypeCell | state: default / selected · icon + label tile, one per widget type — iteration-1 addition **[built 2026-07-18]** |
 | WidgetTypePicker | layout: row (the in-shell "Choose a visualization" strip) / grid (create-flow modal overlay, pages.md B2) · 11 widget types (the pages.md B2 list) · composes WidgetTypeCell — iteration-1 addition **[built 2026-07-18]** |
 | **Marketing (Stage 5)** | |
-| MarketingNav + PillarDropdown | default / pillar-dropdown open (mini feature map ×8, reuses PillarCard) · 4 text links pinned to the parity canon: Features · Dashboards · Docs · GitHub — the GitHub item renders as a compact star badge (star glyph + neutral "Star" label — no count, no invented figure; the pages.md A13 live star count is runtime behavior) · ThemeToggle · "Sign in" text link (`/signin`) + "Try Cloud" brand CTA **[Revised 2026-07-19]** (the pillar mini feature map remains as the dropdown-open preview under Features) |
+| MarketingNav + PillarDropdown | default / pillar-dropdown open (mini feature map ×8, reuses PillarCard) · 4 text links pinned to the parity canon: Features · Platform (anchors to the landing pillar grid) · Docs · GitHub — the GitHub item renders as a compact star badge (star glyph + neutral "Star" label — no count, no invented figure; the pages.md A13 live star count is runtime behavior) · ThemeToggle · "Sign in" text link (`/signin`) + "Try Cloud" brand CTA **[Revised 2026-07-19]** (the pillar mini feature map remains as the dropdown-open preview under Features) |
 | MarketingFooter | brand block (wordmark + tagline) + 4 pinned columns Product / Docs / Community / Legal (4·4·4·3 links, parity canon) + legal bar verbatim "© Cuesoft Inc. 2026. Upstat. CueLABS™ Division. MIT License." · language selector (English-only pre-i18n) · security-policy affordance — **[Directive 2026-07-19]** |
 | PillarCard | pillar ×8 (icon + pillar color accent) · default / hover (lift + accent) |
 | CodeSnippet + Tabs | tab: Go / Python / Node / k8s (active/inactive) · copy: idle / copied-check · mono block on `bg-elev` — **as built (2026-07-17):** the tab axis is the variant set; copy idle/copied-check is handled via instance overrides, not a variant dimension |

--- a/docs/pages.md
+++ b/docs/pages.md
@@ -17,15 +17,15 @@ community-driven") remains the visual base, extended for the new pillars.
 
 | # | Section | Content | Interactions |
 | --- | --- | --- | --- |
-| A1 | Nav | logo · Platform (pillar dropdown) · Docs (GitBook) · Community · GitHub badge · Sign in · **Try Cloud** | pillar dropdown = mini feature map |
+| A1 | Nav | logo · Features (pillar-map dropdown) · Platform (anchors to the A3 pillar grid) · Docs (GitBook) · GitHub star badge (neutral "Star") · ThemeToggle · Sign in text link · **Try Cloud** CTA **[Revised 2026-07-19]** | Features dropdown = mini feature map |
 | A2 | Hero | H1 (from Figma pillars); dual CTA **Try Cloud** / **Self Host**; hero visual: live-looking dashboard with animated timeseries + synced crosshair demo | crosshair demo animates on an 8s loop |
 | A3 | Pillar grid | 8 cards: Uptime & Synthetics · Website Analytics/RUM · Metrics · Logs · APM/Traces · Dashboards · Alerting · Incidents & SLOs | hover lifts + pillar color accent |
 | A4 | Demo strip | **static demo cards** (synthetic data, U0-3) — the interactive embedded demo org is descoped to a post-Phase-3 enhancement **[Decided]** | — |
 | A5 | How ingestion works | OTLP/agent diagram: your services → OTel SDK/collector → Upstat | copyable snippet tabs (Go/Python/Node/k8s) |
 | A6 | Reliability showcase | Upstat's own public status page embedded (self-referential trust, PRD §5) | |
 | A7 | Open source | compose snippet, architecture diagram, GitHub/CONTRIBUTING | |
-| A8 | Community | public-status card (live uptime at status.upstat.cuesoft.io/upstat) · roadmap · CueLABS™ **[Revised 2026-07-19]** — community-CTA placement canon: GitHub/Discord moments live in exactly three spots — the nav star badge, the A13 developers pair (#upstat-lab copy), and the footer Community column | |
-| A9 | Cloud vs Self-host table | per-column CTAs · docs deep-link rows under the compose line — self-host guide (docs.upstat.cuesoft.io/self-host) + query grammar (docs.upstat.cuesoft.io/query-grammar) **[Revised 2026-07-19]** | |
+| A8 | Community | public-status card ("View live →" → https://status.cuesoft.io) · roadmap · CueLABS™ **[Revised 2026-07-19]** — community-CTA placement canon: GitHub/Discord moments live in exactly three spots — the nav star badge, the A13 developers pair (#upstat-lab copy), and the footer Community column | |
+| A9 | Cloud vs Self-host table | per-column CTAs · docs deep-link rows under the compose line — "Self-host guide" (→ cuesoft.gitbook.io/upstat/system/deployment) + "Query grammar" (→ cuesoft.gitbook.io/upstat/system/query-grammar); label copy with hyperlinks, no raw URL strings on canvas **[Revised 2026-07-19]** | |
 | A10 | Footer | standard + privacy (UPS-005) | |
 
 Iteration 1 additions **[Directive 2026-07-18]** — existing rows keep their

--- a/docs/pages.md
+++ b/docs/pages.md
@@ -24,7 +24,7 @@ community-driven") remains the visual base, extended for the new pillars.
 | A5 | How ingestion works | OTLP/agent diagram: your services → OTel SDK/collector → Upstat | copyable snippet tabs (Go/Python/Node/k8s) |
 | A6 | Reliability showcase | Upstat's own public status page embedded (self-referential trust, PRD §5) | |
 | A7 | Open source | compose snippet, architecture diagram, GitHub/CONTRIBUTING | |
-| A8 | Community | public-status card ("View live →" → https://status.cuesoft.io) · roadmap · CueLABS™ **[Revised 2026-07-19]** — community-CTA placement canon: GitHub/Discord moments live in exactly three spots — the nav star badge, the A13 developers pair (#upstat-lab copy), and the footer Community column | |
+| A8 | Community | public-status card ("View live →" → https://upstat.cuesoft.io/status/upstat — the product's own status page, dogfooding B7) · roadmap · CueLABS™ **[Revised 2026-07-19]** — community-CTA placement canon: GitHub/Discord moments live in exactly three spots — the nav star badge, the A13 developers pair (#upstat-lab copy), and the footer Community column | |
 | A9 | Cloud vs Self-host table | per-column CTAs · docs deep-link rows under the compose line — "Self-host guide" (→ cuesoft.gitbook.io/upstat/system/deployment) + "Query grammar" (→ cuesoft.gitbook.io/upstat/system/query-grammar); label copy with hyperlinks, no raw URL strings on canvas **[Revised 2026-07-19]** | |
 | A10 | Footer | standard + privacy (UPS-005) | |
 

--- a/docs/pages.md
+++ b/docs/pages.md
@@ -24,8 +24,8 @@ community-driven") remains the visual base, extended for the new pillars.
 | A5 | How ingestion works | OTLP/agent diagram: your services → OTel SDK/collector → Upstat | copyable snippet tabs (Go/Python/Node/k8s) |
 | A6 | Reliability showcase | Upstat's own public status page embedded (self-referential trust, PRD §5) | |
 | A7 | Open source | compose snippet, architecture diagram, GitHub/CONTRIBUTING | |
-| A8 | Community | Discord card, roadmap, CueLABS™ | |
-| A9 | Cloud vs Self-host table | per-column CTAs | |
+| A8 | Community | public-status card (live uptime at status.upstat.cuesoft.io/upstat) · roadmap · CueLABS™ **[Revised 2026-07-19]** — community-CTA placement canon: GitHub/Discord moments live in exactly three spots — the nav star badge, the A13 developers pair (#upstat-lab copy), and the footer Community column | |
+| A9 | Cloud vs Self-host table | per-column CTAs · docs deep-link rows under the compose line — self-host guide (docs.upstat.cuesoft.io/self-host) + query grammar (docs.upstat.cuesoft.io/query-grammar) **[Revised 2026-07-19]** | |
 | A10 | Footer | standard + privacy (UPS-005) | |
 
 Iteration 1 additions **[Directive 2026-07-18]** — existing rows keep their
@@ -36,7 +36,7 @@ page order.
 | --- | --- | --- | --- |
 | A11 | Feature deep-dives | benefit-led deep-dive per pillar (richer than the A3 card grid, slots after A3): headline benefit, 2–3 proof points, real product screenshot — alternating left/right layout | scroll-linked screenshot swap per pillar |
 | A12 | How it works | 3 steps (install snippet → send data → see everything) — each step carries a **real screen thumbnail** from the Stage-4 templates (design.md §8.1), no abstract art; extends A5's diagram | step thumbnail → matching A4 demo card |
-| A13 | For developers — Contribute | stack line (**Go gRPC services · Next.js + React/TS · ClickHouse · OpenTelemetry** — corrected 2026-07-18 QA loop: the web app is Next.js 16.x + React/TS, verified against `web/package.json`; the store is ClickHouse by the ratified R2 decision, not a generic "columnstore"), "interesting problems" list (ingestion pipeline, query grammar, TSDB), good-first-issues + CONTRIBUTING links, Discord invite, GitHub badge — expands A7's repo links, slots after A7 | star badge: count populated at runtime — no number in static designs |
+| A13 | For developers — Contribute | stack line (**Go gRPC services · Next.js + React/TS · ClickHouse · OpenTelemetry** — corrected 2026-07-18 QA loop: the web app is Next.js 16.x + React/TS, verified against `web/package.json`; the store is ClickHouse by the ratified R2 decision, not a generic "columnstore"), "interesting problems" list (ingestion pipeline, query grammar, TSDB), good-first-issues + CONTRIBUTING links, Discord invite, GitHub badge — expands A7's repo links, slots after A7 · the one body section carrying the GitHub + Discord pair (#upstat-lab copy) per the community-CTA placement canon **[Revised 2026-07-19]** | star badge: count populated at runtime — no number in static designs |
 | A14 | Self-host | data-ownership pitch (your telemetry, your box), compose one-liner, what ships in the box (every pillar, no feature gates), self-host docs link — expands A7's compose snippet, pairs with A9 | copy button on the one-liner |
 | A15 | FAQ | 4–5 product Q&As: cloud vs self-host? · OTel-compatible? · what happens at retention limits? · is everything open source? · how is this not Datadog? | accordion, single-open |
 | A16 | Final CTA band | full-width closing band: one-line pitch + dual CTA **Try Cloud** / **Self Host** (mirrors A2), sits above A10 | |


### PR DESCRIPTION
## Summary

Retro-fits today's three marketing-content decisions into the docs **[Revised 2026-07-19]**:

- **`design.md`** — the nav's upstat product slot is **"Platform"** (anchors to the landing pillar-grid section, not the app): §2 parity-canon nav bullet, §2 footer Product column (Features · Try Cloud · Self Host · Platform), §8.2b MarketingNav row.
- **`pages.md` A1** — rewritten to the as-built canon nav: Features (pillar-map dropdown) · Platform (pillar-grid anchor) · Docs (GitBook) · GitHub star badge (neutral "Star") · ThemeToggle · Sign in text link · Try Cloud CTA.
- **`pages.md` A8 (Community)** — carries the **public-status card** ("View live →" → https://upstat.cuesoft.io/status/upstat — the product's own status page, dogfooding B7; the org status site stays the footer Legal column's Status link) · roadmap · CueLABS™, per the **community-CTA placement canon**: GitHub/Discord moments live in exactly three spots — the nav star badge, the A13 developers pair (#upstat-lab copy), and the footer Community column.
- **`pages.md` A9** — docs deep-link rows under the compose line: "Self-host guide" (→ cuesoft.gitbook.io/upstat/system/deployment) + "Query grammar" (→ cuesoft.gitbook.io/upstat/system/query-grammar) — label copy with hyperlinks, no raw URL strings on canvas ("Links are real" canon).
- **`pages.md` A13** — marked as the one body section keeping the GitHub + Discord pair.

Matches the Figma file as revised today (MarketingNav 98:1710 · MarketingFooter 290:2 · Home 135:2 bottom sections incl. the A6 caption 135:686 re-pointed to the live status page; Home 135:3 + QA 100:2101 instances verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)