### PR TITLE
fix(web): mobile TopBar — collapse the utility cluster below md (390 support)

### DIFF
--- a/docs/web-implementation.md
+++ b/docs/web-implementation.md
@@ -203,6 +203,21 @@ needs those") — stale `/login` links 404 on the branded not-found page;
 `/signin` stays the only auth route. Root prose carries the CueLABS™
 mark (Makefile/CONTRIBUTING byte-identical to the generator templates).
 
+**Mobile TopBar as-built (2026-07-19).** Below `md` the dashboard TopBar's
+fixed-width utility cluster (~770px: org/env + preset TimePicker + w-56
+search + toggle + bell) overflowed the clipped document — right-side taps
+side-scrolled the chrome itself (probed: the bell panel landed at
+x=−302). The cluster now collapses at <md: the org switcher compacts
+(name truncates at 96px, env chip hides), the global TimePicker collapses
+to its calendar icon-button and its absolute-range dialog becomes a fixed
+full-width sheet under the bar (viewport-bounded by construction), search
+collapses to an icon button (same CommandPalette trigger; `/` still
+works), ThemeToggle and the bell stay as icons. Floating layers keep the
+collision clamps from the 2026-07-19 sweep. Playwright (390): no
+horizontal document scroll, every TopBar control visible/operable
+in-viewport, TimePicker sheet + bell popover + org menu bounding boxes
+inside the viewport. Desktop (md+) is untouched.
+
 Screen-state parity **[Directive 2026-07-18, carried from design.md §8.1]**:
 every data-driven screen ships default, empty, and loading states — the
 three-frame rule applies to the implementation exactly as it does to the

--- a/web/e2e/dashboard.spec.ts
+++ b/web/e2e/dashboard.spec.ts
@@ -62,6 +62,71 @@ test("semantic landmarks: one main, nav rail, banner, single h1", async ({ page 
   await expect(page.getByRole("list", { name: "Dashboards" }).first()).toBeVisible();
 });
 
+test("TopBar collapses to icon utilities at 390 — no overflow, everything operable", async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await signIn(page);
+  const banner = page.getByRole("banner");
+
+  // the document does not scroll horizontally, and no chrome side-scroll
+  const docOverflow = await page.evaluate(
+    () => document.documentElement.scrollWidth - document.documentElement.clientWidth,
+  );
+  expect(docOverflow).toBeLessThanOrEqual(0);
+
+  // every TopBar control sits fully inside the viewport
+  const controls: [string, ReturnType<typeof banner.getByRole>][] = [
+    ["org switcher", banner.locator('button[aria-haspopup="menu"]')],
+    ["time picker", banner.getByRole("button", { name: "Custom range" })],
+    ["search", banner.getByRole("button", { name: "Search" })],
+    ["theme toggle", banner.getByTestId("theme-toggle")],
+    ["bell", banner.getByRole("button", { name: /Notifications/ })],
+  ];
+  for (const [label, control] of controls) {
+    await expect(control, label).toBeVisible();
+    const box = (await control.boundingBox())!;
+    expect(box.x, label).toBeGreaterThanOrEqual(0);
+    expect(box.x + box.width, `${label} right edge`).toBeLessThanOrEqual(390);
+  }
+
+  // TimePicker → the fixed sheet dialog, in-viewport
+  await banner.getByRole("button", { name: "Custom range" }).click();
+  const customRange = page.getByRole("dialog", { name: "Absolute range" });
+  await expect(customRange).toBeVisible();
+  const dialogBox = (await customRange.boundingBox())!;
+  expect(dialogBox.x).toBeGreaterThanOrEqual(0);
+  expect(dialogBox.x + dialogBox.width).toBeLessThanOrEqual(390);
+  await page.keyboard.press("Escape");
+  await expect(customRange).toBeHidden();
+
+  // bell popover in-viewport, no chrome side-scroll after the tap
+  await banner.getByRole("button", { name: /Notifications/ }).click();
+  const notifications = page.getByRole("dialog", { name: "Notifications" });
+  await expect(notifications).toBeVisible();
+  const bellBox = (await notifications.boundingBox())!;
+  expect(bellBox.x).toBeGreaterThanOrEqual(0);
+  expect(bellBox.x + bellBox.width).toBeLessThanOrEqual(390);
+  expect(await page.evaluate(() => window.scrollX)).toBe(0);
+  await banner.getByRole("button", { name: /Notifications/ }).click();
+
+  // search icon opens the CommandPalette
+  await banner.getByRole("button", { name: "Search" }).click();
+  await expect(page.getByRole("dialog", { name: "Command palette" })).toBeVisible();
+  await page.keyboard.press("Escape");
+
+  // theme toggle still flips from the collapsed bar
+  await banner.getByTestId("theme-toggle").click();
+  await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
+  await banner.getByTestId("theme-toggle").click();
+
+  // org switcher opens its menu in-viewport
+  await banner.locator('button[aria-haspopup="menu"]').click();
+  const orgs = page.getByRole("navigation", { name: "Organizations" });
+  await expect(orgs).toBeVisible();
+  const orgBox = (await orgs.boundingBox())!;
+  expect(orgBox.x).toBeGreaterThanOrEqual(0);
+  expect(orgBox.x + orgBox.width).toBeLessThanOrEqual(390);
+});
+
 test("right-anchored TopBar layers stay inside the viewport (review class 2026-07-19)", async ({ page }) => {
   await page.setViewportSize({ width: 1440, height: 900 });
   await signIn(page);

--- a/web/src/components/ui/TimePicker.tsx
+++ b/web/src/components/ui/TimePicker.tsx
@@ -19,6 +19,11 @@ export interface TimePickerProps {
 /**
  * TimePicker — §3/§8.2: presets ×5 + custom + live toggle. Global and
  * URL-synced at screen level (MI-1); this component owns the control UI.
+ *
+ * Mobile (<md, 390 support): the ~285px preset row overflowed the TopBar —
+ * presets and the live toggle collapse away, leaving the calendar icon
+ * button, and the absolute-range dialog becomes a fixed full-width sheet
+ * under the bar so it can never leave the viewport.
  */
 export function TimePicker({ value, onChange, live = false, onLiveChange, className }: TimePickerProps) {
   const [customOpen, setCustomOpen] = useState(false);
@@ -40,7 +45,7 @@ export function TimePicker({ value, onChange, live = false, onLiveChange, classN
             onChange(preset);
           }}
           className={clsx(
-            "px-2 text-[12px] font-medium tabular-nums transition-colors duration-[var(--duration-fast)] ease-standard",
+            "hidden px-2 text-[12px] font-medium tabular-nums transition-colors duration-[var(--duration-fast)] ease-standard md:block",
             value === preset
               ? "bg-bg-elev text-brand"
               : "text-text-2 hover:text-text",
@@ -63,21 +68,22 @@ export function TimePicker({ value, onChange, live = false, onLiveChange, classN
             if (e.key === "Escape") setCustomOpen(false);
           }}
           className={clsx(
-            "flex items-center gap-1 border-l border-border px-2 text-[12px] font-medium",
+            "flex items-center gap-1 px-2 text-[12px] font-medium md:border-l md:border-border",
             "transition-colors duration-[var(--duration-fast)] ease-standard",
             value === "custom" ? "bg-bg-elev text-brand" : "text-text-2 hover:text-text",
           )}
         >
           <Calendar aria-hidden="true" className="size-3.5" />
-          custom
+          <span className="hidden md:inline">custom</span>
         </button>
         {customOpen && (
           <div
             role="dialog"
             aria-label="Absolute range"
-            // max-w clamp: right-anchored in the TopBar — the panel must
-            // never overflow the screen (review class 2026-07-19, expendit)
-            className="absolute right-0 top-full z-[var(--z-dropdown)] mt-1 flex w-64 max-w-[calc(100vw-16px)] flex-col gap-2 rounded-(--radius) border border-border bg-bg-elev p-3 shadow-lg"
+            // never leaves the viewport (review class 2026-07-19, expendit):
+            // <md a fixed full-width sheet under the bar; md+ right-anchored
+            // to the control with the max-w clamp
+            className="fixed inset-x-2 top-14 z-[var(--z-dropdown)] flex flex-col gap-2 rounded-(--radius) border border-border bg-bg-elev p-3 shadow-lg md:absolute md:inset-x-auto md:right-0 md:top-full md:mt-1 md:w-64 md:max-w-[calc(100vw-16px)]"
           >
             <label className="flex flex-col gap-1 text-[12px] text-text-2">
               From
@@ -102,7 +108,7 @@ export function TimePicker({ value, onChange, live = false, onLiveChange, classN
           aria-pressed={live}
           onClick={() => onLiveChange(!live)}
           className={clsx(
-            "flex items-center gap-1.5 border-l border-border px-2 text-[12px] font-medium",
+            "hidden items-center gap-1.5 border-l border-border px-2 text-[12px] font-medium md:flex",
             "transition-colors duration-[var(--duration-fast)] ease-standard",
             live ? "text-brand" : "text-text-2 hover:text-text",
           )}

--- a/web/src/components/ui/TopBar.tsx
+++ b/web/src/components/ui/TopBar.tsx
@@ -21,7 +21,17 @@ export interface TopBarProps {
   className?: string;
 }
 
-/** TopBar — §2 layout: org/env switcher · global time picker · search (/) · bell. */
+/**
+ * TopBar — §2 layout: org/env switcher · global time picker · search (/) ·
+ * bell.
+ *
+ * Mobile (<md, 390 support): the fixed-width utility cluster (~770px) used
+ * to overflow the clipped document — right-side taps side-scrolled the
+ * chrome itself (probed 2026-07-19). The cluster now collapses: org name
+ * truncates and the env chip hides, the TimePicker collapses to its
+ * calendar icon (see TimePicker), search collapses to an icon button
+ * (still opens the CommandPalette), ThemeToggle + bell stay as icons.
+ */
 export function TopBar({
   orgName,
   env = "prod",
@@ -36,7 +46,7 @@ export function TopBar({
   return (
     <header
       className={clsx(
-        "font-ui sticky top-0 z-[var(--z-sticky)] flex h-12 items-center gap-3",
+        "font-ui sticky top-0 z-[var(--z-sticky)] flex h-12 items-center gap-1.5 md:gap-3",
         "border-b border-border bg-bg px-3",
         className,
       )}
@@ -45,13 +55,13 @@ export function TopBar({
         type="button"
         onClick={onOrgClick}
         aria-haspopup="menu"
-        className="flex items-center gap-1.5 rounded-(--radius) px-2 py-1 text-[13px] font-medium text-text transition-colors duration-[var(--duration-fast)] hover:bg-bg-elev"
+        className="flex min-w-0 items-center gap-1.5 rounded-(--radius) px-2 py-1 text-[13px] font-medium text-text transition-colors duration-[var(--duration-fast)] hover:bg-bg-elev"
       >
-        {orgName}
-        <span className="rounded-(--radius) border border-border px-1 text-[10px] uppercase tracking-wide text-text-2">
+        <span className="max-w-[96px] truncate md:max-w-none">{orgName}</span>
+        <span className="hidden rounded-(--radius) border border-border px-1 text-[10px] uppercase tracking-wide text-text-2 md:inline-block">
           {env}
         </span>
-        <ChevronDown aria-hidden="true" className="size-3.5 text-text-2" />
+        <ChevronDown aria-hidden="true" className="size-3.5 shrink-0 text-text-2" />
       </button>
 
       <div className="flex-1" />
@@ -61,11 +71,14 @@ export function TopBar({
       <button
         type="button"
         onClick={onSearchClick}
-        className="flex h-8 w-56 items-center gap-2 rounded-(--radius) border border-border bg-bg-elev px-2 text-[13px] text-text-2 transition-colors duration-[var(--duration-fast)] hover:border-text-2"
+        aria-label="Search"
+        className="flex h-8 w-8 items-center justify-center gap-2 rounded-(--radius) border border-border bg-bg-elev text-[13px] text-text-2 transition-colors duration-[var(--duration-fast)] hover:border-text-2 md:w-56 md:justify-start md:px-2"
       >
-        <Search aria-hidden="true" className="size-3.5" />
-        <span className="flex-1 text-left">Search…</span>
-        <KbdChip keys="/" />
+        <Search aria-hidden="true" className="size-3.5 shrink-0" />
+        <span className="hidden flex-1 text-left md:block">Search…</span>
+        <span className="hidden md:inline-flex">
+          <KbdChip keys="/" />
+        </span>
       </button>
 
       {/* theme-parity canon (SKILL.md 2026-07-19): the toggle lives in the

--- a/web/src/components/ui/ZoomStackChip.test.tsx
+++ b/web/src/components/ui/ZoomStackChip.test.tsx
@@ -11,4 +11,12 @@ describe("ZoomStackChip", () => {
     await userEvent.click(screen.getByLabelText("Reset zoom"));
     expect(onReset).toHaveBeenCalledOnce();
   });
+
+  it("compacts below md — the range label collapses, depth + reset stay (390 TopBar)", () => {
+    render(<ZoomStackChip depth={2} label="09:12–09:40" onReset={() => undefined} />);
+    // browsers apply the breakpoint; the pin is the responsive classes
+    expect(screen.getByText("09:12–09:40")).toHaveClass("hidden", "md:inline");
+    expect(screen.getByText("×2")).not.toHaveClass("hidden");
+    expect(screen.getByLabelText("Reset zoom")).toBeInTheDocument();
+  });
 });

--- a/web/src/components/ui/ZoomStackChip.tsx
+++ b/web/src/components/ui/ZoomStackChip.tsx
@@ -25,7 +25,10 @@ export function ZoomStackChip({ depth, label, onReset, className }: ZoomStackChi
     >
       <ZoomIn aria-hidden="true" className="size-3 text-text-2" />
       <span className="tabular-nums text-text-2">×{depth}</span>
-      <span className="tabular-nums">{label}</span>
+      {/* the range label is the wide part — it collapses with the mobile
+          TopBar treatment (<md) so a zoomed chart can't re-overflow the
+          bar; depth + reset stay (PR 164 review) */}
+      <span className="hidden tabular-nums md:inline">{label}</span>
       {onReset && (
         <button
           type="button"


### PR DESCRIPTION
## Summary

Fixes the 390w dashboard-chrome overflow flagged in #158: the TopBar's fixed-width utility cluster (~770px — org/env switcher + 5-preset TimePicker + `w-56` search + ThemeToggle + bell) overflowed the clipped document, so tapping right-side controls side-scrolled the chrome itself (probed: the bell panel landed at x=−302 because its positioned ancestor scrolled).

### Mobile treatment (<md), per upstat's design language

- **Org/env switcher** compacts: org name truncates at 96px, env chip hides (returns at `md`).
- **Global TimePicker** collapses to its calendar icon-button; the absolute-range dialog becomes a **fixed full-width sheet under the bar** (`inset-x-2 top-14`) — viewport-bounded by construction. Presets ×5 + live toggle return at `md`.
- **Search** collapses to an icon button (`aria-label="Search"`), still opening the CommandPalette; the `/` shortcut is unaffected.
- **ThemeToggle + bell** stay as icons; bar gaps compress (`gap-1.5 md:gap-3`).
- Floating layers keep the collision clamps from the #158 sweep. Desktop (`md+`) is visually untouched.

### e2e (390, new test in `e2e/dashboard.spec.ts`)

- `document.scrollWidth − clientWidth ≤ 0` (no horizontal document scroll)
- every TopBar control visible with its bounding box fully inside the viewport
- TimePicker sheet, bell popover, and org-switcher menu bounding boxes in-viewport; `window.scrollX === 0` after the bell tap
- every control operable: TimePicker opens/Escape-closes, search opens the CommandPalette, theme flips, org menu opens

Screenshots taken at 390 in both themes (dark + light, incl. open TimePicker sheet and bell popover) — verified visually.

## Test plan

- [x] lint / typecheck (pipefail) — clean
- [x] unit — 82 files
- [x] `NEXT_PUBLIC_TEST_MODE=1` build — clean
- [x] Playwright e2e — 22/22 (incl. the new 390 TopBar test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)