### PR TITLE
fix(web): mobile-responsive dashboard content — every route fits 390

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -134,7 +134,7 @@ observability-service touch, not as its own phase.
 - **X-6 Environments & deploy gating (RATIFIED 2026-07-16, deliberate
   deviation from the cueprise norm)**: `stg` = **sandbox** and is the ONLY
   environment — no production deployment exists for these products. Secrets
-  live in Doppler `<project>/stg`. Because these repos are **open source**,
+  live in Doppler `<project>/stg`. Because these repos are **open-source**,
   merge-to-main must NOT deploy: main-merge runs build+test only. **Deploys
   happen exclusively on tag creation (`v*`)**, treated as production-grade:
   a GitHub tag ruleset restricts `v*` creation to owner-level access, and the

--- a/docs/pages.md
+++ b/docs/pages.md
@@ -23,7 +23,7 @@ community-driven") remains the visual base, extended for the new pillars.
 | A4 | Demo strip | **static demo cards** (synthetic data, U0-3) — the interactive embedded demo org is descoped to a post-Phase-3 enhancement **[Decided]** | — |
 | A5 | How ingestion works | OTLP/agent diagram: your services → OTel SDK/collector → Upstat | copyable snippet tabs (Go/Python/Node/k8s) |
 | A6 | Reliability showcase | Upstat's own public status page embedded (self-referential trust, PRD §5) | |
-| A7 | Open source | compose snippet, architecture diagram, GitHub/CONTRIBUTING | |
+| A7 | Open-source | compose snippet, architecture diagram, GitHub/CONTRIBUTING | |
 | A8 | Community | public-status card ("View live →" → https://upstat.cuesoft.io/status/upstat — the product's own status page, dogfooding B7) · roadmap · CueLABS™ **[Revised 2026-07-19]** — community-CTA placement canon: GitHub/Discord moments live in exactly three spots — the nav star badge, the A13 developers pair (#upstat-lab copy), and the footer Community column | |
 | A9 | Cloud vs Self-host table | per-column CTAs · docs deep-link rows under the compose line — "Self-host guide" (→ cuesoft.gitbook.io/upstat/system/deployment) + "Query grammar" (→ cuesoft.gitbook.io/upstat/system/query-grammar); label copy with hyperlinks, no raw URL strings on canvas **[Revised 2026-07-19]** | |
 | A10 | Footer | standard + privacy (UPS-005) | |
@@ -38,7 +38,7 @@ page order.
 | A12 | How it works | 3 steps (install snippet → send data → see everything) — each step carries a **real screen thumbnail** from the Stage-4 templates (design.md §8.1), no abstract art; extends A5's diagram | step thumbnail → matching A4 demo card |
 | A13 | For developers — Contribute | stack line (**Go gRPC services · Next.js + React/TS · ClickHouse · OpenTelemetry** — corrected 2026-07-18 QA loop: the web app is Next.js 16.x + React/TS, verified against `web/package.json`; the store is ClickHouse by the ratified R2 decision, not a generic "columnstore"), "interesting problems" list (ingestion pipeline, query grammar, TSDB), good-first-issues + CONTRIBUTING links, Discord invite, GitHub badge — expands A7's repo links, slots after A7 · the one body section carrying the GitHub + Discord pair (#upstat-lab copy) per the community-CTA placement canon **[Revised 2026-07-19]** | star badge: count populated at runtime — no number in static designs |
 | A14 | Self-host | data-ownership pitch (your telemetry, your box), compose one-liner, what ships in the box (every pillar, no feature gates), self-host docs link — expands A7's compose snippet, pairs with A9 | copy button on the one-liner |
-| A15 | FAQ | 4–5 product Q&As: cloud vs self-host? · OTel-compatible? · what happens at retention limits? · is everything open source? · how is this not Datadog? | accordion, single-open |
+| A15 | FAQ | 4–5 product Q&As: cloud vs self-host? · OTel-compatible? · what happens at retention limits? · is everything open-source? · how is this not Datadog? | accordion, single-open |
 | A16 | Final CTA band | full-width closing band: one-line pitch + dual CTA **Try Cloud** / **Self Host** (mirrors A2), sits above A10 | |
 
 ## Part B — Dashboard (the observability app)

--- a/docs/web-implementation.md
+++ b/docs/web-implementation.md
@@ -218,6 +218,30 @@ horizontal document scroll, every TopBar control visible/operable
 in-viewport, TimePicker sheet + bell popover + org menu bounding boxes
 inside the viewport. Desktop (md+) is untouched.
 
+**Mobile content as-built (2026-07-19).** Beyond the TopBar, every pillar
+screen's CONTENT fits the 390 viewport (768 sanity-checked): explorer
+facet sidebars (logs, metrics) stack above their streams below `lg`;
+stat-tile and card grids start single-column and widen at `sm`/`lg`/`xl`;
+the B2 12-col widget grid stacks single-column in reading order below
+`md` (drag/resize affordances stay desktop-only — positions are 12-col
+coordinates); wide visualizations scroll horizontally *inside* their
+panels, never the document — `Table`, the bespoke APM service/endpoint
+tables and trace-result rows, `TraceWaterfall` (560px min canvas),
+`Heatmap`, `LogHistogram`, the service-map topology (880px min canvas)
+and `UptimeCard`'s 90-day strip; `SpanDrawer` becomes a full-width fixed
+sheet below `lg`; `Modal`/`Sheet` clamp to the viewport. Two
+intrinsic-sizing traps are codified from this pass: percentage
+`max-w-full` is ignored during intrinsic width computation (grids need
+explicit `grid-cols-1` / `minmax(0,…)` tracks and flex items `min-w-0`
+for truncation to actually bound a track), and the UA default
+`min-inline-size: min-content` on `<fieldset>` requires `min-w-0`.
+`e2e/mobile-responsive.spec.ts` sweeps every §4 route at 390 in both
+themes (with screenshots) plus a 768 pass — asserting the document never
+side-scrolls, `<main>` never pans, and any element wider than the
+viewport sits inside a horizontal-scroll container — and covers the
+span-drawer sheet, stacked widget grid + widget editor, and log-line
+expansion at 390.
+
 Screen-state parity **[Directive 2026-07-18, carried from design.md §8.1]**:
 every data-driven screen ships default, empty, and loading states — the
 three-frame rule applies to the implementation exactly as it does to the

--- a/docs/web-implementation.md
+++ b/docs/web-implementation.md
@@ -242,6 +242,21 @@ viewport sits inside a horizontal-scroll container — and covers the
 span-drawer sheet, stacked widget grid + widget editor, and log-line
 expansion at 390.
 
+Marketing surfaces in the same pass (user-ratified, 2026-07-19): below
+`md` the MarketingNav bar keeps the **Try Cloud** CTA (compact size)
+beside the hamburger — always visible, so it is not duplicated in the
+disclosure panel, which carries the 4 canonical links + ThemeToggle +
+Sign in. MarketingFooter converges to the sibling mobile structure:
+brand block + 4 link columns render as ONE responsive grid
+(`grid-cols-2 gap-8 md:grid-cols-5`, brand `col-span-2 md:col-span-1` —
+full-width brand row at 390, orderly 2-col link columns, one 5-col row
+at md+), and the legal bar is `flex flex-wrap justify-between` with the
+© line first and the Security + language utilities as one grouped
+cluster wrapping beneath it at 390. The root layout carries
+`suppressHydrationWarning` on `<html>` (apparule ThemeProvider
+contract) — the pre-paint theme script sets `data-theme` before React
+hydrates.
+
 Screen-state parity **[Directive 2026-07-18, carried from design.md §8.1]**:
 every data-driven screen ships default, empty, and loading states — the
 three-frame rule applies to the implementation exactly as it does to the

--- a/web/e2e/home.spec.ts
+++ b/web/e2e/home.spec.ts
@@ -62,7 +62,7 @@ test("home renders every Part A section", async ({ page }) => {
   // CTA-dedupe canon: the one GitHub+Discord pair lives in A13; A8 carries
   // the CueLABS™ card + docs links
   await expect(page.getByText("Discord — #upstat-lab on the CueLABS™ server")).toBeVisible();
-  await expect(page.getByText("CueLABS™ — more open source from Cuesoft")).toBeVisible();
+  await expect(page.getByText("CueLABS™ — more open-source from Cuesoft")).toBeVisible();
 
   // A15 FAQ · A16 CTA band · A10 footer
   await expect(page.getByText("Questions, answered.")).toBeVisible();

--- a/web/e2e/home.spec.ts
+++ b/web/e2e/home.spec.ts
@@ -62,7 +62,7 @@ test("home renders every Part A section", async ({ page }) => {
   // CTA-dedupe canon: the one GitHub+Discord pair lives in A13; A8 carries
   // the CueLABS™ card + docs links
   await expect(page.getByText("Discord — #upstat-lab on the CueLABS™ server")).toBeVisible();
-  await expect(page.getByText("CueLABS™ — more open-source from Cuesoft")).toBeVisible();
+  await expect(page.getByText("CueLABS™ — more open-source software from Cuesoft")).toBeVisible();
 
   // A15 FAQ · A16 CTA band · A10 footer
   await expect(page.getByText("Questions, answered.")).toBeVisible();

--- a/web/e2e/home.spec.ts
+++ b/web/e2e/home.spec.ts
@@ -94,7 +94,7 @@ test("nav + footer carry the canonical parity links (SKILL.md canon)", async ({ 
   }
   await expect(nav.getByTestId("theme-toggle")).toBeVisible();
   await expect(nav.getByRole("link", { name: "Sign in" })).toHaveAttribute("href", "/signin");
-  await expect(nav.getByRole("button", { name: "Try Cloud" })).toBeVisible();
+  await expect(nav.getByRole("button", { name: "Try Cloud" }).filter({ visible: true })).toBeVisible();
 
   const footer = page.getByRole("contentinfo"); // panel legends are scoped <footer>s — the landmark is the page footer
   const columns: [string, [string, string][]][] = [
@@ -210,7 +210,7 @@ test("CTAs hand off into the app: Try Cloud → /signin (§8.4 cross-page)", asy
   const nav = page.getByRole("navigation", { name: "Marketing" });
 
   // nav Try Cloud primary CTA (back per the canon revision 2026-07-19)
-  await nav.getByRole("button", { name: "Try Cloud" }).click();
+  await nav.getByRole("button", { name: "Try Cloud" }).filter({ visible: true }).click();
   await page.waitForURL("**/signin");
   await expect(page.getByTestId("signin-screen")).toBeVisible();
 
@@ -279,7 +279,7 @@ test("enabled controls carry the pointer cursor (Directive 2026-07-19)", async (
   const cursorOf = (locator: ReturnType<typeof page.locator>) =>
     locator.evaluate((el) => getComputedStyle(el).cursor);
   // a rendered button — the base-layer rule, not a per-component class
-  expect(await cursorOf(nav.getByRole("button", { name: "Try Cloud" }))).toBe("pointer");
+  expect(await cursorOf(nav.getByRole("button", { name: "Try Cloud" }).filter({ visible: true }))).toBe("pointer");
   // a nav link — links keep the native pointer
   expect(await cursorOf(nav.getByRole("link", { name: "Docs" }))).toBe("pointer");
 });
@@ -296,6 +296,14 @@ test("mobile nav is a menu-button disclosure at 390w (SKILL.md mobile clause)", 
   await expect(menuButton).toBeVisible();
   await expect(menuButton).toHaveAttribute("aria-expanded", "false");
   await expect(panel).toBeHidden();
+
+  // [Revised 2026-07-19] the bar keeps the Try Cloud CTA beside the
+  // hamburger at every viewport — visible and inside the viewport at 390
+  const barCta = nav.getByRole("button", { name: "Try Cloud" }).filter({ visible: true });
+  await expect(barCta).toBeVisible();
+  const ctaBox = (await barCta.boundingBox())!;
+  expect(ctaBox.x).toBeGreaterThanOrEqual(0);
+  expect(ctaBox.x + ctaBox.width).toBeLessThanOrEqual(390);
 
   // open — retry until React's handler is attached (dev hydrates slowly)
   await expect(async () => {
@@ -332,8 +340,10 @@ test("mobile nav is a menu-button disclosure at 390w (SKILL.md mobile clause)", 
   await panel.getByTestId("theme-toggle").click();
   await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
 
-  // Sign in text link is present; the Try Cloud CTA hands off into the app
+  // Sign in text link is present; Try Cloud lives in the bar, NOT the
+  // panel ([Revised 2026-07-19] — no duplication), and hands off to the app
   await expect(panel.getByRole("link", { name: "Sign in" })).toHaveAttribute("href", "/signin");
-  await panel.getByRole("button", { name: "Try Cloud" }).click();
+  await expect(panel.getByRole("button", { name: "Try Cloud" })).toHaveCount(0);
+  await barCta.click();
   await page.waitForURL("**/signin");
 });

--- a/web/e2e/mobile-responsive.spec.ts
+++ b/web/e2e/mobile-responsive.spec.ts
@@ -1,0 +1,238 @@
+import { expect, test, type Page, type TestInfo } from "@playwright/test";
+
+/**
+ * Mobile responsiveness sweep ([Directive 2026-07-19]): home, the public
+ * status page and EVERY /dashboard/<area> route render inside the 390px
+ * viewport — the document never side-scrolls, <main> never pans, and wide
+ * visualizations/tables scroll inside their own horizontal-scroll
+ * containers. Detail drawers become full-width sheets. 768 gets a sanity
+ * pass. Screenshots land per route in both themes (test-results/).
+ */
+
+const MOBILE = { width: 390, height: 844 };
+const TABLET = { width: 768, height: 1024 };
+
+/** Every route in the web-implementation.md §4 route map (seeded ids §6). */
+const ROUTES = [
+  "/",
+  "/signin",
+  "/status/upstat",
+  "/dashboard",
+  "/dashboard/onboarding",
+  "/dashboard/dashboards",
+  "/dashboard/dashboards/dash_overview",
+  "/dashboard/metrics",
+  "/dashboard/metrics/summary",
+  "/dashboard/logs",
+  "/dashboard/traces",
+  "/dashboard/traces/explorer",
+  "/dashboard/traces/map",
+  "/dashboard/traces/services/api-common",
+  "/dashboard/rum",
+  "/dashboard/rum/new",
+  "/dashboard/uptime",
+  "/dashboard/uptime/mon_homepage",
+  "/dashboard/monitors",
+  "/dashboard/monitors/new",
+  "/dashboard/monitors/mon_api",
+  "/dashboard/incidents",
+  "/dashboard/incidents/inc_42",
+  "/dashboard/slos",
+  "/dashboard/services",
+  "/dashboard/settings",
+  "/dashboard/settings/members",
+  "/dashboard/settings/keys",
+  "/dashboard/settings/properties",
+  "/dashboard/settings/integrations",
+  "/dashboard/settings/retention",
+  "/dashboard/settings/org",
+];
+
+interface OverflowReport {
+  vw: number;
+  htmlScrollWidth: number;
+  bodyScrollWidth: number;
+  mainPan: { scrollWidth: number; clientWidth: number } | null;
+  offenders: string[];
+}
+
+/**
+ * In-page audit: document scroll width, <main> pan, and elements that
+ * extend past the viewport WITHOUT an overflow-x scroll container ancestor
+ * (those are the sanctioned pattern for wide charts/tables/maps).
+ */
+function auditOverflow(): OverflowReport {
+  const vw = window.innerWidth;
+  const doc = document.documentElement;
+  const out: OverflowReport = {
+    vw,
+    htmlScrollWidth: doc.scrollWidth,
+    bodyScrollWidth: document.body.scrollWidth,
+    mainPan: null,
+    offenders: [],
+  };
+  const main = document.querySelector("main");
+  if (main && main.scrollWidth > main.clientWidth + 1) {
+    out.mainPan = { scrollWidth: main.scrollWidth, clientWidth: main.clientWidth };
+  }
+  const hasHScrollAncestor = (el: Element): boolean => {
+    let node = el.parentElement;
+    while (node && node !== document.body) {
+      const style = getComputedStyle(node);
+      if ((style.overflowX === "auto" || style.overflowX === "scroll") && node.tagName !== "MAIN") {
+        return true;
+      }
+      node = node.parentElement;
+    }
+    return false;
+  };
+  const describe = (el: Element): string => {
+    const parts: string[] = [];
+    let node: Element | null = el;
+    while (node && node !== document.body && parts.length < 4) {
+      let part = node.tagName.toLowerCase();
+      if (node.id) part += `#${node.id}`;
+      else if (typeof node.className === "string" && node.className) {
+        part += "." + node.className.split(/\s+/).filter(Boolean).slice(0, 3).join(".");
+      }
+      parts.unshift(part);
+      node = node.parentElement;
+    }
+    return parts.join(" > ");
+  };
+  const reported: Element[] = [];
+  for (const el of document.querySelectorAll("body *")) {
+    const rect = el.getBoundingClientRect();
+    if (rect.width === 0 && rect.height === 0) continue;
+    if (rect.right <= vw + 1 && rect.left >= -1) continue;
+    if (reported.some((a) => a.contains(el))) continue;
+    if (hasHScrollAncestor(el)) continue;
+    reported.push(el);
+    out.offenders.push(
+      `[${Math.round(rect.left)},${Math.round(rect.right)}] ${describe(el)}`,
+    );
+    if (out.offenders.length >= 8) break;
+  }
+  return out;
+}
+
+async function open(page: Page, route: string) {
+  await page.goto(route, { waitUntil: "domcontentloaded" });
+  // charts/lists render client-side from the mock — give them a beat
+  await page.waitForTimeout(1_200);
+}
+
+async function assertNoOverflow(page: Page, route: string) {
+  const report = await page.evaluate(auditOverflow);
+  expect(report.htmlScrollWidth, `${route}: document must not side-scroll`).toBeLessThanOrEqual(
+    report.vw,
+  );
+  expect(report.bodyScrollWidth, `${route}: body must not side-scroll`).toBeLessThanOrEqual(
+    report.vw,
+  );
+  expect(report.mainPan, `${route}: <main> must not pan horizontally`).toBeNull();
+  expect(
+    report.offenders,
+    `${route}: wide elements must live inside horizontal-scroll containers`,
+  ).toEqual([]);
+}
+
+// hermetic start — the dev-persistent store accumulates orgs/incidents from
+// earlier specs; re-seed the §6 narrative so seeded ids resolve
+test.beforeEach(async ({ request }) => {
+  await request.post("/api/mock/v1/reset");
+});
+
+function slug(route: string): string {
+  return route === "/" ? "home" : route.slice(1).replace(/\//g, "-");
+}
+
+async function shoot(page: Page, testInfo: TestInfo, route: string, theme: "dark" | "light") {
+  await page.screenshot({
+    path: testInfo.outputPath(`${slug(route)}--${theme}.png`),
+    fullPage: !route.startsWith("/dashboard"),
+  });
+}
+
+test.describe("390 — every route fits the mobile viewport", () => {
+  test("dark theme sweep + screenshots", async ({ page }, testInfo) => {
+    test.setTimeout(240_000);
+    await page.setViewportSize(MOBILE);
+    for (const route of ROUTES) {
+      await open(page, route);
+      await assertNoOverflow(page, route);
+      await shoot(page, testInfo, route, "dark");
+    }
+  });
+
+  test("light theme sweep + screenshots", async ({ page }, testInfo) => {
+    test.setTimeout(240_000);
+    await page.addInitScript(() => window.localStorage.setItem("upstat.theme", "light"));
+    await page.setViewportSize(MOBILE);
+    for (const route of ROUTES) {
+      await open(page, route);
+      await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
+      await assertNoOverflow(page, route);
+      await shoot(page, testInfo, route, "light");
+    }
+  });
+});
+
+test("768 — sanity sweep, no route side-scrolls", async ({ page }) => {
+  test.setTimeout(240_000);
+  await page.setViewportSize(TABLET);
+  for (const route of ROUTES) {
+    await open(page, route);
+    await assertNoOverflow(page, route);
+  }
+});
+
+test("390 — span drawer opens as a full-width sheet inside the viewport", async ({ page }) => {
+  await page.setViewportSize(MOBILE);
+  await open(page, "/dashboard/traces/explorer");
+  await page.locator('[data-testid^="trace-"]').first().click();
+  await expect(page.getByTestId("trace-waterfall")).toBeVisible();
+  const spanRow = page.getByRole("list", { name: "Trace spans" }).getByRole("button").first();
+  await spanRow.scrollIntoViewIfNeeded();
+  await spanRow.click();
+  const drawer = page.locator('aside[aria-label^="Span "]');
+  await expect(drawer).toBeVisible();
+  const box = (await drawer.boundingBox())!;
+  expect(box.x).toBeGreaterThanOrEqual(0);
+  expect(box.x + box.width).toBeLessThanOrEqual(MOBILE.width);
+  expect(box.width).toBeGreaterThanOrEqual(MOBILE.width - 2); // full-width sheet
+  await assertNoOverflow(page, "/dashboard/traces/explorer (drawer open)");
+  await drawer.getByRole("button", { name: "Close span drawer" }).click();
+  await expect(drawer).toBeHidden();
+});
+
+test("390 — the 12-col dashboard grid stacks; the widget editor fits", async ({ page }) => {
+  await page.setViewportSize(MOBILE);
+  await open(page, "/dashboard/dashboards/dash_overview?edit=1");
+  // stacked: every widget starts on the same left edge
+  const lefts = await page.evaluate(() =>
+    [...document.querySelectorAll("[data-widget-id]")].map((el) =>
+      Math.round(el.getBoundingClientRect().x),
+    ),
+  );
+  expect(lefts.length).toBeGreaterThan(1);
+  expect(new Set(lefts).size, "widgets must stack single-column at 390").toBe(1);
+  // the lg widget-editor modal clamps to the viewport
+  await page.getByTestId("add-widget").click();
+  const modal = page.getByRole("dialog");
+  await expect(modal).toBeVisible();
+  const box = (await modal.boundingBox())!;
+  expect(box.x).toBeGreaterThanOrEqual(0);
+  expect(box.x + box.width).toBeLessThanOrEqual(MOBILE.width);
+  await assertNoOverflow(page, "/dashboard/dashboards/dash_overview (editor open)");
+});
+
+test("390 — expanding a log line keeps the document inside the viewport", async ({ page }) => {
+  await page.setViewportSize(MOBILE);
+  await open(page, "/dashboard/logs");
+  const line = page.getByRole("list", { name: "Log lines" }).locator("li button").first();
+  await expect(line).toBeVisible({ timeout: 15_000 }); // live tail flushes in batches
+  await line.scrollIntoViewIfNeeded();
+  await line.click();
+  await assertNoOverflow(page, "/dashboard/logs (line expanded)");
+});

--- a/web/src/app/dashboard/dashboards/[id]/page.tsx
+++ b/web/src/app/dashboard/dashboards/[id]/page.tsx
@@ -12,6 +12,7 @@ import { WidgetTypePicker } from "@/components/ui/WidgetTypePicker";
 import type { Widget, WidgetLayout, WidgetType } from "@/models";
 import { useDashboardController } from "@/controllers/dashboards";
 import { defaultWidget, substituteVars } from "@/controllers/widgets";
+import { useMediaQuery } from "@/controllers/use-media-query";
 import { useTimeRange } from "@/controllers/time-range";
 import { WidgetBody } from "./widget-body";
 
@@ -52,6 +53,9 @@ export default function DashboardViewPage() {
   // MI-11 drag ghost
   const [drag, setDrag] = useState<DragState | null>(null);
   const gridRef = useRef<HTMLDivElement>(null);
+  // below md the 12-col grid stacks single-column in reading order (390
+  // support); drag/resize affordances follow the desktop layout only
+  const stacked = useMediaQuery("(max-width: 767px)");
 
   const effectiveVars = useMemo(() => {
     const out: Record<string, string> = {};
@@ -121,7 +125,7 @@ export default function DashboardViewPage() {
     return (
       <div className="flex flex-col gap-4 px-6 py-5">
         <Skeleton kind="line" className="w-64" />
-        <div className="grid grid-cols-2 gap-4">
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
           {Array.from({ length: 4 }, (_, i) => (
             <Skeleton key={i} kind="panel-axis" style={{ height: 220 }} />
           ))}
@@ -193,8 +197,10 @@ export default function DashboardViewPage() {
           data-testid="widget-grid"
           className="grid"
           style={{
-            gridTemplateColumns: `repeat(${COLS}, minmax(0, 1fr))`,
-            gridAutoRows: ROW_H,
+            gridTemplateColumns: stacked ? "minmax(0, 1fr)" : `repeat(${COLS}, minmax(0, 1fr))`,
+            // stacked rows size to content: the plot keeps its layout.h
+            // height and the legend renders below it unclipped
+            gridAutoRows: stacked ? "auto" : ROW_H,
             gap: GUTTER,
           }}
           onPointerMove={onDragMove}
@@ -212,8 +218,8 @@ export default function DashboardViewPage() {
                 data-widget-id={widget.id}
                 className="relative min-w-0"
                 style={{
-                  gridColumn: `${layout.x + 1} / span ${layout.w}`,
-                  gridRow: `${layout.y + 1} / span ${layout.h}`,
+                  gridColumn: stacked ? "1 / -1" : `${layout.x + 1} / span ${layout.w}`,
+                  gridRow: stacked ? "auto" : `${layout.y + 1} / span ${layout.h}`,
                   opacity: drag?.widgetId === widget.id ? 0.85 : 1,
                 }}
               >
@@ -239,7 +245,7 @@ export default function DashboardViewPage() {
                     height={mode === "fullscreen" ? 480 : Math.max(plotH, 64)}
                   />
                 </WidgetShell>
-                {ctrl.editMode && mode !== "fullscreen" && (
+                {ctrl.editMode && mode !== "fullscreen" && !stacked && (
                   <>
                     {/* MI-11 drag strip — grabs the header band */}
                     <div

--- a/web/src/app/dashboard/logs/page.tsx
+++ b/web/src/app/dashboard/logs/page.tsx
@@ -77,9 +77,10 @@ export default function LogsPage() {
         placeholder="service:api-common level:ERROR free text…"
       />
 
-      <div className="flex min-h-0 flex-1 gap-5">
+      {/* facets stack above the stream below lg (390 support) */}
+      <div className="flex min-h-0 flex-1 flex-col gap-5 lg:flex-row">
         {/* FacetSidebar (MI-6) */}
-        <aside aria-label="Facets" className="w-52 shrink-0 overflow-y-auto">
+        <aside aria-label="Facets" className="w-full shrink-0 lg:w-52 lg:overflow-y-auto">
           {(["service", "level", "host"] as const).map((facet) => (
             <FacetGroup
               key={facet}
@@ -94,8 +95,8 @@ export default function LogsPage() {
         </aside>
 
         <section aria-label="Log stream" className="flex min-w-0 flex-1 flex-col gap-3">
-          <header className="flex items-start gap-4">
-            <div className="w-96 max-w-full rounded-(--radius) border border-border bg-bg-elev p-3">
+          <header className="flex flex-wrap items-start gap-4">
+            <div className="w-96 min-w-0 max-w-full rounded-(--radius) border border-border bg-bg-elev p-3">
               {/* LogHistogram renders its own totals header (events · error · warn) */}
               {ctrl.base.loading ? (
                 <Skeleton kind="panel-axis" style={{ height: 64 }} />

--- a/web/src/app/dashboard/metrics/page.tsx
+++ b/web/src/app/dashboard/metrics/page.tsx
@@ -68,7 +68,7 @@ export default function MetricsExplorerPage() {
 
   return (
     <div className="flex min-h-full flex-col gap-4 px-6 py-5" data-testid="metrics-explorer">
-      <header className="flex items-center gap-6">
+      <header className="flex flex-wrap items-center gap-x-6 gap-y-2">
         <h1 className="text-[20px] font-semibold">Metrics</h1>
         <PageTabs
           label="Metrics views"
@@ -121,9 +121,10 @@ export default function MetricsExplorerPage() {
         placeholder="metric:… facet:value | fn() by facet"
       />
 
-      <div className="flex min-h-0 flex-1 gap-5">
+      {/* facets stack above the chart below lg (390 support) */}
+      <div className="flex min-h-0 flex-1 flex-col gap-5 lg:flex-row">
         {/* FacetSidebar (MI-6) */}
-        <aside aria-label="Facets" className="w-52 shrink-0">
+        <aside aria-label="Facets" className="w-full shrink-0 lg:w-52">
           <FacetGroup
             name="service"
             values={serviceFacets}

--- a/web/src/app/dashboard/metrics/summary/page.tsx
+++ b/web/src/app/dashboard/metrics/summary/page.tsx
@@ -39,7 +39,8 @@ export default function MetricsSummaryPage() {
         />
       </header>
 
-      <div className="flex gap-5">
+      {/* tag explorer stacks under the catalog below xl (390 support) */}
+      <div className="flex flex-col gap-5 xl:flex-row">
         <section
           aria-label="Metric catalog"
           className="min-w-0 flex-[2] rounded-(--radius) border border-border bg-bg-elev p-3"
@@ -73,7 +74,7 @@ export default function MetricsSummaryPage() {
         {/* tag explorer */}
         <aside
           aria-label="Tag explorer"
-          className="w-80 shrink-0 rounded-(--radius) border border-border bg-bg-elev p-4"
+          className="w-full shrink-0 rounded-(--radius) border border-border bg-bg-elev p-4 xl:w-80"
         >
           <h2 className="mb-3 text-[16px] font-semibold">
             Tag explorer{active ? ` — ${active.name}` : ""}

--- a/web/src/app/dashboard/monitors/page.tsx
+++ b/web/src/app/dashboard/monitors/page.tsx
@@ -53,7 +53,7 @@ export default function MonitorsPage() {
         </Button>
       </header>
 
-      <div className="grid gap-6 xl:grid-cols-[minmax(320px,1fr)_2fr]">
+      <div className="grid grid-cols-1 gap-6 xl:grid-cols-[minmax(320px,1fr)_minmax(0,2fr)]">
         <div className="flex min-w-0 flex-col gap-6">
           <section aria-label="Monitor rules">
             {ctrl.rules.loading ? (

--- a/web/src/app/dashboard/monitors/rule-editor.tsx
+++ b/web/src/app/dashboard/monitors/rule-editor.tsx
@@ -114,7 +114,8 @@ export function RuleEditor({
         </label>
       </div>
 
-      <fieldset className="grid grid-cols-3 gap-4 border-0 p-0">
+      {/* min-w-0 beats the UA fieldset min-inline-size:min-content (390) */}
+      <fieldset className="grid min-w-0 grid-cols-1 gap-4 border-0 p-0 sm:grid-cols-3">
         <legend className="mb-1 text-[13px] text-text-2">Thresholds · evaluation window</legend>
         <label className="flex flex-col gap-1 text-[13px]">
           <span className="text-warn">warn &gt;</span>
@@ -135,7 +136,7 @@ export function RuleEditor({
         </label>
       </fieldset>
 
-      <fieldset className="border-0 p-0">
+      <fieldset className="min-w-0 border-0 p-0">
         <legend className="mb-1 text-[13px] text-text-2">Notification channels</legend>
         <ul className="flex flex-col gap-1.5">
           {channels.map((ch) => (
@@ -145,7 +146,7 @@ export function RuleEditor({
                 onCheckedChange={() => toggleChannel(ch.id)}
                 aria-label={`Notify ${ch.target}`}
               />
-              <span className="font-data truncate text-text-2">{ch.target}</span>
+              <span className="font-data min-w-0 truncate text-text-2">{ch.target}</span>
               {ch.health !== "verified" && (
                 <span className="text-[11px] text-warn">({ch.health})</span>
               )}

--- a/web/src/app/dashboard/page.tsx
+++ b/web/src/app/dashboard/page.tsx
@@ -23,7 +23,7 @@ export default function DashboardHomePage() {
       <h1 className="text-[20px] font-semibold">Home — org health</h1>
 
       {/* stat tiles */}
-      <section aria-label="Org health stats" className="grid grid-cols-2 gap-4 xl:grid-cols-4">
+      <section aria-label="Org health stats" className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
         {tiles.loading || !tiles.data
           ? Array.from({ length: 4 }, (_, i) => <Skeleton key={i} kind="value" />)
           : tiles.data.map((tile) => (
@@ -39,7 +39,7 @@ export default function DashboardHomePage() {
             ))}
       </section>
 
-      <div className="grid gap-10 lg:grid-cols-2">
+      <div className="grid grid-cols-1 gap-10 lg:grid-cols-2">
         {/* watched dashboards */}
         <section aria-labelledby="watched-heading" className="min-w-0">
           <h2 id="watched-heading" className="mb-3 text-[16px] font-semibold">

--- a/web/src/app/dashboard/rum/page.tsx
+++ b/web/src/app/dashboard/rum/page.tsx
@@ -94,7 +94,7 @@ export default function RumPage() {
       ) : (
         <>
           {/* stat tiles */}
-          <section aria-label="Traffic and vitals" className="grid grid-cols-2 gap-4 lg:grid-cols-3 2xl:grid-cols-6">
+          <section aria-label="Traffic and vitals" className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-6">
             {summary.loading || vitals.loading ? (
               Array.from({ length: 6 }, (_, i) => <Skeleton key={i} kind="value" />)
             ) : (
@@ -109,7 +109,7 @@ export default function RumPage() {
             )}
           </section>
 
-          <div className="grid gap-5 xl:grid-cols-[1.2fr_1fr_1fr]">
+          <div className="grid grid-cols-1 gap-5 xl:grid-cols-[minmax(0,1.2fr)_minmax(0,1fr)_minmax(0,1fr)]">
             <TimeseriesPanel
               title={`Sessions — ${propertyName}`}
               query={`rum:sessions{property:${propertyName}} by device`}
@@ -136,7 +136,7 @@ export default function RumPage() {
             </section>
           </div>
 
-          <div className="grid gap-5 xl:grid-cols-[1fr_1.4fr]">
+          <div className="grid grid-cols-1 gap-5 xl:grid-cols-[minmax(0,1fr)_minmax(0,1.4fr)]">
             <section aria-labelledby="vitals-heading" className="rounded-(--radius) border border-border bg-bg-elev p-4">
               <h2 id="vitals-heading" className="mb-3 text-[13px] text-text-2">
                 Web vitals — LCP distribution

--- a/web/src/app/dashboard/traces/explorer/page.tsx
+++ b/web/src/app/dashboard/traces/explorer/page.tsx
@@ -74,9 +74,11 @@ export default function TraceExplorerPage() {
         ) : (traces.data ?? []).length === 0 ? (
           <EmptyState pillar="traces" className="border-0" />
         ) : (
-          <ul aria-label="Trace results" className="max-h-72 overflow-y-auto">
+          // overflow-x-auto: the fixed-column result rows scroll inside the
+          // panel on narrow viewports (390 support)
+          <ul aria-label="Trace results" className="max-h-72 overflow-y-auto overflow-x-auto">
             {(traces.data ?? []).map((t) => (
-              <li key={t.trace_id}>
+              <li key={t.trace_id} className="min-w-max">
                 <button
                   type="button"
                   data-testid={`trace-${t.trace_id.slice(0, 8)}`}
@@ -124,7 +126,7 @@ export default function TraceExplorerPage() {
             <Skeleton kind="panel-axis" style={{ height: 200 }} />
           ) : (
             <>
-              <header className="mb-2 flex items-center justify-between gap-3">
+              <header className="mb-2 flex flex-wrap items-center justify-between gap-3">
                 <h2 className="text-[16px] font-semibold">Trace — {selected.root_name}</h2>
                 <Link
                   href={`/dashboard/traces/map?service=${selected.root_service}`}

--- a/web/src/app/dashboard/traces/map/page.tsx
+++ b/web/src/app/dashboard/traces/map/page.tsx
@@ -44,7 +44,7 @@ export default function ServiceMapPage() {
 
   return (
     <div className="flex flex-col gap-4 px-6 py-5" data-testid="service-map">
-      <header className="flex items-center gap-6">
+      <header className="flex flex-wrap items-center gap-x-6 gap-y-2">
         <h1 className="text-[20px] font-semibold">Service map</h1>
         <PageTabs label="APM views" tabs={apmTabs("map")} />
         {selected && (
@@ -68,7 +68,10 @@ export default function ServiceMapPage() {
           their edge appears here.
         </section>
       ) : (
-        <section aria-label="Service topology" className="relative" style={{ height: H }}>
+        // overflow-x-auto: the %-positioned topology needs a minimum canvas
+        // width — it pans inside the section on narrow viewports (390)
+        <section aria-label="Service topology" className="overflow-x-auto">
+          <div className="relative min-w-[880px]" style={{ height: H }}>
           {/* edges */}
           <svg
             viewBox={`0 0 ${W} ${H}`}
@@ -161,6 +164,7 @@ export default function ServiceMapPage() {
               </li>
             ))}
           </ul>
+          </div>
         </section>
       )}
     </div>

--- a/web/src/app/dashboard/traces/page.tsx
+++ b/web/src/app/dashboard/traces/page.tsx
@@ -54,7 +54,10 @@ export default function ApmServicesPage() {
             arrive.
           </p>
         ) : (
-          <table className="w-full border-collapse text-[13px]">
+          // overflow-x-auto: the seven-column stats table scrolls inside the
+          // panel on narrow viewports (390 support)
+          <div className="overflow-x-auto">
+          <table className="w-full min-w-[560px] border-collapse text-[13px]">
             <thead>
               <tr className="text-left text-[11px] uppercase tracking-wide text-text-2">
                 <th scope="col" className="px-2 py-2 font-medium">Service</th>
@@ -92,6 +95,7 @@ export default function ApmServicesPage() {
               ))}
             </tbody>
           </table>
+          </div>
         )}
       </section>
     </div>

--- a/web/src/app/dashboard/traces/services/[service]/page.tsx
+++ b/web/src/app/dashboard/traces/services/[service]/page.tsx
@@ -75,7 +75,7 @@ export default function ServiceDetailPage() {
         )}
       </header>
 
-      <div className="grid gap-5 xl:grid-cols-2">
+      <div className="grid grid-cols-1 gap-5 xl:grid-cols-2">
         <section
           aria-labelledby="endpoints-heading"
           className="rounded-(--radius) border border-border bg-bg-elev p-4"
@@ -92,7 +92,10 @@ export default function ServiceDetailPage() {
           ) : endpoints.length === 0 ? (
             <p className="text-[13px] text-text-2">No traced endpoints in this range.</p>
           ) : (
-            <table className="w-full border-collapse text-[13px]">
+            // overflow-x-auto: the endpoints table scrolls inside the panel
+            // on narrow viewports (390 support)
+            <div className="overflow-x-auto">
+            <table className="w-full min-w-[420px] border-collapse text-[13px]">
               <thead>
                 <tr className="text-left text-[11px] uppercase tracking-wide text-text-2">
                   <th scope="col" className="px-2 py-1.5 font-medium">Endpoint</th>
@@ -125,6 +128,7 @@ export default function ServiceDetailPage() {
                 ))}
               </tbody>
             </table>
+            </div>
           )}
         </section>
 

--- a/web/src/app/dashboard/uptime/[id]/page.tsx
+++ b/web/src/app/dashboard/uptime/[id]/page.tsx
@@ -71,7 +71,7 @@ export default function MonitorDetailPage() {
         </p>
       </header>
 
-      <div className="grid gap-5 xl:grid-cols-[1.2fr_1fr]">
+      <div className="grid grid-cols-1 gap-5 xl:grid-cols-[minmax(0,1.2fr)_minmax(0,1fr)]">
         <div className="flex flex-col gap-5">
           {history.loading || !h ? (
             <Skeleton kind="panel-axis" style={{ height: 96 }} />

--- a/web/src/app/dashboard/uptime/page.tsx
+++ b/web/src/app/dashboard/uptime/page.tsx
@@ -65,7 +65,7 @@ export default function UptimePage() {
       </header>
 
       {/* UptimeCard strips */}
-      <section aria-label="Uptime overview" className="grid gap-4 lg:grid-cols-3">
+      <section aria-label="Uptime overview" className="grid grid-cols-1 gap-4 lg:grid-cols-3">
         {cards.loading || ctrl.loading ? (
           Array.from({ length: 3 }, (_, i) => (
             <Skeleton key={i} kind="panel-axis" style={{ height: 96 }} />

--- a/web/src/app/dev/components/gallery.tsx
+++ b/web/src/app/dev/components/gallery.tsx
@@ -355,7 +355,7 @@ function MonitorRowDemo({ status, muted: initialMuted }: { status: StatusPillSta
 function FAQDemo() {
   const [openIndex, setOpenIndex] = useState<number | null>(0);
   const faqs = [
-    { q: "Is everything open source?", a: "Yes — the whole platform is MIT licensed; cloud runs the same code." },
+    { q: "Is everything open-source?", a: "Yes — the whole platform is MIT licensed; cloud runs the same code." },
     { q: "Do you use cookies for analytics?", a: "No. RUM is cookieless by design — the event schema is the privacy boundary." },
   ];
   return (

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -28,7 +28,14 @@ export const viewport: Viewport = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en" className={`${inter.variable} ${jetbrainsMono.variable}`}>
+    // suppressHydrationWarning: the pre-paint script may set data-theme
+    // before React hydrates the <html> element (apparule ThemeProvider
+    // contract — the persisted-light boot flagged a dev hydration warning)
+    <html
+      lang="en"
+      className={`${inter.variable} ${jetbrainsMono.variable}`}
+      suppressHydrationWarning
+    >
       <body>
         {/* pre-paint: applies the persisted `upstat.theme` override before
             first paint (theme-parity canon) — a static literal script */}

--- a/web/src/components/home/HomeView.test.tsx
+++ b/web/src/components/home/HomeView.test.tsx
@@ -61,7 +61,7 @@ describe("HomeView (pages.md Part A — Figma frame 135:2)", () => {
     // CTA-dedupe canon: A13 keeps the one GitHub+Discord pair; A8 points at
     // the lab + docs instead
     expect(screen.getByText("Discord — #upstat-lab on the CueLABS™ server")).toBeInTheDocument();
-    expect(screen.getByText("CueLABS™ — more open source from Cuesoft")).toBeInTheDocument();
+    expect(screen.getByText("CueLABS™ — more open-source from Cuesoft")).toBeInTheDocument();
     // A15 FAQ + A16 CTA band
     expect(screen.getByText("Questions, answered.")).toBeInTheDocument();
     expect(screen.getByText("OTLP in. Answers out.")).toBeInTheDocument();

--- a/web/src/components/home/HomeView.test.tsx
+++ b/web/src/components/home/HomeView.test.tsx
@@ -61,7 +61,7 @@ describe("HomeView (pages.md Part A — Figma frame 135:2)", () => {
     // CTA-dedupe canon: A13 keeps the one GitHub+Discord pair; A8 points at
     // the lab + docs instead
     expect(screen.getByText("Discord — #upstat-lab on the CueLABS™ server")).toBeInTheDocument();
-    expect(screen.getByText("CueLABS™ — more open-source from Cuesoft")).toBeInTheDocument();
+    expect(screen.getByText("CueLABS™ — more open-source software from Cuesoft")).toBeInTheDocument();
     // A15 FAQ + A16 CTA band
     expect(screen.getByText("Questions, answered.")).toBeInTheDocument();
     expect(screen.getByText("OTLP in. Answers out.")).toBeInTheDocument();

--- a/web/src/components/home/sections-bottom.tsx
+++ b/web/src/components/home/sections-bottom.tsx
@@ -248,7 +248,7 @@ export function CommunitySection() {
           <FlaskConical aria-hidden="true" className="mt-1 size-7 shrink-0 text-brand" />
           <span className="flex min-w-0 flex-1 flex-col gap-1">
             <span className="text-[14px] font-semibold text-text">
-              CueLABS™ — more open source from Cuesoft
+              CueLABS™ — more open-source from Cuesoft
             </span>
             <span className="text-[13px] text-text-2">
               The division upstat ships from — see what else is built in the open.

--- a/web/src/components/home/sections-bottom.tsx
+++ b/web/src/components/home/sections-bottom.tsx
@@ -248,7 +248,7 @@ export function CommunitySection() {
           <FlaskConical aria-hidden="true" className="mt-1 size-7 shrink-0 text-brand" />
           <span className="flex min-w-0 flex-1 flex-col gap-1">
             <span className="text-[14px] font-semibold text-text">
-              CueLABS™ — more open-source from Cuesoft
+              CueLABS™ — more open-source software from Cuesoft
             </span>
             <span className="text-[13px] text-text-2">
               The division upstat ships from — see what else is built in the open.

--- a/web/src/components/home/sections-top.tsx
+++ b/web/src/components/home/sections-top.tsx
@@ -60,7 +60,7 @@ export function HeroSection({
             </Button>
           </div>
           <p className="text-[12px] text-text-2">
-            Open source · OTLP in, answers out · Self-host in one line
+            Open-source · OTLP in, answers out · Self-host in one line
           </p>
         </div>
 

--- a/web/src/components/ui/ErrorGroupRow.tsx
+++ b/web/src/components/ui/ErrorGroupRow.tsx
@@ -45,7 +45,8 @@ export function ErrorGroupRow({ group, onClick, className }: ErrorGroupRowProps)
         preserveAspectRatio="none"
         aria-hidden="true"
         style={{ width: 72, height: 16 }}
-        className="shrink-0"
+        // the sparkline yields to the fingerprint message below sm (390)
+        className="hidden shrink-0 sm:block"
       >
         {group.sparkline.map((v, i) => (
           <rect

--- a/web/src/components/ui/FAQItem.test.tsx
+++ b/web/src/components/ui/FAQItem.test.tsx
@@ -7,13 +7,13 @@ describe("FAQItem", () => {
   it("expands and collapses (single-open orchestrated by parent)", async () => {
     const onToggle = vi.fn();
     const { rerender } = render(
-      <FAQItem question="Is everything open source?" answer="Yes — MIT." expanded={false} onToggle={onToggle} />,
+      <FAQItem question="Is everything open-source?" answer="Yes — MIT." expanded={false} onToggle={onToggle} />,
     );
     expect(screen.queryByText("Yes — MIT.")).toBeNull();
     await userEvent.click(screen.getByRole("button"));
     expect(onToggle).toHaveBeenCalledOnce();
     rerender(
-      <FAQItem question="Is everything open source?" answer="Yes — MIT." expanded onToggle={onToggle} />,
+      <FAQItem question="Is everything open-source?" answer="Yes — MIT." expanded onToggle={onToggle} />,
     );
     expect(screen.getByText("Yes — MIT.")).toBeInTheDocument();
   });

--- a/web/src/components/ui/Heatmap.tsx
+++ b/web/src/components/ui/Heatmap.tsx
@@ -26,7 +26,9 @@ export function Heatmap({ columns, rows, values, className }: HeatmapProps) {
     [0, 0.25, 0.5, 0.75, 1].map((t) => Math.round(t * (columns.length - 1))),
   );
   return (
-    <div className={clsx("font-ui flex w-fit gap-1.5", className)}>
+    // overflow-x-auto: the fixed-cell grid scrolls inside its panel on
+    // narrow viewports (390 support); desktop rendering is unchanged
+    <div className={clsx("font-ui flex w-fit max-w-full gap-1.5 overflow-x-auto", className)}>
       <div
         className="flex flex-col justify-between py-0.5 text-right"
         style={{ height: rows.length * (CELL + 1) }}

--- a/web/src/components/ui/LogHistogram.tsx
+++ b/web/src/components/ui/LogHistogram.tsx
@@ -58,13 +58,17 @@ export function LogHistogram({ buckets, height = 64, className }: LogHistogramPr
         </span>
       </div>
 
-      <div
-        role="img"
-        aria-label="log volume histogram"
-        className="flex items-end gap-0.5"
-        style={{ height }}
-      >
-        {buckets.map((bucket, i) => (
+      {/* overflow-x-auto: the fixed-width bars (and their axis labels)
+          scroll inside the card on narrow viewports (390 support) */}
+      <div className="overflow-x-auto">
+        <div className="w-max min-w-full">
+          <div
+            role="img"
+            aria-label="log volume histogram"
+            className="flex items-end gap-0.5"
+            style={{ height }}
+          >
+            {buckets.map((bucket, i) => (
           <Tooltip
             key={bucket.ts}
             content={STACK.filter(({ level }) => (bucket.counts[level] ?? 0) > 0)
@@ -97,17 +101,19 @@ export function LogHistogram({ buckets, height = 64, className }: LogHistogramPr
               <span className="sr-only">{totals[i]} lines</span>
             </span>
           </Tooltip>
-        ))}
-      </div>
+            ))}
+          </div>
 
-      <div className="flex justify-between">
-        {buckets
-          .filter((_, i) => labelIdx.has(i))
-          .map((b) => (
-            <span key={b.ts} className="font-data text-[11px] tabular-nums text-text-2">
-              {b.ts.slice(11, 16)}
-            </span>
-          ))}
+          <div className="mt-2 flex justify-between">
+            {buckets
+              .filter((_, i) => labelIdx.has(i))
+              .map((b) => (
+                <span key={b.ts} className="font-data text-[11px] tabular-nums text-text-2">
+                  {b.ts.slice(11, 16)}
+                </span>
+              ))}
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/web/src/components/ui/MarketingFooter.tsx
+++ b/web/src/components/ui/MarketingFooter.tsx
@@ -87,10 +87,20 @@ export function MarketingFooter({
   return (
     <footer className={clsx("font-ui border-t border-border bg-bg px-6 py-10", className)}>
       {/* marketing container (design.md §2): footer band is full-bleed, its
-          content sits on the 1152 rails (outer px-6 supplies the gutters) */}
-      <div className="mx-auto flex max-w-[1152px] flex-wrap justify-between gap-8">
+          content sits on the 1152 rails (outer px-6 supplies the gutters).
+          Sibling-parity mobile structure (2026-07-19): brand + 4 columns in
+          ONE responsive grid — full-width brand row at 390, 2-col link
+          columns, one 5-col row at md+ (apparule/expendit stacking) */}
+      <div
+        className={clsx(
+          "mx-auto max-w-[1152px]",
+          inline
+            ? "flex flex-wrap justify-between gap-8"
+            : "grid grid-cols-2 gap-8 md:grid-cols-5",
+        )}
+      >
         {showBrand && (
-          <div className="flex max-w-56 flex-col gap-2">
+          <div className={clsx("flex max-w-56 flex-col gap-2", !inline && "col-span-2 md:col-span-1")}>
             <span className="flex items-center gap-2 text-[16px] font-semibold text-text">
               <span
                 aria-hidden="true"
@@ -148,8 +158,9 @@ export function MarketingFooter({
 
       {/* legal bar — verbatim copyright (linked marks), language selector
           (English-only, a real control — no i18n yet, ratified) and the
-          security-policy affordance */}
-      <div className="mx-auto mt-8 flex max-w-[1152px] flex-wrap items-center gap-x-6 gap-y-3 border-t border-border pt-4">
+          security-policy affordance. Sibling-parity stacking: © line first,
+          utilities as ONE grouped cluster that wraps beneath it at 390 */}
+      <div className="mx-auto mt-8 flex max-w-[1152px] flex-wrap items-center justify-between gap-x-6 gap-y-3 border-t border-border pt-4">
         <p className="text-[12px] text-text-2">
           ©{" "}
           <a
@@ -174,24 +185,25 @@ export function MarketingFooter({
           </a>
           .
         </p>
-        <span className="flex-1" />
-        <a
-          href={SECURITY_URL}
-          className="flex items-center gap-1.5 text-[12px] text-text-2 transition-colors duration-[var(--duration-fast)] hover:text-text"
-        >
-          <ShieldCheck aria-hidden="true" className="size-3.5" />
-          Security
-        </a>
-        <label className="flex items-center gap-1.5 text-[12px] text-text-2">
-          <span className="sr-only">Language</span>
-          <select
-            aria-label="Language"
-            defaultValue="en"
-            className="rounded-(--radius) border border-border bg-bg-elev px-1.5 py-0.5 text-[12px] text-text-2"
+        <div className="flex flex-wrap items-center gap-x-6 gap-y-2">
+          <a
+            href={SECURITY_URL}
+            className="flex items-center gap-1.5 text-[12px] text-text-2 transition-colors duration-[var(--duration-fast)] hover:text-text"
           >
-            <option value="en">English</option>
-          </select>
-        </label>
+            <ShieldCheck aria-hidden="true" className="size-3.5" />
+            Security
+          </a>
+          <label className="flex items-center gap-1.5 text-[12px] text-text-2">
+            <span className="sr-only">Language</span>
+            <select
+              aria-label="Language"
+              defaultValue="en"
+              className="rounded-(--radius) border border-border bg-bg-elev px-1.5 py-0.5 text-[12px] text-text-2"
+            >
+              <option value="en">English</option>
+            </select>
+          </label>
+        </div>
       </div>
     </footer>
   );

--- a/web/src/components/ui/MarketingNav.test.tsx
+++ b/web/src/components/ui/MarketingNav.test.tsx
@@ -31,7 +31,9 @@ describe("MarketingNav (parity canon, SKILL.md 2026-07-19, revised same day)", (
     renderNav();
     expect(screen.getByTestId("theme-toggle")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Sign in" })).toHaveAttribute("href", "/signin");
-    expect(screen.getByRole("button", { name: "Try Cloud" })).toBeInTheDocument();
+    // two renderings of the one CTA ([Revised 2026-07-19]): compact below
+    // md (the bar keeps it beside the hamburger) + standard on md+
+    expect(screen.getAllByRole("button", { name: "Try Cloud" })).toHaveLength(2);
   });
 
   it("shows the runtime star count on the star badge when provided (never static)", () => {

--- a/web/src/components/ui/MarketingNav.tsx
+++ b/web/src/components/ui/MarketingNav.tsx
@@ -68,10 +68,11 @@ function StarBadge({
  * marketing container (design.md §2: 1152px content at 1440, rails
  * x144/x1296).
  *
- * Mobile (SKILL.md mobile clause): below `md` the text links collapse into
- * a menu-button disclosure (hamburger, `aria-expanded`) opening a panel
- * with the same 4 links + ThemeToggle + Sign in + Try Cloud — no canonical
- * link may be unreachable at any viewport.
+ * Mobile (SKILL.md mobile clause, [Revised 2026-07-19]): below `md` the
+ * bar keeps the Try Cloud CTA beside the hamburger; the menu-button
+ * disclosure (`aria-expanded`) opens a panel carrying the 4 links +
+ * ThemeToggle + Sign in — no canonical link may be unreachable at any
+ * viewport, and the always-visible bar CTA is not duplicated in the panel.
  */
 export function MarketingNav({
   onSignIn,
@@ -138,9 +139,20 @@ export function MarketingNav({
         >
           Sign in
         </Link>
-        <Button kind="brand" onClick={onTryCloud} className="hidden md:inline-flex">
-          Try Cloud
-        </Button>
+        {/* Try Cloud stays in the bar at every viewport ([Revised
+            2026-07-19]) — compact below md, standard size on md+. Display
+            control lives on wrapper spans: a `hidden` on the Button itself
+            fights its base `inline-flex` (same-property utility conflict) */}
+        <span className="shrink-0 md:hidden">
+          <Button kind="brand" size="sm" onClick={onTryCloud}>
+            Try Cloud
+          </Button>
+        </span>
+        <span className="hidden shrink-0 md:block">
+          <Button kind="brand" onClick={onTryCloud}>
+            Try Cloud
+          </Button>
+        </span>
 
         {/* mobile disclosure trigger — the panel below carries the links */}
         <button
@@ -181,29 +193,20 @@ export function MarketingNav({
               </a>
             ),
           )}
+          {/* Try Cloud lives in the always-visible bar, not the panel
+              ([Revised 2026-07-19] — no duplication) */}
           <div className="mt-2 flex items-center justify-between border-t border-border pt-3">
             <ThemeToggle />
-            <div className="flex items-center gap-4">
-              <Link
-                href="/signin"
-                onClick={() => {
-                  setMenuOpen(false);
-                  onSignIn?.();
-                }}
-                className="text-[14px] font-medium text-text-2 transition-colors duration-[var(--duration-fast)] hover:text-text"
-              >
-                Sign in
-              </Link>
-              <Button
-                kind="brand"
-                onClick={() => {
-                  setMenuOpen(false);
-                  onTryCloud?.();
-                }}
-              >
-                Try Cloud
-              </Button>
-            </div>
+            <Link
+              href="/signin"
+              onClick={() => {
+                setMenuOpen(false);
+                onSignIn?.();
+              }}
+              className="text-[14px] font-medium text-text-2 transition-colors duration-[var(--duration-fast)] hover:text-text"
+            >
+              Sign in
+            </Link>
           </div>
         </div>
       )}

--- a/web/src/components/ui/Modal.tsx
+++ b/web/src/components/ui/Modal.tsx
@@ -57,9 +57,11 @@ export function Modal({
             }}
             className={clsx(
               "font-ui flex flex-col border-border bg-bg-elev shadow-xl outline-none",
+              // sheets and modals clamp to the viewport — full-width sheet /
+              // full-width dialog below their design widths (390 support)
               variant === "sheet"
-                ? "h-full w-[480px] animate-[sheet-in_var(--duration-entrance)_var(--ease-standard)] border-l motion-reduce:animate-none"
-                : "max-h-[85vh] rounded-(--radius) border",
+                ? "h-full w-full max-w-[480px] animate-[sheet-in_var(--duration-entrance)_var(--ease-standard)] border-l motion-reduce:animate-none"
+                : "max-h-[85vh] max-w-full rounded-(--radius) border",
               variant === "sm" && "w-[400px]",
               variant === "lg" && "w-[640px]",
               className,

--- a/web/src/components/ui/QueryValue.tsx
+++ b/web/src/components/ui/QueryValue.tsx
@@ -48,7 +48,9 @@ export function QueryValue({
     <div
       data-threshold={threshold}
       className={clsx(
-        "font-ui relative flex w-fit min-w-44 flex-col items-start gap-1.5 overflow-hidden",
+        // max-w-full + min-w-0: the tile clamps to its widget/grid cell on
+        // narrow layouts instead of overflowing (390/768 support)
+        "font-ui relative flex w-fit min-w-0 max-w-full flex-col items-start gap-1.5 overflow-hidden",
         "rounded-(--radius) border border-border bg-bg-elev p-4",
         className,
       )}
@@ -79,7 +81,7 @@ export function QueryValue({
           viewBox={`0 0 ${sparkline.length - 1} 28`}
           preserveAspectRatio="none"
           aria-hidden="true"
-          className="relative"
+          className="relative max-w-full"
           style={{ width: 200, height: 28 }}
         >
           <polyline

--- a/web/src/components/ui/SLOCard.tsx
+++ b/web/src/components/ui/SLOCard.tsx
@@ -19,7 +19,9 @@ export function SLOCard({ slo, className }: SLOCardProps) {
     <div
       data-state={slo.state}
       className={clsx(
-        "font-ui flex w-64 flex-col gap-2 rounded-(--radius) border border-border bg-bg-elev p-4",
+        // w-full capped at the Figma 256px card — shrinks with its grid cell
+        // instead of overflowing narrow viewports (390/768 support)
+        "font-ui flex w-full max-w-64 flex-col gap-2 rounded-(--radius) border border-border bg-bg-elev p-4",
         className,
       )}
     >

--- a/web/src/components/ui/SpanDrawer.tsx
+++ b/web/src/components/ui/SpanDrawer.tsx
@@ -24,7 +24,11 @@ export function SpanDrawer({ span, logs = [], onClose, className }: SpanDrawerPr
     <aside
       aria-label={`Span ${span.name}`}
       className={clsx(
-        "font-ui flex h-full w-[480px] flex-col border-l border-border bg-bg-elev",
+        "font-ui flex flex-col border-l border-border bg-bg-elev",
+        // §2 detail drawer (480px right panel) on lg+; below lg it becomes a
+        // full-width fixed sheet so the waterfall never side-scrolls the page
+        "fixed inset-y-0 right-0 z-[var(--z-modal)] w-full max-w-[480px] shadow-xl",
+        "lg:static lg:inset-auto lg:z-auto lg:h-full lg:w-[480px] lg:shadow-none",
         className,
       )}
     >

--- a/web/src/components/ui/Table.tsx
+++ b/web/src/components/ui/Table.tsx
@@ -19,7 +19,10 @@ export interface TableProps {
 /** Table — §8.2: header + rows, numeric right-aligned mono, compact density. */
 export function Table({ columns, rows, onRowClick, className }: TableProps) {
   return (
-    <table className={clsx("font-ui w-full border-collapse text-[13px]", className)}>
+    // overflow-x-auto: tables never shrink below their content min-width —
+    // on narrow viewports the table scrolls inside this wrapper (390 support)
+    <div className="overflow-x-auto">
+      <table className={clsx("font-ui w-full border-collapse text-[13px]", className)}>
       <thead>
         <tr className="border-b border-border">
           {columns.map((col) => (
@@ -60,6 +63,7 @@ export function Table({ columns, rows, onRowClick, className }: TableProps) {
           </tr>
         ))}
       </tbody>
-    </table>
+      </table>
+    </div>
   );
 }

--- a/web/src/components/ui/TraceWaterfall.tsx
+++ b/web/src/components/ui/TraceWaterfall.tsx
@@ -57,7 +57,10 @@ export function TraceWaterfall({ trace, className }: TraceWaterfallProps) {
 
   return (
     <div className={clsx("font-ui flex w-full", className)}>
-      <div className="min-w-0 flex-1">
+      {/* overflow-x-auto: the fixed-column waterfall (name · service · time
+          axis · duration) scrolls inside its panel on narrow viewports */}
+      <div className="min-w-0 flex-1 overflow-x-auto">
+        <div className="min-w-[560px]">
         <TraceMinimap
           spans={trace.spans}
           durationMs={trace.duration_ms}
@@ -98,6 +101,7 @@ export function TraceWaterfall({ trace, className }: TraceWaterfallProps) {
               onHover={(hovering) => setHoverService(hovering ? span.service : null)}
             />
           ))}
+          </div>
         </div>
       </div>
       {selected && (

--- a/web/src/components/ui/UptimeCard.tsx
+++ b/web/src/components/ui/UptimeCard.tsx
@@ -42,7 +42,7 @@ export function UptimeCard({ name, days, uptimePct, p95Ms, status, className }: 
   return (
     <div
       className={clsx(
-        "font-ui flex w-full max-w-xl flex-col gap-2.5 rounded-(--radius) border border-border bg-bg-elev p-4",
+        "font-ui flex w-full min-w-0 max-w-xl flex-col gap-2.5 rounded-(--radius) border border-border bg-bg-elev p-4",
         className,
       )}
     >

--- a/web/src/controllers/use-media-query.ts
+++ b/web/src/controllers/use-media-query.ts
@@ -1,0 +1,20 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+/**
+ * useMediaQuery — SSR-safe viewport query (design.md §2 breakpoints).
+ * Server snapshot is `false` (desktop-first markup renders; the client
+ * corrects after hydration — the NavRail default-width pattern).
+ */
+export function useMediaQuery(query: string): boolean {
+  return useSyncExternalStore(
+    (onChange) => {
+      const mql = window.matchMedia(query);
+      mql.addEventListener("change", onChange);
+      return () => mql.removeEventListener("change", onChange);
+    },
+    () => window.matchMedia(query).matches,
+    () => false,
+  );
+}


### PR DESCRIPTION
## Summary

PR1 of the P1 polish series. #164 collapsed the TopBar chrome at 390 — this PR makes the **content** of home, `/status/upstat`, and every `/dashboard/<area>` route fully responsive at 390 (with a 768 sanity pass): the document never side-scrolls, `<main>` never pans, and wide visualizations/tables scroll horizontally **inside** their own containers within the fixed viewport. It also folds in three user-ratified canon revisions (mobile marketing chrome, sibling footer stacking, brand-copy hyphenation).

## What changed

**Layout stacking**
- Logs/metrics explorer facet sidebars stack above their streams below `lg`
- Stat-tile and card grids start `grid-cols-1` and widen at `sm`/`lg`/`xl`; arbitrary `fr` grids wrapped in `minmax(0,…)` so text truncation actually bounds tracks
- The B2 12-col widget grid stacks single-column in reading order below `md` (rows size to content so legends aren't clipped; drag/resize affordances stay desktop-only — positions are 12-col coordinates)
- Metrics summary catalog + tag explorer stack below `xl`; monitors list + rule editor stack below `xl`; rule-editor thresholds stack below `sm`

**Horizontal-scroll containers (within the viewport — the document itself never side-scrolls)**
- `Table`, the bespoke APM service/endpoint tables and trace-result rows
- `TraceWaterfall` (560px min canvas), `Heatmap`, `LogHistogram`, the service-map topology (880px min canvas), `UptimeCard`'s 90-day strip

**Drawers & overlays**
- `SpanDrawer` becomes a full-width fixed sheet below `lg` (§2 480px right panel on desktop, unchanged)
- `Modal`/`Sheet` clamp to the viewport (`max-w-full`)

**Intrinsic-sizing fixes**
- `<fieldset>` UA default `min-inline-size: min-content` (rule editor overflow) → `min-w-0`
- `QueryValue` fixed 200px sparkline / `SLOCard` fixed `w-64` now clamp to their cells

**Folded-in canon revisions (user-ratified 2026-07-19)**
- **MarketingNav <md**: the bar keeps the **Try Cloud** CTA (compact) beside the hamburger — always visible; the disclosure panel carries the 4 links + ThemeToggle + Sign in (CTA not duplicated). Display control moved to wrapper spans — `hidden` on the Button fought its base `inline-flex` (same-property utility conflict decided visibility by class order)
- **MarketingFooter**: converges to the sibling mobile structure — brand + 4 columns as ONE responsive grid (`grid-cols-2 gap-8 md:grid-cols-5`, brand `col-span-2 md:col-span-1`); legal bar `flex-wrap justify-between`, © line first, Security + language as one grouped cluster
- **Brand copy**: "open-source" hyphenated everywhere in prose (9 occurrences: copy, tests, docs); no `by Cuesoft CueLABS™` attribution exists
- Root layout: `suppressHydrationWarning` on `<html>` (apparule ThemeProvider contract — the pre-paint theme script sets `data-theme` before hydration)

## Tests

`web/e2e/mobile-responsive.spec.ts` sweeps **all 32 routes** at 390 in **both themes** (screenshots per route) plus a 768 pass, asserting per route: `document.scrollWidth ≤ viewport`, `<main>` never pans, and any element wider than the viewport sits inside an `overflow-x` scroll container. Interactive coverage at 390: span-drawer full-width sheet, stacked widget grid + widget-editor modal, log-line expansion. home.spec asserts the bar CTA visible/in-viewport at 390 and the panel CTA-free.

Full gates green locally: lint + check:boundaries, typecheck, 217 unit tests, 28 Playwright tests (TEST_MODE).

docs/web-implementation.md carries the as-built notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)