### PR TITLE
fix(web): demo realism + UX polish — deploy-correlated telemetry, coherent feed, a11y live region

### DIFF
--- a/docs/web-implementation.md
+++ b/docs/web-implementation.md
@@ -257,6 +257,37 @@ cluster wrapping beneath it at 390. The root layout carries
 contract) — the pre-paint theme script sets `data-theme` before React
 hydrates.
 
+**Demo realism & UX pass as-built (2026-07-19).** The seeded telemetry now
+reads as a real production system under watch: a deterministic
+continuous-delivery schedule (one deploy per service every 6h) surfaces as
+staged release LOG lines (started → canary → full → finished over ~2min)
+and a correlated 45-min post-deploy latency/error blip on that service's
+metrics — release events visibly explain chart shifts, while chart deploy
+MARKERS stay cut per pages.md B1 (no deploy-events API is implied); every
+log line's `version` attr is the service's current version and bumps at
+the deploy. Log trace ids are per-line deterministic hexes (~25% of
+lines) — only lines inside the hero-trace window on its services carry
+the hero id (it previously rode ~30% of ALL lines). Error-group
+sparklines cohere with their states (new = appears at first_seen;
+regressed = spike aligned to the INC-42 window; ongoing = steady band).
+The alert feed matches rule states — the warn-state SLO-burn rule has its
+sev2 entry, and the trace-latency rule carries a triggered→recovered pair
+matching its `last_triggered_at`; feed timestamps render "MMM d" once an
+event is older than today (a bare "16:00" on a 4-day-old event read as
+today), UTC-derived like every data surface. UX fixes in the same pass:
+QueryBar's syntax-error live region is always-mounted (role=alert on a
+conditionally-mounted node is unreliable in screen readers); the RUM
+uniques tile reads "unique visitors · daily avg" (analytics-math §4
+exact-label rule); `/status/{slug}` 404s on a branded public page (CTA →
+home, not the auth-gated app) and the status header no longer advertises
+the not-yet-built subscribe affordance; query-value widgets no longer
+repeat their title inside the body (WidgetShell owns the title);
+WidgetShell clips fixed-height cells cleanly and the seeded p95 widget is
+one row taller so its 7-service legend renders unclipped; SpanDrawer
+dismisses on ESC and, below `lg`, on backdrop tap. Token hygiene: signin
+brand-mark type joins the §2 ramp (16px), BufferedCountChip uses
+`rounded-full`.
+
 Screen-state parity **[Directive 2026-07-18, carried from design.md §8.1]**:
 every data-driven screen ships default, empty, and loading states — the
 three-frame rule applies to the implementation exactly as it does to the
@@ -267,19 +298,22 @@ B1/B2/B4/B5), and the QA loop checks all three.
 ## 3. Token mapping — design.md §2 → `web/src/design/tokens.css`
 
 One custom property per Figma variable in the `upstat/tokens` collection
-(design.md §7); light values on `:root`, dark on `[data-theme="dark"]`.
-**Dark is the default** (design.md §2: dashboards + marketing default dark)
-— no stored preference resolves to dark; `prefers-color-scheme` honored
-with manual override (the theme toggle sets `data-theme`).
+(design.md §7). **Dark is the default and lives on `:root`** (design.md
+§2: dashboards + marketing default dark); light mode is the manual
+override `[data-theme="light"]` set by the theme toggle. Deliberately
+**no `prefers-color-scheme` auto-switch** — upstat is dark-primary and
+theme is an explicit user choice (a ratified deviation from the sibling
+light-`:root` arrangement; the ThemeProvider contract is otherwise
+identical).
 
-| Group | Token names |
+| Group | Token names (as built in `tokens.css`) |
 | --- | --- |
-| Color | `--bg` · `--bg-elev` · `--border` · `--text` · `--text-2` · `--brand` · `--brand-deep` · `--on-brand` · `--ok` · `--warn` · `--crit` · `--nodata` |
-| Series palette | `--series-1` … `--series-8` — the §2 8-step categorical set, identical both modes; series→color assignment stable per view session |
-| Spacing | `--space-4` `--space-8` `--space-12` `--space-16` `--space-24` `--space-32` `--space-48` `--space-64` — the 4px-grid scale, no off-scale values (data views may compress to the 4px sub-grid: 2px hairline gaps in dense tables, §2) |
-| Radii | `--radius: 4px` (the product radius — denser than siblings) · `--radius-full: 9999px` (pills, dots, avatars) |
+| Color | `--color-bg` · `--color-bg-elev` · `--color-border` · `--color-text` · `--color-text-2` · `--color-brand` · `--color-brand-deep` · `--color-on-brand` · `--color-ok` · `--color-warn` · `--color-crit` · `--color-nodata` (the `--color-` prefix is the Tailwind v4 `@theme` convention; the Figma variables carry the bare names) |
+| Series palette | `--color-series-1` … `--color-series-8` — the §2 8-step categorical set, identical both modes; series→color assignment stable per view session |
+| Spacing | step-named on the 4px grid: `--space-1: 4px` `--space-2: 8px` `--space-3: 12px` `--space-4: 16px` `--space-6: 24px` `--space-8: 32px` `--space-12: 48px` `--space-16: 64px` — no off-scale values (data views may compress to the 4px sub-grid: 2px hairline gaps in dense tables, §2) |
+| Radii | `--radius: 4px` (the product radius — denser than siblings); fully-round pills/dots/avatars use the Tailwind `rounded-full` utility (no separate custom property) |
 | Motion | `--duration-fast: 120ms` · `--duration-base: 200ms` · `--duration-slow: 300ms` · `--duration-entrance: 250ms` · `--ease-standard: cubic-bezier(0.2, 0, 0, 1)` · `--ease-exit: cubic-bezier(0.4, 0, 1, 1)` |
-| Z layers | `--z-base: 0` · `--z-sticky: 10` · `--z-dropdown: 20` · `--z-overlay: 30` · `--z-sheet: 40` · `--z-toast: 50` |
+| Z layers | `--z-base: 0` · `--z-sticky: 10` · `--z-dropdown: 20` · `--z-overlay: 30` · `--z-modal: 40` (the §2 "sheet/modal 40" layer) · `--z-toast: 50` |
 
 Notes: status semantics are sacred — `ok/warn/crit/nodata` are reserved for
 state, never decoration, and `ok` stays visually distinct from `brand`

--- a/web/src/app/api/mock/v1/logs/route.ts
+++ b/web/src/app/api/mock/v1/logs/route.ts
@@ -47,6 +47,16 @@ export async function GET(req: Request) {
     return jsonOk({ events: [], histogram: [], facets: {} });
   }
   const windowFrom = live ? now - 15 * SECOND : fromMs;
+  // hero-trace correlation window: only lines inside it (on its services)
+  // carry the hero trace id — log ↔ trace coherence (realism 2026-07-19)
+  const hero = db.heroTrace
+    ? {
+        id: db.heroTrace.trace_id,
+        startMs: Date.parse(db.heroTrace.start),
+        durationMs: db.heroTrace.duration_ms,
+        services: [...new Set(db.heroTrace.spans.map((s) => s.service))],
+      }
+    : undefined;
   const events: LogEvent[] = generateLogs(
     windowFrom,
     beforeMs,
@@ -54,6 +64,7 @@ export async function GET(req: Request) {
     service,
     level,
     limit,
+    hero,
   );
 
   const oldest = events[events.length - 1];

--- a/web/src/app/dashboard/dashboards/[id]/widget-body.tsx
+++ b/web/src/app/dashboard/dashboards/[id]/widget-body.tsx
@@ -84,9 +84,10 @@ export function WidgetBody({
       const sparkline = (series?.points ?? []).map((p) => p.value ?? 0).slice(-24);
       const precision = (widget.viz_options.precision as number) ?? 0;
       return (
+        // no label — WidgetShell's header already carries the widget title;
+        // a labeled QueryValue rendered it twice (UX walk 2026-07-19)
         <QueryValue
           value={v.toFixed(precision)}
-          label={widget.title}
           sparkline={widget.viz_options.sparkline ? sparkline : undefined}
           threshold="none"
         />

--- a/web/src/app/dashboard/rum/page.tsx
+++ b/web/src/app/dashboard/rum/page.tsx
@@ -99,7 +99,9 @@ export default function RumPage() {
               Array.from({ length: 6 }, (_, i) => <Skeleton key={i} kind="value" />)
             ) : (
               <>
-                <QueryValue label="visitors · daily avg" value={fmtK(s?.uniques_daily_avg ?? 0)} deltaPct={6} threshold="none" sparkline={uniquesSpark} className="rounded-(--radius) border border-border bg-bg-elev p-4" />
+                {/* analytics-math §4 exact-label rule: multi-day uniques are
+                    "daily-average uniques" — the label must carry "unique" */}
+                <QueryValue label="unique visitors · daily avg" value={fmtK(s?.uniques_daily_avg ?? 0)} deltaPct={6} threshold="none" sparkline={uniquesSpark} className="rounded-(--radius) border border-border bg-bg-elev p-4" />
                 <QueryValue label="pageviews" value={fmtK(s?.page_views ?? 0)} deltaPct={3} threshold="ok" sparkline={viewsSpark} className="rounded-(--radius) border border-border bg-bg-elev p-4" />
                 <QueryValue label="bounce rate" value={s?.bounce_rate === null || s?.bounce_rate === undefined ? "—" : `${Math.round(s.bounce_rate * 100)}%`} deltaPct={4} threshold="warn" sparkline={viewsSpark.map((x) => x % 17)} className="rounded-(--radius) border border-border bg-bg-elev p-4" />
                 <QueryValue label="p75 LCP" value={`${((v?.lcp_ms.p75 ?? 0) / 1000).toFixed(1)} s`} deltaPct={18} threshold="crit" sparkline={lcpSpark} className="rounded-(--radius) border border-border bg-bg-elev p-4" />

--- a/web/src/app/signin/page.tsx
+++ b/web/src/app/signin/page.tsx
@@ -21,7 +21,7 @@ export default function SignInPage() {
         <header className="flex flex-col gap-[var(--space-2)]">
           <span
             aria-hidden="true"
-            className="mb-[var(--space-2)] inline-flex size-8 items-center justify-center rounded-(--radius) bg-brand text-[15px] font-semibold text-on-brand"
+            className="mb-[var(--space-2)] inline-flex size-8 items-center justify-center rounded-(--radius) bg-brand text-[16px] font-semibold text-on-brand"
           >
             U
           </span>

--- a/web/src/app/status/[slug]/page.tsx
+++ b/web/src/app/status/[slug]/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useParams } from "next/navigation";
 import { IncidentHistoryEntry } from "@/components/ui/IncidentHistoryEntry";
 import { Skeleton } from "@/components/ui/Skeleton";
@@ -28,12 +29,22 @@ export default function StatusPage() {
   }
 
   if (error || !page) {
+    // branded 404 treatment (the app-wide not-found pattern) — public
+    // surface, so the CTA points home, not into the auth-gated dashboard
     return (
-      <main className="mx-auto w-full max-w-[960px] px-6 py-10">
-        <h1 className="text-[20px] font-semibold">Status page not found</h1>
-        <p className="mt-2 text-[13px] leading-[1.45] text-text-2">
-          No status page exists at this address.
+      <main className="font-ui flex min-h-screen flex-col items-center justify-center gap-4 bg-bg px-6 text-text">
+        <p className="font-data text-[13px] text-text-2">404</p>
+        <h1 className="text-[24px] font-semibold">Status page not found</h1>
+        <p className="max-w-[420px] text-center text-[13px] leading-[1.45] text-text-2">
+          No status page exists at this address — the owner may have renamed
+          its slug or unpublished it.
         </p>
+        <Link
+          href="/"
+          className="rounded-(--radius) bg-brand px-4 py-2 text-[13px] font-medium text-on-brand transition-colors duration-[var(--duration-fast)] hover:bg-brand-deep"
+        >
+          Go to upstat.cuesoft.io
+        </Link>
       </main>
     );
   }
@@ -52,9 +63,11 @@ export default function StatusPage() {
           </span>
           {page.org_name.toLowerCase()} status
         </h1>
+        {/* no subscribe affordance yet (pages.md B7 subscribe = Later) —
+            the copy must not advertise one (dead-end copy, QA 2026-07-19) */}
         <p className="text-[13px] leading-[1.45] text-text-2">
           Live status for the {page.org_name.toLowerCase()} cloud — updates
-          every 60s · subscribe via RSS / webhook
+          every 60s
         </p>
       </header>
 

--- a/web/src/components/ui/AlertFeedRow.tsx
+++ b/web/src/components/ui/AlertFeedRow.tsx
@@ -5,6 +5,19 @@ import { clsx } from "clsx";
 import type { ReactNode } from "react";
 import type { AlertEvent } from "@/models";
 
+const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+
+/**
+ * Feed timestamp — HH:mm for today's events, "MMM d" for older ones (a
+ * bare "16:00" on a 4-day-old event read as today; UX walk 2026-07-19).
+ * Derived from the ISO string so it renders UTC like every other data
+ * surface (the TimeseriesPanel X-10 note), independent of host timezone.
+ */
+function feedTime(ts: string): string {
+  if (ts.slice(0, 10) === new Date().toISOString().slice(0, 10)) return ts.slice(11, 16);
+  return `${MONTHS[Number(ts.slice(5, 7)) - 1]} ${Number(ts.slice(8, 10))}`;
+}
+
 export interface AlertFeedRowProps {
   event: AlertEvent;
   onClick?: () => void;
@@ -49,8 +62,8 @@ export function AlertFeedRow({ event, onClick, className }: AlertFeedRowProps) {
         </span>
         <span className="truncate text-[12px] text-text-2">{event.message}</span>
       </div>
-      <time className="shrink-0 text-[11px] tabular-nums text-text-2">
-        {event.ts.slice(11, 16)}
+      <time dateTime={event.ts} className="shrink-0 text-[11px] tabular-nums text-text-2">
+        {feedTime(event.ts)}
       </time>
       {event.unread && (
         <span aria-label="unread" className="size-1.5 shrink-0 rounded-full bg-brand" />

--- a/web/src/components/ui/CountBadge.tsx
+++ b/web/src/components/ui/CountBadge.tsx
@@ -44,7 +44,7 @@ export function BufferedCountChip({ count, onClick, className }: BufferedCountCh
       type="button"
       onClick={onClick}
       className={clsx(
-        "font-data inline-flex items-center gap-1 rounded-[10px] border border-brand bg-brand/12 px-2 py-[3px]",
+        "font-data inline-flex items-center gap-1 rounded-full border border-brand bg-brand/12 px-2 py-[3px]",
         "text-[11px] font-medium text-brand",
         "transition-colors duration-[var(--duration-fast)] ease-standard hover:bg-brand/20",
         className,

--- a/web/src/components/ui/QueryBar.tsx
+++ b/web/src/components/ui/QueryBar.tsx
@@ -107,11 +107,13 @@ export function QueryBar({
         />
       </div>
 
-      {syntaxError && (
-        <p role="alert" className="mt-1 text-[12px] text-crit">
-          {syntaxError}
-        </p>
-      )}
+      {/* always-mounted live region — screen readers announce role=alert
+          reliably only when the region pre-exists and its TEXT changes; a
+          conditionally-mounted node can be missed (QA 2026-07-19). Empty
+          <p> renders zero-height; mt-1 applies only with content. */}
+      <p role="alert" className={clsx("text-[12px] text-crit", syntaxError && "mt-1")}>
+        {syntaxError}
+      </p>
 
       {open && (
         <ul

--- a/web/src/components/ui/SpanDrawer.tsx
+++ b/web/src/components/ui/SpanDrawer.tsx
@@ -2,7 +2,7 @@
 
 import { clsx } from "clsx";
 import { X } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import type { LogEvent, Span } from "@/models";
 import { LogLine } from "./LogLine";
 
@@ -20,7 +20,24 @@ export interface SpanDrawerProps {
 export function SpanDrawer({ span, logs = [], onClose, className }: SpanDrawerProps) {
   const [tab, setTab] = useState<SpanDrawerTab>("tags");
 
+  // ESC closes the drawer in both renderings (inline panel and <lg sheet) —
+  // parity with Modal/Sheet dismissal (UX walk 2026-07-19)
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
   return (
+    <>
+    {/* <lg sheet backdrop: scrim + tap-to-dismiss behind the fixed sheet */}
+    <div
+      role="presentation"
+      onClick={onClose}
+      className="fixed inset-0 z-[var(--z-overlay)] bg-bg/70 lg:hidden"
+    />
     <aside
       aria-label={`Span ${span.name}`}
       className={clsx(
@@ -106,5 +123,6 @@ export function SpanDrawer({ span, logs = [], onClose, className }: SpanDrawerPr
         )}
       </div>
     </aside>
+    </>
   );
 }

--- a/web/src/components/ui/WidgetShell.tsx
+++ b/web/src/components/ui/WidgetShell.tsx
@@ -137,7 +137,10 @@ export function WidgetShell({
           </div>
         )}
       </header>
-      <div className="min-h-0 flex-1">{children}</div>
+      {/* overflow-hidden: fixed-height grid cells clip cleanly instead of
+          bleeding legends into the neighbor row (UX walk 2026-07-19);
+          stacked mobile rows size to content, so nothing clips there */}
+      <div className="min-h-0 flex-1 overflow-hidden">{children}</div>
     </section>
   );
 }

--- a/web/src/mocks/seed.ts
+++ b/web/src/mocks/seed.ts
@@ -104,7 +104,8 @@ export function buildSeed(now: number): MockDb {
           query: null,
           query_string: "metric:http.request.duration_ms | p95() by service",
           viz_options: { display: "line" },
-          layout: { x: 0, y: 0, w: 8, h: 3 },
+          // h4: the 7-service legend needs the extra row to render unclipped
+          layout: { x: 0, y: 0, w: 8, h: 4 },
         },
         {
           id: "wid_reqs",
@@ -117,7 +118,7 @@ export function buildSeed(now: number): MockDb {
           // (system-QA finding 2026-07-19)
           query_string: "metric:http.requests_total service:$service | rate()",
           viz_options: { precision: 0, sparkline: true },
-          layout: { x: 8, y: 0, w: 4, h: 3 },
+          layout: { x: 8, y: 0, w: 4, h: 4 },
         },
         {
           id: "wid_err_rate",
@@ -129,7 +130,7 @@ export function buildSeed(now: number): MockDb {
           viz_options: { display: "area" },
           // second timeseries widget: makes the MI-2 cross-widget crosshair
           // sync observable on the seeded dashboard
-          layout: { x: 0, y: 6, w: 12, h: 2 },
+          layout: { x: 0, y: 7, w: 12, h: 2 },
         },
         {
           id: "wid_top",
@@ -139,7 +140,7 @@ export function buildSeed(now: number): MockDb {
           query: null,
           query_string: "metric:http.errors_total | sum() by service",
           viz_options: { limit: 5 },
-          layout: { x: 0, y: 3, w: 6, h: 3 },
+          layout: { x: 0, y: 4, w: 6, h: 3 },
         },
         {
           id: "wid_logs",
@@ -149,7 +150,7 @@ export function buildSeed(now: number): MockDb {
           query: null,
           query_string: "level:ERROR",
           viz_options: {},
-          layout: { x: 6, y: 3, w: 6, h: 3 },
+          layout: { x: 6, y: 4, w: 6, h: 3 },
         },
       ],
     },
@@ -424,10 +425,14 @@ export function buildSeed(now: number): MockDb {
       thresholds: { warn: 400, crit: 900, window: "10m" },
       notify: { channel_ids: ["ch_slack"], cooldown_minutes: 15, renotify_minutes: 0, mute_windows: [] },
       state: "ok",
-      last_triggered_at: null,
+      // fired + recovered 4d ago — matches the evt_5/evt_6 feed pair
+      last_triggered_at: iso(now - 4 * DAY),
     },
   ];
 
+  // every non-ok rule state has a matching feed event, and each rule's
+  // newest event matches its `last_triggered_at` (realism fix 2026-07-19:
+  // rule_slo_burn sat in `warn` with no feed entry)
   const alertFeed: AlertEvent[] = [
     {
       id: "evt_1",
@@ -445,6 +450,33 @@ export function buildSeed(now: number): MockDb {
       rule_id: "rule_error_logs",
       monitor_name: "Error log spike (checkout)",
       message: "132 ERROR lines in 5m (warn 50)",
+      unread: false,
+    },
+    {
+      id: "evt_4",
+      ts: iso(inc42Start + 12 * MINUTE),
+      sev: "sev2",
+      rule_id: "rule_slo_burn",
+      monitor_name: "Checkout SLO fast burn",
+      message: "burn rate 6.2x over warn 6x (window 2h)",
+      unread: false,
+    },
+    {
+      id: "evt_5",
+      ts: iso(now - 4 * DAY + 25 * MINUTE),
+      sev: "resolved",
+      rule_id: "rule_trace_latency",
+      monitor_name: "Ingest gateway trace latency",
+      message: "Recovered after 25m — p95 back under 400 ms",
+      unread: false,
+    },
+    {
+      id: "evt_6",
+      ts: iso(now - 4 * DAY),
+      sev: "sev2",
+      rule_id: "rule_trace_latency",
+      monitor_name: "Ingest gateway trace latency",
+      message: "p95 612 ms breached warn 400 ms (window 10m)",
       unread: false,
     },
     {
@@ -760,6 +792,9 @@ export function buildSeed(now: number): MockDb {
   }
   traceSummaries.sort((a, b) => (a.start < b.start ? 1 : -1));
 
+  // sparklines = 24 hourly buckets ending now; shapes cohere with state
+  // (new appeared 2h ago → bars in the last 2 buckets; regressed spiked in
+  // the INC-42 window ~2–3h ago → spike near bucket 21)
   const errorGroups: ErrorGroup[] = [
     {
       fingerprint: "fe4a9d21",
@@ -768,7 +803,7 @@ export function buildSeed(now: number): MockDb {
       first_seen: iso(now - 6 * DAY),
       last_seen: iso(now - 18 * MINUTE),
       state: "ongoing",
-      sparkline: sparklineFor("err:fe4a9d21", 24, 8),
+      sparkline: stateSparkline("err:fe4a9d21", "ongoing", 24, 8),
     },
     {
       fingerprint: "a10c33b7",
@@ -777,7 +812,7 @@ export function buildSeed(now: number): MockDb {
       first_seen: iso(now - 2 * HOUR),
       last_seen: iso(now - 4 * MINUTE),
       state: "new",
-      sparkline: sparklineFor("err:a10c33b7", 24, 5),
+      sparkline: stateSparkline("err:a10c33b7", "new", 24, 12, { firstSeenBucket: 22 }),
     },
     {
       fingerprint: "c88e01f2",
@@ -786,7 +821,7 @@ export function buildSeed(now: number): MockDb {
       first_seen: iso(now - 40 * DAY),
       last_seen: iso(inc42End),
       state: "regressed",
-      sparkline: sparklineFor("err:c88e01f2", 24, 26),
+      sparkline: stateSparkline("err:c88e01f2", "regressed", 24, 26, { spikeBucket: 21 }),
     },
     {
       fingerprint: "1d0b9ae4",
@@ -795,7 +830,7 @@ export function buildSeed(now: number): MockDb {
       first_seen: iso(now - 30 * DAY),
       last_seen: iso(now - 3 * HOUR),
       state: "ongoing",
-      sparkline: sparklineFor("err:1d0b9ae4", 24, 4),
+      sparkline: stateSparkline("err:1d0b9ae4", "ongoing", 24, 4),
     },
   ];
 
@@ -921,7 +956,37 @@ function heroTraceSummary(t: Trace): TraceSummary {
   return { trace_id, root_service, root_name, start, duration_ms, span_count, status };
 }
 
-function sparklineFor(key: string, buckets: number, scale: number): number[] {
+/**
+ * State-coherent error-group sparkline (24 hourly buckets, oldest→newest —
+ * realism fix 2026-07-19: pure noise contradicted the group states):
+ * - `new` — flat zero until the group's first_seen, then rising bars
+ * - `regressed` — low baseline with a spike in the buckets around the
+ *   INC-42 window (last_seen = inc42End)
+ * - `ongoing` — steady mid-level noise across the day
+ */
+function stateSparkline(
+  key: string,
+  state: ErrorGroup["state"],
+  buckets: number,
+  scale: number,
+  opts: { firstSeenBucket?: number; spikeBucket?: number } = {},
+): number[] {
   const r = mulberry32(hashSeed(key));
-  return Array.from({ length: buckets }, () => Math.round(r() * scale));
+  return Array.from({ length: buckets }, (_, i) => {
+    if (state === "new") {
+      const start = opts.firstSeenBucket ?? buckets - 3;
+      if (i < start) return 0;
+      return Math.max(1, Math.round(((i - start + 1) / (buckets - start)) * scale * (0.6 + r() * 0.6)));
+    }
+    if (state === "regressed") {
+      const spike = opts.spikeBucket ?? buckets - 3;
+      const dist = Math.abs(i - spike);
+      const base = Math.round(r() * scale * 0.15);
+      if (dist <= 1) return Math.round(scale * (0.7 + r() * 0.3));
+      if (dist === 2) return Math.round(scale * 0.35 * (0.7 + r() * 0.6));
+      return base;
+    }
+    // ongoing — steady band, never zero for long
+    return Math.max(1, Math.round(scale * (0.35 + r() * 0.45)));
+  });
 }

--- a/web/src/mocks/series.ts
+++ b/web/src/mocks/series.ts
@@ -84,6 +84,55 @@ function envScale(env: string | undefined): number {
   return 0.15 + unitFor(`env:${env}`) * 0.3; // staging-class envs ≈ 15–45%
 }
 
+/* ------------------------------------------------------------------ */
+/* Deploys                                                              */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Deterministic per-service release schedule — continuous delivery, one
+ * deploy per service every 6h at a stable per-service offset. Releases
+ * surface as staged LOG lines (started → canary → full → finished over
+ * ~2min) and as a short post-deploy latency/error blip on the service's
+ * metrics, so the log stream visibly correlates with metric shifts
+ * (realism directive 2026-07-19). Chart deploy MARKERS stay cut per
+ * pages.md B1 — no deploy-events API is implied.
+ */
+const DEPLOY_PERIOD = 6 * HOUR;
+const DEPLOY_BLIP_MS = 45 * MINUTE;
+const DEPLOY_STAGE_STEP_MS = 30 * SECOND;
+
+const DEPLOY_STAGES = [
+  (s: string, v: string) => `deploy started service=${s} version=${v} strategy=canary`,
+  (s: string, v: string) => `canary at 25% service=${s} version=${v} error_rate=nominal`,
+  (s: string, v: string) => `canary checks passed service=${s} version=${v}`,
+  (s: string, v: string) => `rollout 100% service=${s} version=${v}`,
+  (s: string, v: string) => `deploy finished service=${s} version=${v} duration=120s`,
+];
+
+export function lastDeploy(service: string, tMs: number): { at: number; version: string } {
+  const offset = Math.floor(unitFor(`deploy:${service}`) * DEPLOY_PERIOD);
+  const n = Math.floor((tMs - offset) / DEPLOY_PERIOD);
+  const at = offset + n * DEPLOY_PERIOD;
+  // monotonic-looking versions: patch bumps per deploy, minor weekly
+  return { at, version: `1.${14 + (Math.floor(n / 28) % 4)}.${((n % 28) + 28) % 28}` };
+}
+
+/** Rollout stage line for the second at `secMs`, or null outside windows. */
+function deployStageLine(service: string, secMs: number): string | null {
+  const { at, version } = lastDeploy(service, secMs + SECOND - 1);
+  const since = secMs - at;
+  if (since < 0 || since > DEPLOY_STAGE_STEP_MS * (DEPLOY_STAGES.length - 1)) return null;
+  if (since % DEPLOY_STAGE_STEP_MS >= SECOND) return null; // band's first second only
+  return DEPLOY_STAGES[Math.round(since / DEPLOY_STAGE_STEP_MS)](service, version);
+}
+
+/** 1 → just deployed, fading to 0 over the blip window (prod only). */
+function deployRamp(service: string, tMs: number): number {
+  const since = tMs - lastDeploy(service, tMs).at;
+  if (since < 0 || since >= DEPLOY_BLIP_MS) return 0;
+  return 1 - since / DEPLOY_BLIP_MS;
+}
+
 /**
  * Value generator for a (metric, fn, service) triple at a time bucket.
  * Shapes: duration metrics honor p50/p95/p99 ordering; count/rate metrics
@@ -108,12 +157,16 @@ export function metricValue(
     ? Math.min(1, (tMs - outage.start) / (5 * MINUTE), (outage.end - tMs) / (5 * MINUTE))
     : 0;
 
+  // post-deploy cold-cache blip (prod only, log-line correlated)
+  const dRamp = scale === 1 ? deployRamp(service, tMs) : 0;
+
   if (metric.includes("duration") || metric.includes("latency")) {
     const { p50, spread } = baseLatency(service);
     const quantile =
       fn === "p99" ? spread * 2.6 : fn === "p95" ? spread : fn === "p50" || fn === "avg" ? 1 : 1;
     let v = p50 * quantile * (0.9 + 0.2 * cycle) + noise(`${metric}:${fn}:${service}`, tMs, p50 * 0.08);
     if (ramp > 0) v *= 1 + 7 * ramp; // ~8x at peak (over the 1.5s crit line)
+    v *= 1 + 0.14 * dRamp;
     v *= 0.85 + 0.15 * scale; // lighter non-prod load runs a touch faster
     return Math.max(1, Math.round(v * 100) / 100);
   }
@@ -121,6 +174,7 @@ export function metricValue(
   if (metric.includes("error")) {
     let v = baseRate(service) * 0.004 * cycle + Math.abs(noise(`${metric}:${service}`, tMs, 0.2));
     if (ramp > 0) v = baseRate(service) * 0.1 * ramp; // ~25x error spike
+    v *= 1 + 1.2 * dRamp;
     v *= scale;
     return Math.round(v * 1000) / 1000;
   }
@@ -327,9 +381,32 @@ function levelFor(u: number, outageHit: boolean): LogLevel {
   return "TRACE";
 }
 
+/** Hero-trace correlation window (log ↔ trace ↔ span coherence). */
+export interface HeroTraceWindow {
+  id: string;
+  startMs: number;
+  durationMs: number;
+  services: string[];
+}
+
+/** Deterministic 32-hex trace id for a log line (plausible variety). */
+function traceIdHex(key: string): string {
+  let out = "";
+  for (let i = 0; i < 4; i++) {
+    out += (hashSeed(`${key}:${i}`) >>> 0).toString(16).padStart(8, "0");
+  }
+  return out;
+}
+
 /**
  * Deterministic log stream: ~3 lines/sec across services. `beforeMs`
- * exclusive upper bound; returns newest-first.
+ * exclusive upper bound; returns newest-first. Release events surface as
+ * "deploy finished" INFO lines at each service's deploy second; every
+ * line's `version` attr is the service's CURRENT version (bumps at the
+ * deploy, matching the metric blip). Trace ids are per-line deterministic
+ * hexes — only lines inside the hero-trace window on its services carry
+ * the hero trace id (the seeded 9f86d081… id previously rode ~30% of ALL
+ * lines; realism fix 2026-07-19).
  */
 export function generateLogs(
   fromMs: number,
@@ -338,28 +415,47 @@ export function generateLogs(
   filterService?: string,
   filterLevel?: string,
   limit = 100,
+  hero?: HeroTraceWindow,
 ): LogEvent[] {
   const events: LogEvent[] = [];
   const startSec = Math.floor(beforeMs / SECOND) - 1;
   const endSec = Math.floor(fromMs / SECOND);
   for (let sec = startSec; sec >= endSec && events.length < limit; sec--) {
+    const secMs = sec * SECOND;
+    // rollout stage lines landing in this second (usually none)
+    const rollouts = SERVICES.map((s) => ({
+      service: s as string,
+      line: deployStageLine(s, secMs),
+    })).filter((x): x is { service: string; line: string } => x.line !== null);
     const perSecond = 3;
     for (let slot = perSecond - 1; slot >= 0 && events.length < limit; slot--) {
       const key = `log:${sec}:${slot}`;
       const r = mulberry32(hashSeed(key));
       // slot-banded offsets keep newest-first ordering strict within a second
-      const tMs = sec * SECOND + slot * 300 + Math.floor(r() * 250);
+      const tMs = secMs + slot * 300 + Math.floor(r() * 250);
       const outageHit = tMs >= outage.start && tMs <= outage.end;
+      const rollout = slot === 0 ? rollouts[0] : undefined;
       // during the outage, bias lines toward the implicated services
-      const service =
-        outageHit && r() < 0.5
+      const service = rollout
+        ? rollout.service
+        : outageHit && r() < 0.5
           ? outage.services[Math.floor(r() * outage.services.length)]
           : SERVICES[Math.floor(r() * SERVICES.length)];
-      const level = levelFor(r(), outageHit && outage.services.includes(service));
+      const level = rollout
+        ? "INFO"
+        : levelFor(r(), outageHit && outage.services.includes(service));
       if (filterService && service !== filterService) continue;
       if (filterLevel && level !== filterLevel.toUpperCase()) continue;
+      const deploy = lastDeploy(service, tMs);
       const templates = LOG_TEMPLATES[level];
-      const message = templates[Math.floor(r() * templates.length)];
+      const message = rollout
+        ? rollout.line
+        : templates[Math.floor(r() * templates.length)];
+      const heroHit =
+        hero !== undefined &&
+        tMs >= hero.startMs - 1_500 &&
+        tMs <= hero.startMs + hero.durationMs + 1_500 &&
+        hero.services.includes(service);
       events.push({
         id: `log_${sec}_${slot}`,
         ts: iso(tMs),
@@ -369,10 +465,14 @@ export function generateLogs(
         message,
         attrs: {
           env: "prod",
-          version: "1.14.2",
+          version: deploy.version,
           ...(level === "ERROR" ? { "error.kind": "upstream" } : {}),
         },
-        ...(r() < 0.3 ? { trace_id: "9f86d081884c7d659a2feaa0c55ad015" } : {}),
+        ...(heroHit
+          ? { trace_id: hero.id }
+          : r() < 0.25
+            ? { trace_id: traceIdHex(key) }
+            : {}),
       });
     }
   }

--- a/web/src/mocks/series.ts
+++ b/web/src/mocks/series.ts
@@ -110,7 +110,11 @@ const DEPLOY_STAGES = [
 ];
 
 export function lastDeploy(service: string, tMs: number): { at: number; version: string } {
-  const offset = Math.floor(unitFor(`deploy:${service}`) * DEPLOY_PERIOD);
+  // second-aligned offset: the log generator iterates whole seconds, so
+  // deploy instants must land exactly on one (PR #166 review — a ms-precise
+  // offset shifted every stage band off the generator's grid)
+  const offset =
+    Math.floor((unitFor(`deploy:${service}`) * DEPLOY_PERIOD) / SECOND) * SECOND;
   const n = Math.floor((tMs - offset) / DEPLOY_PERIOD);
   const at = offset + n * DEPLOY_PERIOD;
   // monotonic-looking versions: patch bumps per deploy, minor weekly
@@ -361,7 +365,10 @@ const LOG_TEMPLATES: Record<LogLevel, string[]> = {
     "check failed monitor=checkout-flow status=503 timeout=false",
   ],
   TRACE: [
-    "span exported trace_id=9f86d081884c7d659a2feaa0c55ad015 spans=6",
+    // `trace_id=…` is interpolated with the LINE's own trace id at
+    // generation time (PR #166 review — a hardcoded hero id here clashed
+    // with the generated per-line id and leaked outside the hero window)
+    "span exported trace_id={trace_id} spans=6",
     "otlp frame decoded size=2.1kb",
   ],
 };
@@ -456,23 +463,31 @@ export function generateLogs(
         tMs >= hero.startMs - 1_500 &&
         tMs <= hero.startMs + hero.durationMs + 1_500 &&
         hero.services.includes(service);
+      // the line's trace id: hero window → hero id; else a per-line hex on
+      // ~25% of lines — and always on messages that print a trace_id
+      let traceId = heroHit
+        ? hero.id
+        : r() < 0.25
+          ? traceIdHex(key)
+          : undefined;
+      let finalMessage = message;
+      if (finalMessage.includes("{trace_id}")) {
+        traceId ??= traceIdHex(key);
+        finalMessage = finalMessage.replace("{trace_id}", traceId);
+      }
       events.push({
         id: `log_${sec}_${slot}`,
         ts: iso(tMs),
         service,
         level,
         host: HOSTS[Math.floor(r() * HOSTS.length)],
-        message,
+        message: finalMessage,
         attrs: {
           env: "prod",
           version: deploy.version,
           ...(level === "ERROR" ? { "error.kind": "upstream" } : {}),
         },
-        ...(heroHit
-          ? { trace_id: hero.id }
-          : r() < 0.25
-            ? { trace_id: traceIdHex(key) }
-            : {}),
+        ...(traceId ? { trace_id: traceId } : {}),
       });
     }
   }


### PR DESCRIPTION
## Summary

PR2 of the P1 polish series (`fix/ux-demo-realism`). The seeded telemetry now reads as a real production system watched by real engineers, plus the adjudicated UX/a11y fixes and a UI-consistency pass.

## Demo-data realism (adjudicated)

- **Release events, log-correlated with metric shifts**: a deterministic CD schedule (each service deploys every 6h at a stable offset) surfaces as staged log lines (`deploy started → canary at 25% → canary checks passed → rollout 100% → deploy finished` over ~2 min) and a correlated 45-minute post-deploy latency/error blip on that service's metrics. Chart deploy **markers** stay cut per pages.md B1 — no deploy-events API is implied. Every log line's `version` attr is the service's current version and bumps at the deploy.
- **Trace-id diversification**: the hero trace id (`9f86d081…`) previously rode ~30% of ALL log lines; now ~25% of lines carry per-line deterministic hex ids, and only lines inside the hero-trace window on its services carry the hero id (verified live: 4 correlated lines around the hero `POST /v1/events` window, 107/500 diversified unique ids elsewhere).
- **Error-group sparklines cohere with state**: `new` appears at first_seen, `regressed` spikes in the INC-42 window (last_seen = mitigation time), `ongoing` holds a steady band.
- **Alert feed matches rule states**: the warn-state SLO-burn rule now has its sev2 feed entry (`burn rate 6.2x over warn 6x`); the trace-latency rule carries a triggered→recovered pair matching its `last_triggered_at`; the seeded unread-count (bell badge = 1) is unchanged. Feed timestamps render `MMM d` for pre-today events — a bare "16:00" on a 4-day-old event read as today. UTC-derived like every data surface.

## UX + a11y

- QueryBar's syntax-error region is an **always-mounted** `role=alert` live region (conditionally mounted alerts are unreliable in screen readers) — the MI-13 error still renders identically
- RUM uniques tile reads **"unique visitors · daily avg"** (analytics-math §4 exact-label rule)
- `/status/{slug}` unknown slugs get the **branded 404** treatment (public surface: CTA → home, not the auth-gated app); the status header drops the dead-end "subscribe via RSS / webhook" copy (subscribe = Later per pages.md B7)
- `query_value` widgets no longer repeat their title inside the body (WidgetShell owns the title); WidgetShell clips fixed-height cells cleanly; the seeded p95 widget is one grid row taller so its 7-service legend renders unclipped
- SpanDrawer dismisses on ESC and (below `lg`) on backdrop tap

## Consistency audit

- **web-implementation §3 corrected to the as-built `tokens.css`** (docs describe the current system): dark-first `:root` with `[data-theme="light"]` manual override and deliberately no `prefers-color-scheme` auto-switch; `--color-*` naming (Tailwind v4 `@theme`); step-named `--space-1..16` on the 4px grid; `--z-modal`; no `--radius-full` custom property
- signin brand-mark type joins the §2 ramp (16px); BufferedCountChip uses `rounded-full`
- Figma-side findings (node-level, for the design agent) are listed in the PR report to the coordinator

## Tests

All gates green locally: lint + check:boundaries, typecheck, 217 unit tests, 28 Playwright e2e (TEST_MODE, incl. the PR1 mobile sweep on all 32 routes × both themes). Realism mechanics verified against the live mock (deploy-stage lines, hero-window correlation, diversified ids).

🤖 Generated with [Claude Code](https://claude.com/claude-code)