### PR TITLE
docs(design): §2 type ramp — micro/10 step + marketing display extension

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -57,11 +57,18 @@ verified in both themes) — the one extra constraint the teal brand imposes.
 ### Type & numerals
 
 - UI: `Inter`; data/query/code: `JetBrains Mono` (log lines, queries, IDs).
-- Type ramp **[Decided]**: 11 (axis labels) / 12 (dense meta) / **13 base**
-  (data views, lh 1.45) / 14 (settings/forms) / 16 (panel titles, 600) /
-  20 (page titles, 600) / 24–32 (marketing only); weights 400/500/600;
-  tabular figures in all numeric contexts; fixed-precision latencies
-  (`142 ms`, `1.24 s`).
+- Type ramp **[Decided]**: **10 micro** (chip type — TopBar env chip,
+  MemberRow role chip, APIKeyRow kind/scope chips, Avatar initials/+n,
+  CountBadge, ErrorGroupRow state chip; Inter + JetBrains Mono twins,
+  named `Micro/10` / `Mono/Micro 10` in Figma) **[Ratified 2026-07-19]** /
+  11 (axis labels) / 12 (dense meta) / **13 base** (data views, lh 1.45) /
+  14 (settings/forms) / 16 (panel titles, 600) / 20 (page titles, 600) /
+  24–32 (marketing only) · **marketing display extension [Ratified
+  2026-07-19]**: landing hero h1 **34/44** and final CTA band **26/32**
+  (mobile/desktop responsive pairs; desktop steps are the named
+  `Display/44` / `Display/32` Figma styles, Stage-5 marketing only);
+  weights 400/500/600; tabular figures in all numeric contexts;
+  fixed-precision latencies (`142 ms`, `1.24 s`).
 
 ### Layout
 


### PR DESCRIPTION
## Summary

Pins the ratified P1 PR2 type findings **[Ratified 2026-07-19]** in `docs/design.md` §2:

- **micro/10 ramp step** — the six 10px chip components (TopBar env chip · MemberRow role chip · APIKeyRow kind/scope chips · Avatar initials/+n · CountBadge · ErrorGroupRow state chip) are canon at 10px; named Figma styles `Micro/10 Medium` (Inter) + `Mono/Micro 10` (JetBrains Mono twin).
- **Marketing display extension** — landing hero h1 **34/44** and final CTA band **26/32** are legitimate display steps (mobile/desktop responsive pairs); the desktop steps ship as the named `Display/44` / `Display/32` styles, Stage-5 marketing only.
- Foundations spacing verified: `upstat/tokens` `space/1..16` = 4/8/12/16/24/32/48/64 — exactly matches `web/src/design/tokens.css`; no rename needed.

Matches the Figma file as revised today (styles created + bound; FAQItem radius/padding and StatusPill padding retro-fits; QueryValue label=off usage note; MemberRow role-Select scale constraint documented in its description — see the canvas report).

🤖 Generated with [Claude Code](https://claude.com/claude-code)