### PR TITLE
feat(web): demo completeness — portable dashboards, logs-in-span, declare-from-alert, mobile rail drawer

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -71,7 +71,12 @@ verified in both themes) — the one extra constraint the teal brand imposes.
   Platform); sections = pillars (§pages.md B). Chevron toggle at the rail foot
   switches state; the choice persists per user across sessions
   (`nav.rail.expanded` in localStorage). Default: expanded on desktop ≥1280px,
-  collapsed below. Active item = brand accent bar + brand icon in both states.
+  collapsed below. **[Clarified 2026-07-19]** Below `md` expansion must never
+  squeeze the content: the persisted state does not apply (mobile always
+  boots the 56px rail) and the foot chevron opens a 240px **overlay drawer**
+  over a scrim instead — content keeps full width beneath; scrim tap,
+  Escape, and item selection close it. Active item = brand accent bar +
+  brand icon in both states.
   Top bar: org/env switcher · **global time picker** · search (`/`) ·
   theme toggle · incidents bell (**[Directive 2026-07-19]** the toggle joins
   the utility cluster; see the parity canon below).
@@ -98,9 +103,11 @@ verified in both themes) — the one extra constraint the teal brand imposes.
   "Marketing nav, footer & theme parity canon", ratified 2026-07-19): all
   three products share ONE link inventory — same sections, counts and
   destinations; upstat renders it in its own dark visual design.
-  - **Nav** **[Revised 2026-07-19]**: 4 text links Features · Platform
-    (upstat product slot — anchors to the landing pillar-grid section) ·
-    Docs (GitBook root) · GitHub — the GitHub item
+  - **Nav** **[Revised 2026-07-19]**: 4 text links Features (anchors the
+    landing feature-highlights band, `/#features` — differentiated from
+    Platform, which anchors the pillar grid; the two previously shared one
+    anchor) · Platform (upstat product slot — anchors to the landing
+    pillar-grid section) · Docs (GitBook root) · GitHub — the GitHub item
     renders as a compact star badge (star glyph + neutral "Star" label; no
     count on canvas — the live star count is runtime behavior) — +
     ThemeToggle control + **"Sign in" text link** (`/signin`) + **"Try

--- a/docs/pages.md
+++ b/docs/pages.md
@@ -17,7 +17,7 @@ community-driven") remains the visual base, extended for the new pillars.
 
 | # | Section | Content | Interactions |
 | --- | --- | --- | --- |
-| A1 | Nav | logo · Features (pillar-map dropdown) · Platform (anchors to the A3 pillar grid) · Docs (GitBook) · GitHub star badge (neutral "Star") · ThemeToggle · Sign in text link · **Try Cloud** CTA **[Revised 2026-07-19]** | Features dropdown = mini feature map |
+| A1 | Nav | logo · Features (anchors the A11 feature-highlights band, `/#features` — differentiated from Platform 2026-07-19; the pillar-map dropdown preview remains specced, unbuilt) · Platform (anchors to the A3 pillar grid) · Docs (GitBook) · GitHub star badge (neutral "Star") · ThemeToggle · Sign in text link · **Try Cloud** CTA **[Revised 2026-07-19]** | Features dropdown = mini feature map **[gap — pending adjudication vs the 4-text-links canon]** |
 | A2 | Hero | H1 (from Figma pillars); dual CTA **Try Cloud** / **Self Host**; hero visual: live-looking dashboard with animated timeseries + synced crosshair demo | crosshair demo animates on an 8s loop |
 | A3 | Pillar grid | 8 cards: Uptime & Synthetics · Website Analytics/RUM · Metrics · Logs · APM/Traces · Dashboards · Alerting · Incidents & SLOs | hover lifts + pillar color accent |
 | A4 | Demo strip | **static demo cards** (synthetic data, U0-3) — the interactive embedded demo org is descoped to a post-Phase-3 enhancement **[Decided]** | — |

--- a/docs/web-implementation.md
+++ b/docs/web-implementation.md
@@ -288,6 +288,33 @@ dismisses on ESC and, below `lg`, on backdrop tap. Token hygiene: signin
 brand-mark type joins the §2 ramp (16px), BufferedCountChip uses
 `rounded-full`.
 
+**Demo completeness as-built (2026-07-19).** Gap-diff of pages.md /
+features.md against the implementation, closed in one pass: **B2 portable
+JSON** — dashboards export a versioned portable definition (ids stripped;
+`Export JSON` on the view downloads it) and import one (`Import JSON` on
+the list validates version/name/widget types/layout and lands on the new
+dashboard); **B6** devices + countries breakdowns render (the summary
+generated both, unrendered); **B5 logs-in-span** — the span drawer's logs
+tab carries the trace-correlated lines (a controller fetches the trace
+window and keeps `trace_id` matches; per-span filtering by service + a
+±1.5s window matching the stream's correlation skew); **B9
+declare-from-alert** — active rows in the monitors Triggered feed open the
+declare-incident modal prefilled (title from the alert, sev mapped), via
+the extracted shared `DeclareIncidentModal`; **A1/A-footer nav anchors
+differentiated** — Features → `/#features` (the A11 feature-highlights
+band), Platform → `/#pillars`. Adjudicated Figma-parity restyles landed
+with the design-side updates: FAQItem → product radius + 4px-grid padding;
+StatusPill → 4px-grid padding. **Expanded-rail reflow ([Directive
+2026-07-19] + mobile clarification)**: with the 240px rail, every
+dashboard route reflows cleanly at 1280/1440 (e2e sweep asserts no
+document side-scroll and no element outside a scroll container, both
+widths, rail expanded); below `md` rail expansion renders as a 240px
+**overlay drawer** over a scrim — content keeps full width, the persisted
+desktop state does not apply (mobile boots collapsed), scrim/Escape/item
+selection dismiss (`e2e/navrail.spec.ts`). Known spec gap deliberately
+deferred: the A1 Features pillar-map dropdown (pending adjudication
+against the 4-text-links parity canon).
+
 Screen-state parity **[Directive 2026-07-18, carried from design.md §8.1]**:
 every data-driven screen ships default, empty, and loading states — the
 three-frame rule applies to the implementation exactly as it does to the

--- a/web/e2e/completeness.spec.ts
+++ b/web/e2e/completeness.spec.ts
@@ -1,0 +1,130 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * Demo-completeness features (PR3): portable dashboard JSON import (B2 /
+ * api.md §6), RUM devices+geo breakdowns (B6), logs-in-span (B5 span
+ * drawer), declare-incident from an alert row (B9 [Directive]), and the
+ * Features/Platform nav-anchor differentiation.
+ */
+
+test.beforeEach(async ({ request }) => {
+  await request.post("/api/mock/v1/reset");
+});
+
+const PORTABLE = JSON.stringify({
+  version: 1,
+  name: "Imported — golden signals",
+  template_vars: { env: ["prod"] },
+  widgets: [
+    {
+      type: "timeseries",
+      title: "p95 latency (imported)",
+      query_string: "metric:http.request.duration_ms | p95()",
+      viz_options: { display: "line" },
+      layout: { x: 0, y: 0, w: 8, h: 3 },
+    },
+    {
+      type: "query_value",
+      title: "req/s (imported)",
+      query_string: "metric:http.requests_total | rate()",
+      viz_options: { precision: 0 },
+      layout: { x: 8, y: 0, w: 4, h: 3 },
+    },
+  ],
+});
+
+test("dashboards: import a portable JSON definition → lands on the new dashboard", async ({
+  page,
+}) => {
+  await page.goto("/dashboard/dashboards");
+  await page.getByTestId("import-dashboard").click();
+  await page.getByTestId("import-json").fill(PORTABLE);
+  await page.getByTestId("confirm-import").click();
+  await page.waitForURL("**/dashboard/dashboards/dash*");
+  await expect(page.getByRole("heading", { name: "Imported — golden signals" })).toBeVisible();
+  await expect(page.getByText("p95 latency (imported)")).toBeVisible();
+  // the imported definition carries its template vars
+  await expect(page.getByRole("combobox", { name: "$env" })).toBeVisible();
+  // and the view exposes the matching export affordance
+  await expect(page.getByTestId("export-dashboard")).toBeVisible();
+});
+
+test("dashboards: malformed import errors readably, nothing created", async ({ page }) => {
+  await page.goto("/dashboard/dashboards");
+  await page.getByTestId("import-dashboard").click();
+  await page.getByTestId("import-json").fill('{"version": 3}');
+  await page.getByTestId("confirm-import").click();
+  await expect(page.getByRole("alert")).toHaveText(/unsupported version/);
+});
+
+test("RUM: devices and countries breakdowns render (B6)", async ({ page }) => {
+  await page.goto("/dashboard/rum");
+  await expect(page.getByRole("heading", { name: "Devices" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Countries" })).toBeVisible();
+  // cookieless geo = coarse country codes from the seeded summary
+  await expect(page.getByText("desktop")).toBeVisible();
+  await expect(page.getByText("NG", { exact: true })).toBeVisible();
+});
+
+test("traces: the hero span's logs-in-span tab carries correlated lines (B5)", async ({
+  page,
+}) => {
+  await page.goto("/dashboard/traces/explorer");
+  // the hero trace is the seeded POST /v1/events run; selecting it fires
+  // the correlated-logs fetch — wait for it before reading tab counts
+  const logsLanded = page.waitForResponse((r) => r.url().includes("/api/mock/v1/logs"));
+  await page.getByTestId(/^trace-9f86d081/).click();
+  await expect(page.getByTestId("trace-waterfall")).toBeVisible();
+  await logsLanded;
+  // walk the spans until one's window holds correlated lines (which span
+  // catches them depends on the deterministic-but-seed-relative stream)
+  const spanRows = page.getByRole("list", { name: "Trace spans" }).getByRole("button");
+  const drawer = page.locator('aside[aria-label^="Span "]');
+  const count = await spanRows.count();
+  let found = false;
+  for (let i = 0; i < count && !found; i++) {
+    await spanRows.nth(i).click();
+    await expect(drawer).toBeVisible();
+    const label = await drawer.getByRole("tab", { name: /logs/ }).textContent();
+    found = label !== null && !label.includes("logs (0)");
+  }
+  expect(found, "some hero span should carry correlated log lines").toBe(true);
+  await drawer.getByRole("tab", { name: /logs/ }).click();
+  await expect(drawer.getByText("No logs within this span.")).toHaveCount(0);
+  // correlated line(s) render as LogLine rows (level chip + mono message)
+  await expect(drawer.getByText(/INFO|DEBUG|WARN|ERROR|TRACE/).first()).toBeVisible();
+});
+
+test("monitors: an active alert row opens declare-incident prefilled (B9)", async ({ page }) => {
+  await page.goto("/dashboard/monitors");
+  await page
+    .getByRole("list", { name: "Triggered feed" })
+    .getByRole("button")
+    .first()
+    .click();
+  const modal = page.getByRole("dialog", { name: "Declare incident" });
+  await expect(modal).toBeVisible();
+  // prefilled from the alert (sev1 checkout p95 breach is the newest row)
+  await expect(modal.getByTestId("incident-title")).toHaveValue(/Checkout p95 latency/);
+  await modal.getByRole("combobox", { name: "Commander" }).click();
+  await page.getByRole("option", { name: "Kemi" }).click();
+  await modal.getByTestId("confirm-declare").click();
+  await page.waitForURL("**/dashboard/incidents/inc*");
+  await expect(page.getByText(/Checkout p95 latency/).first()).toBeVisible();
+});
+
+test("nav: Features and Platform anchor different landing sections", async ({ page }) => {
+  await page.goto("/");
+  const nav = page.getByRole("navigation", { name: "Marketing" });
+  await expect(nav.getByRole("link", { name: "Features" })).toHaveAttribute(
+    "href",
+    "/#features",
+  );
+  await expect(nav.getByRole("link", { name: "Platform" })).toHaveAttribute(
+    "href",
+    "/#pillars",
+  );
+  // both anchors exist on the page
+  await expect(page.locator("#features")).toHaveCount(1);
+  await expect(page.locator("#pillars")).toHaveCount(1);
+});

--- a/web/e2e/completeness.spec.ts
+++ b/web/e2e/completeness.spec.ts
@@ -128,3 +128,20 @@ test("nav: Features and Platform anchor different landing sections", async ({ pa
   await expect(page.locator("#features")).toHaveCount(1);
   await expect(page.locator("#pillars")).toHaveCount(1);
 });
+
+test("logs: j/k walk the log lines with focus; Enter expands (§5)", async ({ page }) => {
+  await page.goto("/dashboard/logs");
+  // live tail is off by default (?live=1 enables it) — the row window is
+  // the static base query, so focus targets stay stable
+  const lines = page.getByRole("list", { name: "Log lines" }).locator("button[aria-expanded]");
+  await expect(lines.first()).toBeVisible({ timeout: 15_000 });
+  await page.getByRole("heading", { name: "Logs" }).click(); // ensure no input has focus
+  await page.keyboard.press("j");
+  await expect(lines.first()).toBeFocused();
+  await page.keyboard.press("j");
+  await expect(lines.nth(1)).toBeFocused();
+  await page.keyboard.press("k");
+  await expect(lines.first()).toBeFocused();
+  await page.keyboard.press("Enter");
+  await expect(lines.first()).toHaveAttribute("aria-expanded", "true");
+});

--- a/web/e2e/home.spec.ts
+++ b/web/e2e/home.spec.ts
@@ -84,7 +84,7 @@ test("nav + footer carry the canonical parity links (SKILL.md canon)", async ({ 
 
   const nav = page.getByRole("navigation", { name: "Marketing" });
   for (const [label, href] of [
-    ["Features", "/#pillars"],
+    ["Features", "/#features"], // differentiated 2026-07-19
     ["Platform", "/#pillars"],
     ["Docs", "https://cuesoft.gitbook.io/upstat"],
     // the GitHub item renders as the star badge (canon revision 2026-07-19)
@@ -101,7 +101,7 @@ test("nav + footer carry the canonical parity links (SKILL.md canon)", async ({ 
     [
       "Product",
       [
-        ["Features", "/#pillars"],
+        ["Features", "/#features"], // differentiated 2026-07-19
         ["Try Cloud", "/signin"],
         ["Self Host", "/#self-host"],
         ["Platform", "/#pillars"],
@@ -319,7 +319,7 @@ test("mobile nav is a menu-button disclosure at 390w (SKILL.md mobile clause)", 
 
   // every canonical link is reachable from the panel — no dead ends <md
   for (const [label, href] of [
-    ["Features", "/#pillars"],
+    ["Features", "/#features"], // differentiated 2026-07-19
     ["Platform", "/#pillars"],
     ["Docs", "https://cuesoft.gitbook.io/upstat"],
     // the GitHub item renders as the star badge (canon revision 2026-07-19)

--- a/web/e2e/mobile-responsive.spec.ts
+++ b/web/e2e/mobile-responsive.spec.ts
@@ -187,6 +187,43 @@ test("768 — sanity sweep, no route side-scrolls", async ({ page }) => {
   }
 });
 
+// [Directive 2026-07-19] with the rail EXPANDED (240px), every dashboard
+// route's content column must reflow cleanly at 1280 and 1440 — charts,
+// tables, widget grids and filter bars adapt; nothing overflows.
+test.describe("expanded rail — dashboard content reflows", () => {
+  const DASH_ROUTES = ROUTES.filter((r) => r.startsWith("/dashboard"));
+
+  for (const width of [1280, 1440]) {
+    test(`${width} sweep with the rail expanded`, async ({ page }, testInfo) => {
+      test.setTimeout(240_000);
+      await page.addInitScript(() => window.localStorage.setItem("nav.rail.expanded", "1"));
+      await page.setViewportSize({ width, height: 900 });
+      for (const route of DASH_ROUTES) {
+        await open(page, route);
+        await expect(
+          page.getByRole("navigation", { name: "Product navigation" }),
+        ).toHaveAttribute("data-expanded", "true");
+        await assertNoOverflow(page, `${route} @${width} rail-expanded`);
+      }
+      // densest layouts, both rail states, for the visual record
+      for (const route of ["/dashboard/dashboards/dash_overview", "/dashboard/logs"]) {
+        await open(page, route);
+        await page.screenshot({
+          path: testInfo.outputPath(`${slug(route)}--${width}-expanded.png`),
+        });
+        await page.getByTestId("rail-toggle").click();
+        await page.waitForTimeout(350);
+        await page.screenshot({
+          path: testInfo.outputPath(`${slug(route)}--${width}-collapsed.png`),
+        });
+        // restore for the next route (the desktop toggle persists)
+        await page.getByTestId("rail-toggle").click();
+        await page.waitForTimeout(350);
+      }
+    });
+  }
+});
+
 test("390 — span drawer opens as a full-width sheet inside the viewport", async ({ page }) => {
   await page.setViewportSize(MOBILE);
   await open(page, "/dashboard/traces/explorer");

--- a/web/e2e/navrail.spec.ts
+++ b/web/e2e/navrail.spec.ts
@@ -81,6 +81,50 @@ test("dashboard chrome theme toggle flips + persists (theme-parity canon)", asyn
   await expect(html).not.toHaveAttribute("data-theme", "light");
 });
 
+test("below md, expansion is an overlay drawer — content never squeezes ([Clarified 2026-07-19])", async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  // desktop-persisted expansion must NOT apply below md — boots collapsed
+  await page.addInitScript(() => window.localStorage.setItem("nav.rail.expanded", "1"));
+  await signIn(page);
+  await expect(rail(page)).toHaveAttribute("data-expanded", "false");
+  await expect
+    .poll(async () => Math.round((await rail(page).boundingBox())!.width))
+    .toBe(56);
+  const contentWidth = async () =>
+    Math.round((await page.locator("main").boundingBox())!.width);
+  const before = await contentWidth();
+
+  // toggle opens the overlay drawer; the content keeps full width beneath
+  await page.getByTestId("rail-toggle").click();
+  const drawer = page.getByTestId("rail-drawer");
+  await expect(drawer).toBeVisible();
+  const box = (await drawer.boundingBox())!;
+  expect(Math.round(box.width)).toBe(240);
+  expect(await contentWidth()).toBe(before);
+  await expect(page.getByTestId("rail-scrim")).toBeVisible();
+
+  // scrim tap closes (tap right of the 240px drawer — the drawer overlaps
+  // the scrim's center point)
+  await page.getByTestId("rail-scrim").click({ position: { x: 370, y: 420 } });
+  await expect(drawer).toBeHidden();
+  await expect(rail(page)).toHaveAttribute("data-expanded", "false");
+
+  // Escape closes too
+  await page.getByTestId("rail-toggle").click();
+  await expect(drawer).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(drawer).toBeHidden();
+
+  // selecting a pillar navigates AND closes the drawer
+  await page.getByTestId("rail-toggle").click();
+  await drawer.getByRole("button", { name: "Logs", exact: true }).click();
+  await page.waitForURL("**/dashboard/logs");
+  await expect(drawer).toBeHidden();
+
+  // the transient drawer never rewrites the persisted desktop choice
+  expect(await page.evaluate(() => window.localStorage.getItem("nav.rail.expanded"))).toBe("1");
+});
+
 test("navigation works at both rail widths (charts unaffected)", async ({ page }) => {
   await page.setViewportSize({ width: 1440, height: 900 });
   await signIn(page);

--- a/web/src/app/dashboard/dashboards/[id]/page.tsx
+++ b/web/src/app/dashboard/dashboards/[id]/page.tsx
@@ -10,7 +10,7 @@ import { Skeleton } from "@/components/ui/Skeleton";
 import { WidgetShell, type WidgetShellMode } from "@/components/ui/WidgetShell";
 import { WidgetTypePicker } from "@/components/ui/WidgetTypePicker";
 import type { Widget, WidgetLayout, WidgetType } from "@/models";
-import { useDashboardController } from "@/controllers/dashboards";
+import { dashboardToPortableJson, useDashboardController } from "@/controllers/dashboards";
 import { defaultWidget, substituteVars } from "@/controllers/widgets";
 import { useMediaQuery } from "@/controllers/use-media-query";
 import { useTimeRange } from "@/controllers/time-range";
@@ -156,6 +156,24 @@ export default function DashboardViewPage() {
               + Add widget
             </Button>
           )}
+          {/* B2 portable JSON export (api.md §6) — downloads the definition */}
+          <Button
+            kind="quiet"
+            data-testid="export-dashboard"
+            onClick={() => {
+              const blob = new Blob([dashboardToPortableJson(dashboard)], {
+                type: "application/json",
+              });
+              const url = URL.createObjectURL(blob);
+              const a = document.createElement("a");
+              a.href = url;
+              a.download = `${dashboard.name.toLowerCase().replace(/\s+/g, "-")}.dashboard.json`;
+              a.click();
+              URL.revokeObjectURL(url);
+            }}
+          >
+            Export JSON
+          </Button>
           <Button
             kind={ctrl.editMode ? "brand" : "quiet"}
             onClick={() => ctrl.setEditMode(!ctrl.editMode)}

--- a/web/src/app/dashboard/dashboards/[id]/page.tsx
+++ b/web/src/app/dashboard/dashboards/[id]/page.tsx
@@ -104,7 +104,9 @@ export default function DashboardViewPage() {
             : {
                 ...d.origin,
                 w: Math.max(2, Math.min(COLS - d.origin.x, d.origin.w + dCol)),
-                h: Math.max(1, d.origin.h + dRow),
+                // 1..24 — matches the portable-JSON import bound, so any
+                // editable layout stays exportable→importable (PR 168 r4)
+                h: Math.min(24, Math.max(1, d.origin.h + dRow)),
               };
         return { ...d, preview };
       });

--- a/web/src/app/dashboard/dashboards/[id]/widget-body.tsx
+++ b/web/src/app/dashboard/dashboards/[id]/widget-body.tsx
@@ -177,7 +177,9 @@ export function WidgetBody({
       );
     }
     case "markdown": {
-      const text = (widget.viz_options.text as string) ?? "";
+      // typeof guard, not a cast: a non-string value would render as a
+      // React child and throw (defense in depth behind the import parser)
+      const text = typeof widget.viz_options.text === "string" ? widget.viz_options.text : "";
       return (
         <article className="whitespace-pre-wrap text-[13px] leading-[1.45] text-text-2">
           {text}

--- a/web/src/app/dashboard/dashboards/page.tsx
+++ b/web/src/app/dashboard/dashboards/page.tsx
@@ -19,12 +19,29 @@ import { defaultWidget } from "@/controllers/widgets";
  */
 export default function DashboardsPage() {
   const router = useRouter();
-  const { data, loading, create, toggleFavorite } = useDashboardsController();
+  const { data, loading, create, toggleFavorite, importJson } = useDashboardsController();
   const [createOpen, setCreateOpen] = useState(false);
   const [name, setName] = useState("");
   const [type, setType] = useState<WidgetType | null>("timeseries");
   const [creating, setCreating] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // B2 portable JSON import (api.md §6)
+  const [importOpen, setImportOpen] = useState(false);
+  const [importText, setImportText] = useState("");
+  const [importing, setImporting] = useState(false);
+  const [importError, setImportError] = useState<string | null>(null);
+
+  const submitImport = async () => {
+    setImporting(true);
+    setImportError(null);
+    try {
+      const dashboard = await importJson(importText);
+      router.push(`/dashboard/dashboards/${dashboard.id}`);
+    } catch (e) {
+      setImportError(e instanceof Error ? e.message : "could not import the dashboard");
+      setImporting(false);
+    }
+  };
 
   const submit = async () => {
     if (!name.trim()) return;
@@ -41,11 +58,16 @@ export default function DashboardsPage() {
 
   return (
     <div className="flex flex-col gap-6 px-6 py-5" data-testid="dashboards-list">
-      <header className="flex items-center justify-between">
+      <header className="flex flex-wrap items-center justify-between gap-2">
         <h1 className="text-[20px] font-semibold">Dashboards</h1>
-        <Button onClick={() => setCreateOpen(true)} data-testid="new-dashboard">
-          New dashboard
-        </Button>
+        <div className="flex items-center gap-2">
+          <Button kind="quiet" onClick={() => setImportOpen(true)} data-testid="import-dashboard">
+            Import JSON
+          </Button>
+          <Button onClick={() => setCreateOpen(true)} data-testid="new-dashboard">
+            New dashboard
+          </Button>
+        </div>
       </header>
 
       {loading ? (
@@ -123,6 +145,48 @@ export default function DashboardsPage() {
               {error}
             </p>
           )}
+        </div>
+      </Modal>
+
+      {/* B2 portable JSON import (api.md §6) */}
+      <Modal
+        open={importOpen}
+        onClose={() => setImportOpen(false)}
+        title="Import dashboard JSON"
+        variant="lg"
+        footer={
+          <>
+            <Button kind="quiet" onClick={() => setImportOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              onClick={() => void submitImport()}
+              disabled={importing || importText.trim() === ""}
+              data-testid="confirm-import"
+            >
+              {importing ? "Importing…" : "Import"}
+            </Button>
+          </>
+        }
+      >
+        <div className="flex flex-col gap-3">
+          <label className="flex flex-col gap-1 text-[13px]">
+            <span className="text-text-2">
+              Paste a portable dashboard definition (the Export JSON output)
+            </span>
+            <textarea
+              value={importText}
+              onChange={(e) => setImportText(e.target.value)}
+              rows={12}
+              spellCheck={false}
+              placeholder='{"version": 1, "name": "…", "widgets": […]}'
+              data-testid="import-json"
+              className="font-data w-full resize-y rounded-(--radius) border border-border bg-bg px-2.5 py-2 text-[12px] leading-[1.45] text-text placeholder:text-text-2 focus:outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand"
+            />
+          </label>
+          <p role="alert" className="text-[13px] text-crit">
+            {importError}
+          </p>
         </div>
       </Modal>
     </div>

--- a/web/src/app/dashboard/incidents/DeclareIncidentModal.tsx
+++ b/web/src/app/dashboard/incidents/DeclareIncidentModal.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { Button } from "@/components/ui/Button";
+import { Input } from "@/components/ui/Input";
+import { Modal } from "@/components/ui/Modal";
+import { Select } from "@/components/ui/Select";
+import { useIncidentsController } from "@/controllers/incidents";
+import { useSettingsController } from "@/controllers/settings";
+
+export interface DeclareIncidentModalProps {
+  open: boolean;
+  onClose: () => void;
+  /** Prefill for the from-an-alert path (pages.md B9 [Directive]). */
+  initialTitle?: string;
+  initialSev?: string;
+}
+
+/**
+ * Declare-incident modal (Figma 173:5805; pages.md B9 [Directive]) —
+ * reachable from an alert row (prefilled) or manually: sev picker · title
+ * · commander assignment; declaring lands on the incident timeline.
+ */
+export function DeclareIncidentModal({
+  open,
+  onClose,
+  initialTitle = "",
+  initialSev = "1",
+}: DeclareIncidentModalProps) {
+  const router = useRouter();
+  const { declare } = useIncidentsController();
+  const { members } = useSettingsController();
+  const [title, setTitle] = useState(initialTitle);
+  const [sev, setSev] = useState(initialSev);
+  const [commander, setCommander] = useState<string | null>(null);
+  const [declaring, setDeclaring] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // reset per-open (render-phase derive-state pattern; the prefill from a
+  // different alert row must replace stale fields)
+  const openKey = open ? `${initialTitle}|${initialSev}` : "closed";
+  const [lastKey, setLastKey] = useState(openKey);
+  if (lastKey !== openKey) {
+    setLastKey(openKey);
+    if (open) {
+      setTitle(initialTitle);
+      setSev(initialSev);
+      setCommander(null);
+      setError(null);
+    }
+  }
+
+  const submit = async () => {
+    if (!title.trim() || !commander) {
+      setError("Give the incident a title and a commander.");
+      return;
+    }
+    setDeclaring(true);
+    setError(null);
+    try {
+      const incident = await declare({ title: title.trim(), sev: Number(sev), commander });
+      router.push(`/dashboard/incidents/${incident.id}`);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not declare the incident.");
+      setDeclaring(false);
+    }
+  };
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      title="Declare incident"
+      footer={
+        <>
+          <Button kind="quiet" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            kind="destructive"
+            onClick={() => void submit()}
+            disabled={declaring}
+            data-testid="confirm-declare"
+          >
+            {declaring ? "Declaring…" : "Declare"}
+          </Button>
+        </>
+      }
+    >
+      <div className="flex flex-col gap-4">
+        <label className="flex flex-col gap-1 text-[13px]">
+          <span className="text-text-2">Title</span>
+          <Input
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="Elevated error rate on /v1/events"
+            data-testid="incident-title"
+          />
+        </label>
+        <div className="grid grid-cols-2 gap-3">
+          <label className="flex flex-col gap-1 text-[13px]">
+            <span className="text-text-2">Severity</span>
+            <Select
+              options={["1", "2", "3", "4"].map((s) => ({ value: s, label: `SEV-${s}` }))}
+              value={sev}
+              onValueChange={setSev}
+              aria-label="Severity"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-[13px]">
+            <span className="text-text-2">Commander</span>
+            <Select
+              options={(members.data ?? [])
+                .filter((m) => m.status === "active")
+                .map((m) => ({ value: m.name, label: m.name }))}
+              value={commander}
+              onValueChange={setCommander}
+              placeholder="assign…"
+              aria-label="Commander"
+            />
+          </label>
+        </div>
+        {error && (
+          <p role="alert" className="text-[13px] text-crit">
+            {error}
+          </p>
+        )}
+      </div>
+    </Modal>
+  );
+}

--- a/web/src/app/dashboard/incidents/page.tsx
+++ b/web/src/app/dashboard/incidents/page.tsx
@@ -3,14 +3,11 @@
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { Button } from "@/components/ui/Button";
-import { Input } from "@/components/ui/Input";
-import { Modal } from "@/components/ui/Modal";
-import { Select } from "@/components/ui/Select";
 import { SevChip, type Sev } from "@/components/ui/SevChip";
 import { Skeleton } from "@/components/ui/Skeleton";
 import { ageLabel } from "@/controllers/shell";
 import { useIncidentsController } from "@/controllers/incidents";
-import { useSettingsController } from "@/controllers/settings";
+import { DeclareIncidentModal } from "./DeclareIncidentModal";
 
 /**
  * B9 incident feed (Figma 131:2901) + declare-incident modal (173:5805):
@@ -19,30 +16,8 @@ import { useSettingsController } from "@/controllers/settings";
  */
 export default function IncidentsPage() {
   const router = useRouter();
-  const { data, loading, declare } = useIncidentsController();
-  const { members } = useSettingsController();
+  const { data, loading } = useIncidentsController();
   const [declareOpen, setDeclareOpen] = useState(false);
-  const [title, setTitle] = useState("");
-  const [sev, setSev] = useState("1");
-  const [commander, setCommander] = useState<string | null>(null);
-  const [declaring, setDeclaring] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  const submit = async () => {
-    if (!title.trim() || !commander) {
-      setError("Give the incident a title and a commander.");
-      return;
-    }
-    setDeclaring(true);
-    setError(null);
-    try {
-      const incident = await declare({ title: title.trim(), sev: Number(sev), commander });
-      router.push(`/dashboard/incidents/${incident.id}`);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Could not declare the incident.");
-      setDeclaring(false);
-    }
-  };
 
   return (
     <div data-testid="incidents" className="flex flex-col gap-6 px-6 py-5">
@@ -99,66 +74,7 @@ export default function IncidentsPage() {
         </ul>
       )}
 
-      <Modal
-        open={declareOpen}
-        onClose={() => setDeclareOpen(false)}
-        title="Declare incident"
-        footer={
-          <>
-            <Button kind="quiet" onClick={() => setDeclareOpen(false)}>
-              Cancel
-            </Button>
-            <Button
-              kind="destructive"
-              onClick={() => void submit()}
-              disabled={declaring}
-              data-testid="confirm-declare"
-            >
-              {declaring ? "Declaring…" : "Declare"}
-            </Button>
-          </>
-        }
-      >
-        <div className="flex flex-col gap-4">
-          <label className="flex flex-col gap-1 text-[13px]">
-            <span className="text-text-2">Title</span>
-            <Input
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
-              placeholder="Elevated error rate on /v1/events"
-              data-testid="incident-title"
-            />
-          </label>
-          <div className="grid grid-cols-2 gap-3">
-            <label className="flex flex-col gap-1 text-[13px]">
-              <span className="text-text-2">Severity</span>
-              <Select
-                options={["1", "2", "3", "4"].map((s) => ({ value: s, label: `SEV-${s}` }))}
-                value={sev}
-                onValueChange={setSev}
-                aria-label="Severity"
-              />
-            </label>
-            <label className="flex flex-col gap-1 text-[13px]">
-              <span className="text-text-2">Commander</span>
-              <Select
-                options={(members.data ?? [])
-                  .filter((m) => m.status === "active")
-                  .map((m) => ({ value: m.name, label: m.name }))}
-                value={commander}
-                onValueChange={setCommander}
-                placeholder="assign…"
-                aria-label="Commander"
-              />
-            </label>
-          </div>
-          {error && (
-            <p role="alert" className="text-[13px] text-crit">
-              {error}
-            </p>
-          )}
-        </div>
-      </Modal>
+      <DeclareIncidentModal open={declareOpen} onClose={() => setDeclareOpen(false)} />
     </div>
   );
 }

--- a/web/src/app/dashboard/logs/page.tsx
+++ b/web/src/app/dashboard/logs/page.tsx
@@ -9,7 +9,7 @@ import { LogLine } from "@/components/ui/LogLine";
 import { QueryBar } from "@/components/ui/QueryBar";
 import { SavedViewChip } from "@/components/ui/SavedViewChip";
 import { Skeleton } from "@/components/ui/Skeleton";
-import { useLogsExplorerController } from "@/controllers/logs";
+import { useLogLineKeys, useLogsExplorerController } from "@/controllers/logs";
 
 /**
  * B4 logs explorer (Figma 128:1236) — FacetSidebar + QueryBar + LogLine
@@ -19,6 +19,8 @@ import { useLogsExplorerController } from "@/controllers/logs";
 export default function LogsPage() {
   const ctrl = useLogsExplorerController();
   const listRef = useRef<HTMLDivElement>(null);
+  // §5: j/k walk the log lines; Enter expands (MI-17 cheatsheet rows)
+  useLogLineKeys(listRef);
 
   const facets = ctrl.base.data?.facets ?? {};
   const histogram = ctrl.base.data?.histogram ?? [];

--- a/web/src/app/dashboard/monitors/page.tsx
+++ b/web/src/app/dashboard/monitors/page.tsx
@@ -7,7 +7,9 @@ import { AlertFeedRow } from "@/components/ui/AlertFeedRow";
 import { AlertRuleCard } from "@/components/ui/AlertRuleCard";
 import { Button } from "@/components/ui/Button";
 import { Skeleton } from "@/components/ui/Skeleton";
+import type { AlertEvent } from "@/models";
 import { useAlertsController, useRuleTest } from "@/controllers/alerts";
+import { DeclareIncidentModal } from "../incidents/DeclareIncidentModal";
 import { RuleEditor, type RuleInput } from "./rule-editor";
 import { ReplayPanel } from "../replay-panel";
 
@@ -23,6 +25,8 @@ export default function MonitorsPage() {
   const [selectedId, setSelectedId] = useState<string | null>(ruleParam);
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
+  // pages.md B9 [Directive]: declare-incident reachable FROM an alert row
+  const [declareFrom, setDeclareFrom] = useState<AlertEvent | null>(null);
 
   const rules = ctrl.rules.data ?? [];
   const selected = rules.find((r) => r.id === selectedId) ?? rules[0] ?? null;
@@ -118,7 +122,14 @@ export default function MonitorsPage() {
               <ul aria-label="Triggered feed">
                 {(ctrl.feed.data ?? []).map((event) => (
                   <li key={event.id}>
-                    <AlertFeedRow event={event} />
+                    {/* clicking an active alert opens declare-incident
+                        prefilled (pages.md B9 [Directive]) */}
+                    <AlertFeedRow
+                      event={event}
+                      onClick={
+                        event.sev === "resolved" ? undefined : () => setDeclareFrom(event)
+                      }
+                    />
                   </li>
                 ))}
               </ul>
@@ -157,6 +168,13 @@ export default function MonitorsPage() {
           )}
         </section>
       </div>
+
+      <DeclareIncidentModal
+        open={declareFrom !== null}
+        onClose={() => setDeclareFrom(null)}
+        initialTitle={declareFrom ? `${declareFrom.monitor_name} — ${declareFrom.message}` : ""}
+        initialSev={declareFrom?.sev === "sev1" ? "1" : "2"}
+      />
     </div>
   );
 }

--- a/web/src/app/dashboard/rum/page.tsx
+++ b/web/src/app/dashboard/rum/page.tsx
@@ -138,6 +138,25 @@ export default function RumPage() {
             </section>
           </div>
 
+          {/* B6: devices + geo breakdowns (pages.md "top pages/referrers/
+              devices/geo" — the last two were generated but unrendered) */}
+          <div className="grid grid-cols-1 gap-5 sm:grid-cols-2">
+            <section aria-labelledby="devices-heading" className="rounded-(--radius) border border-border bg-bg-elev p-4">
+              <h2 id="devices-heading" className="mb-3 text-[13px] text-text-2">Devices</h2>
+              <TopList
+                loading={summary.loading}
+                entries={(s?.devices ?? []).map((d) => ({ label: d.value, value: d.count, display: fmtK(d.count) }))}
+              />
+            </section>
+            <section aria-labelledby="countries-heading" className="rounded-(--radius) border border-border bg-bg-elev p-4">
+              <h2 id="countries-heading" className="mb-3 text-[13px] text-text-2">Countries</h2>
+              <TopList
+                loading={summary.loading}
+                entries={(s?.countries ?? []).map((c) => ({ label: c.value, value: c.count, display: fmtK(c.count) }))}
+              />
+            </section>
+          </div>
+
           <div className="grid grid-cols-1 gap-5 xl:grid-cols-[minmax(0,1fr)_minmax(0,1.4fr)]">
             <section aria-labelledby="vitals-heading" className="rounded-(--radius) border border-border bg-bg-elev p-4">
               <h2 id="vitals-heading" className="mb-3 text-[13px] text-text-2">

--- a/web/src/app/dashboard/traces/explorer/page.tsx
+++ b/web/src/app/dashboard/traces/explorer/page.tsx
@@ -142,7 +142,13 @@ export default function TraceExplorerPage() {
                   View {selected.root_service} in service map →
                 </Link>
               </header>
-              <TraceWaterfall trace={selected} logs={traceLogs.data ?? []} />
+              {/* filter to the CURRENT trace id — useRequest retains the
+                  prior trace's data while a new fetch is in flight
+                  (PR 168 review round 2) */}
+              <TraceWaterfall
+                trace={selected}
+                logs={(traceLogs.data ?? []).filter((l) => l.trace_id === selected.trace_id)}
+              />
               <p className="font-data mt-2 text-[11px] tabular-nums text-text-2">
                 trace_id {selected.trace_id.slice(0, 16)} · {selected.span_count} spans ·{" "}
                 {fmtMs(selected.duration_ms)} total

--- a/web/src/app/dashboard/traces/explorer/page.tsx
+++ b/web/src/app/dashboard/traces/explorer/page.tsx
@@ -8,7 +8,11 @@ import { QueryBar } from "@/components/ui/QueryBar";
 import { Skeleton } from "@/components/ui/Skeleton";
 import { TraceWaterfall } from "@/components/ui/TraceWaterfall";
 import { initialQueryFromUrl, joinQuery, useQueryPills } from "@/controllers/explorer";
-import { useTraceController, useTracesController } from "@/controllers/telemetry";
+import {
+  useTraceController,
+  useTraceLogsController,
+  useTracesController,
+} from "@/controllers/telemetry";
 import { useTimeRange } from "@/controllers/time-range";
 import { PageTabs } from "../../page-tabs";
 import { apmTabs } from "../apm-tabs";
@@ -43,6 +47,8 @@ export default function TraceExplorerPage() {
   // guard the stale-data window while the detail request is in flight
   const selected =
     selectedId && trace.data && trace.data.trace_id === selectedId ? trace.data : null;
+  // logs-in-span (pages.md B5): correlated lines for the drawer's logs tab
+  const traceLogs = useTraceLogsController(selected);
 
   return (
     <div className="flex flex-col gap-4 px-6 py-5" data-testid="trace-explorer">
@@ -136,7 +142,7 @@ export default function TraceExplorerPage() {
                   View {selected.root_service} in service map →
                 </Link>
               </header>
-              <TraceWaterfall trace={selected} />
+              <TraceWaterfall trace={selected} logs={traceLogs.data ?? []} />
               <p className="font-data mt-2 text-[11px] tabular-nums text-text-2">
                 trace_id {selected.trace_id.slice(0, 16)} · {selected.span_count} spans ·{" "}
                 {fmtMs(selected.duration_ms)} total

--- a/web/src/components/home/sections-demo.tsx
+++ b/web/src/components/home/sections-demo.tsx
@@ -127,8 +127,11 @@ export function UseCasesSection({
   visitorsSparkline,
   lcpSparkline,
 }: UseCasesSectionProps) {
+  // id="features": the nav/footer Features links anchor here — the feature
+  // highlights band; Platform keeps /#pillars (differentiated 2026-07-19,
+  // the two previously shared one anchor)
   return (
-    <Section title="How teams actually use it.">
+    <Section id="features" title="How teams actually use it.">
       <div className="flex flex-col gap-16">
         {/* 1 — dashboards */}
         <div className="grid items-center gap-12 md:grid-cols-[1fr_480px]">

--- a/web/src/components/ui/FAQItem.tsx
+++ b/web/src/components/ui/FAQItem.tsx
@@ -24,7 +24,9 @@ export function FAQItem({ question, answer, expanded, onToggle, className }: FAQ
     <div
       data-expanded={expanded}
       className={clsx(
-        "font-ui w-full max-w-[720px] rounded-[8px] border border-border bg-bg-elev px-[18px] py-4",
+        // foundations restyle (adjudicated 2026-07-19): product radius +
+        // 4px-grid padding — the Figma master converges to the same values
+        "font-ui w-full max-w-[720px] rounded-(--radius) border border-border bg-bg-elev px-4 py-4",
         "flex flex-col",
         expanded && "gap-2.5",
         className,

--- a/web/src/components/ui/MarketingFooter.test.tsx
+++ b/web/src/components/ui/MarketingFooter.test.tsx
@@ -5,7 +5,7 @@ import { MarketingFooter } from "./MarketingFooter";
 /** The ratified column/link set (SKILL.md parity canon, 2026-07-19). */
 const CANON: Record<string, [string, string][]> = {
   Product: [
-    ["Features", "/#pillars"],
+    ["Features", "/#features"], // differentiated 2026-07-19
     ["Try Cloud", "/signin"],
     ["Self Host", "/#self-host"],
     ["Platform", "/#pillars"],

--- a/web/src/components/ui/MarketingFooter.tsx
+++ b/web/src/components/ui/MarketingFooter.tsx
@@ -34,7 +34,7 @@ const COLUMNS: FooterColumn[] = [
   {
     heading: "Product",
     links: [
-      { label: "Features", href: "/#pillars" },
+      { label: "Features", href: "/#features" },
       { label: "Try Cloud", href: "/signin" },
       { label: "Self Host", href: "/#self-host" },
       { label: "Platform", href: "/#pillars" },

--- a/web/src/components/ui/MarketingNav.test.tsx
+++ b/web/src/components/ui/MarketingNav.test.tsx
@@ -14,7 +14,8 @@ describe("MarketingNav (parity canon, SKILL.md 2026-07-19, revised same day)", (
   it("renders the four canonical links with the ratified hrefs", () => {
     renderNav();
     expect(NAV_LINKS.map((l) => l.label)).toEqual(["Features", "Platform", "Docs", "GitHub"]);
-    expect(screen.getByRole("link", { name: "Features" })).toHaveAttribute("href", "/#pillars");
+    // differentiated 2026-07-19: Features → the feature-highlights band
+    expect(screen.getByRole("link", { name: "Features" })).toHaveAttribute("href", "/#features");
     expect(screen.getByRole("link", { name: "Platform" })).toHaveAttribute("href", "/#pillars");
     expect(screen.getByRole("link", { name: "Docs" })).toHaveAttribute(
       "href",

--- a/web/src/components/ui/MarketingNav.tsx
+++ b/web/src/components/ui/MarketingNav.tsx
@@ -15,9 +15,13 @@ export interface MarketingNavProps {
   className?: string;
 }
 
-/** The canonical nav links (SKILL.md nav-parity canon, 2026-07-19). */
+/**
+ * The canonical nav links (SKILL.md nav-parity canon, 2026-07-19).
+ * Features anchors the feature-highlights band; Platform anchors the
+ * 8-pillar grid — differentiated 2026-07-19 (both previously /#pillars).
+ */
 export const NAV_LINKS = [
-  { label: "Features", href: "/#pillars", external: false },
+  { label: "Features", href: "/#features", external: false },
   { label: "Platform", href: "/#pillars", external: false },
   { label: "Docs", href: "https://cuesoft.gitbook.io/upstat", external: true },
   { label: "GitHub", href: "https://github.com/cuesoftinc/upstat", external: true },

--- a/web/src/components/ui/NavRail.tsx
+++ b/web/src/components/ui/NavRail.tsx
@@ -289,22 +289,28 @@ export function NavRail({ activeKey, onNavigate, className }: NavRailProps) {
   const inlineExpanded = expanded && !isMobile;
   const open = isMobile && drawerOpen;
 
-  // Escape closes the drawer; focus returns to the foot toggle
+  // every dismissal path returns focus to the foot toggle (PR #168
+  // review — only Escape restored it before)
+  const closeDrawer = () => {
+    setDrawerOpen(false);
+    railRef.current?.querySelector<HTMLElement>("[data-testid=rail-toggle]")?.focus();
+  };
+
+  // Escape closes the drawer; focus moves in on open
   useEffect(() => {
     if (!open) return;
     drawerRef.current?.focus();
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        setDrawerOpen(false);
-        railRef.current?.querySelector<HTMLElement>("[data-testid=rail-toggle]")?.focus();
-      }
+      if (e.key === "Escape") closeDrawer();
     };
     document.addEventListener("keydown", onKey);
     return () => document.removeEventListener("keydown", onKey);
+    // closeDrawer is stable in behavior (setState + ref read)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open]);
 
   const select = (key: string) => {
-    setDrawerOpen(false);
+    closeDrawer();
     onNavigate?.(key);
   };
 
@@ -338,7 +344,7 @@ export function NavRail({ activeKey, onNavigate, className }: NavRailProps) {
           <div
             role="presentation"
             data-testid="rail-scrim"
-            onClick={() => setDrawerOpen(false)}
+            onClick={closeDrawer}
             className="fixed inset-0 z-[var(--z-overlay)] bg-bg/70 md:hidden"
           />
           <nav
@@ -359,7 +365,7 @@ export function NavRail({ activeKey, onNavigate, className }: NavRailProps) {
               footLabel="Close navigation"
               footTestId="rail-drawer-close"
               footExpanded
-              onToggle={() => setDrawerOpen(false)}
+              onToggle={closeDrawer}
             />
           </nav>
         </>

--- a/web/src/components/ui/NavRail.tsx
+++ b/web/src/components/ui/NavRail.tsx
@@ -18,7 +18,8 @@ import {
   Settings,
   Target,
 } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import { useMediaQuery } from "@/controllers/use-media-query";
 
 export interface NavRailItemProps {
   icon: LucideIcon;
@@ -171,28 +172,28 @@ export interface NavRailProps {
   className?: string;
 }
 
-/**
- * NavRail — product nav (design.md §2, [Directive 2026-07-19] expandable
- * rail supersedes flyout-only): collapsed 56px icon rail ⇄ expanded 240px
- * icon+label rows in Telemetry/Respond/Platform groups. Foot chevron
- * toggles; the choice persists (`nav.rail.expanded`); expanded is the
- * ≥1280px default.
- */
-export function NavRail({ activeKey, onNavigate, className }: NavRailProps) {
-  const [expanded, toggleExpanded] = useRailExpanded();
+/** Rail brand mark + section groups + foot toggle (shared by the inline
+ *  rail and the <md overlay drawer). */
+function RailBody({
+  expanded,
+  activeKey,
+  onSelect,
+  footLabel,
+  footExpanded,
+  footTestId = "rail-toggle",
+  onToggle,
+}: {
+  expanded: boolean;
+  activeKey: string;
+  onSelect: (key: string) => void;
+  footLabel: string;
+  footExpanded: boolean;
+  footTestId?: string;
+  onToggle: () => void;
+}) {
   const byKey = new Map(NAV_PILLARS.map((p) => [p.key, p]));
   return (
-    <nav
-      aria-label="Product navigation"
-      data-expanded={expanded}
-      className={clsx(
-        "sticky top-0 z-[var(--z-sticky)] flex h-dvh flex-col gap-1",
-        "border-r border-border bg-bg py-2",
-        "transition-[width] duration-[var(--duration-base)] ease-standard motion-reduce:transition-none",
-        expanded ? "w-60 items-stretch px-1.5" : "w-14 items-center",
-        className,
-      )}
-    >
+    <>
       <span
         aria-hidden="true"
         className={clsx(
@@ -231,7 +232,7 @@ export function NavRail({ activeKey, onNavigate, className }: NavRailProps) {
                 label={pillar.label}
                 active={pillar.key === activeKey}
                 expanded={expanded}
-                onClick={() => onNavigate?.(pillar.key)}
+                onClick={() => onSelect(pillar.key)}
               />
             );
           })}
@@ -240,10 +241,10 @@ export function NavRail({ activeKey, onNavigate, className }: NavRailProps) {
 
       <button
         type="button"
-        data-testid="rail-toggle"
-        aria-label={expanded ? "Collapse navigation" : "Expand navigation"}
-        aria-expanded={expanded}
-        onClick={toggleExpanded}
+        data-testid={footTestId}
+        aria-label={footLabel}
+        aria-expanded={footExpanded}
+        onClick={onToggle}
         className={clsx(
           "mt-auto flex h-9 items-center rounded-(--radius) text-text-2",
           "transition-colors duration-[var(--duration-fast)] ease-standard hover:bg-bg-elev hover:text-text",
@@ -259,6 +260,110 @@ export function NavRail({ activeKey, onNavigate, className }: NavRailProps) {
           <ChevronsRight aria-hidden="true" className="size-4.5" />
         )}
       </button>
-    </nav>
+    </>
+  );
+}
+
+/**
+ * NavRail — product nav (design.md §2, [Directive 2026-07-19] expandable
+ * rail supersedes flyout-only): collapsed 56px icon rail ⇄ expanded 240px
+ * icon+label rows in Telemetry/Respond/Platform groups. Foot chevron
+ * toggles; the choice persists (`nav.rail.expanded`); expanded is the
+ * ≥1280px default.
+ *
+ * Below `md` ([Clarified 2026-07-19]) expansion must never squeeze the
+ * content: the persisted state does not apply (mobile always boots the
+ * 56px rail) and the foot chevron opens a 240px OVERLAY DRAWER over a
+ * scrim instead — content keeps full width beneath; scrim tap, Escape,
+ * and item selection close it; focus moves into the drawer and returns
+ * to the toggle on close.
+ */
+export function NavRail({ activeKey, onNavigate, className }: NavRailProps) {
+  const [expanded, toggleExpanded] = useRailExpanded();
+  const isMobile = useMediaQuery("(max-width: 767px)");
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const drawerRef = useRef<HTMLElement>(null);
+  const railRef = useRef<HTMLElement>(null);
+
+  // the inline rail never expands below md — the drawer takes over
+  const inlineExpanded = expanded && !isMobile;
+  const open = isMobile && drawerOpen;
+
+  // Escape closes the drawer; focus returns to the foot toggle
+  useEffect(() => {
+    if (!open) return;
+    drawerRef.current?.focus();
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setDrawerOpen(false);
+        railRef.current?.querySelector<HTMLElement>("[data-testid=rail-toggle]")?.focus();
+      }
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open]);
+
+  const select = (key: string) => {
+    setDrawerOpen(false);
+    onNavigate?.(key);
+  };
+
+  return (
+    <>
+      <nav
+        ref={railRef}
+        aria-label="Product navigation"
+        data-expanded={inlineExpanded}
+        className={clsx(
+          "sticky top-0 z-[var(--z-sticky)] flex h-dvh flex-col gap-1",
+          "border-r border-border bg-bg py-2",
+          "transition-[width] duration-[var(--duration-base)] ease-standard motion-reduce:transition-none",
+          inlineExpanded ? "w-60 items-stretch px-1.5" : "w-14 items-center",
+          className,
+        )}
+      >
+        <RailBody
+          expanded={inlineExpanded}
+          activeKey={activeKey}
+          onSelect={(key) => onNavigate?.(key)}
+          footLabel={inlineExpanded ? "Collapse navigation" : "Expand navigation"}
+          footExpanded={isMobile ? drawerOpen : inlineExpanded}
+          onToggle={() => (isMobile ? setDrawerOpen(true) : toggleExpanded())}
+        />
+      </nav>
+
+      {open && (
+        <>
+          {/* scrim — tap closes; content keeps full width beneath */}
+          <div
+            role="presentation"
+            data-testid="rail-scrim"
+            onClick={() => setDrawerOpen(false)}
+            className="fixed inset-0 z-[var(--z-overlay)] bg-bg/70 md:hidden"
+          />
+          <nav
+            ref={drawerRef}
+            tabIndex={-1}
+            aria-label="Product navigation drawer"
+            data-testid="rail-drawer"
+            className={clsx(
+              "fixed inset-y-0 left-0 z-[var(--z-modal)] flex w-60 flex-col gap-1 outline-none",
+              "border-r border-border bg-bg px-1.5 py-2 shadow-xl md:hidden",
+              "animate-[slide-in_var(--duration-entrance)_var(--ease-standard)] motion-reduce:animate-none",
+            )}
+          >
+            <RailBody
+              expanded
+              activeKey={activeKey}
+              onSelect={select}
+              footLabel="Close navigation"
+              footTestId="rail-drawer-close"
+              footExpanded
+              onToggle={() => setDrawerOpen(false)}
+            />
+          </nav>
+        </>
+      )}
+    </>
   );
 }

--- a/web/src/components/ui/NavRail.tsx
+++ b/web/src/components/ui/NavRail.tsx
@@ -18,7 +18,8 @@ import {
   Settings,
   Target,
 } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import * as Dialog from "@radix-ui/react-dialog";
+import { useEffect, useState } from "react";
 import { useMediaQuery } from "@/controllers/use-media-query";
 
 export interface NavRailItemProps {
@@ -282,42 +283,19 @@ export function NavRail({ activeKey, onNavigate, className }: NavRailProps) {
   const [expanded, toggleExpanded] = useRailExpanded();
   const isMobile = useMediaQuery("(max-width: 767px)");
   const [drawerOpen, setDrawerOpen] = useState(false);
-  const drawerRef = useRef<HTMLElement>(null);
-  const railRef = useRef<HTMLElement>(null);
 
   // the inline rail never expands below md — the drawer takes over
   const inlineExpanded = expanded && !isMobile;
   const open = isMobile && drawerOpen;
 
-  // every dismissal path returns focus to the foot toggle (PR #168
-  // review — only Escape restored it before)
-  const closeDrawer = () => {
-    setDrawerOpen(false);
-    railRef.current?.querySelector<HTMLElement>("[data-testid=rail-toggle]")?.focus();
-  };
-
-  // Escape closes the drawer; focus moves in on open
-  useEffect(() => {
-    if (!open) return;
-    drawerRef.current?.focus();
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") closeDrawer();
-    };
-    document.addEventListener("keydown", onKey);
-    return () => document.removeEventListener("keydown", onKey);
-    // closeDrawer is stable in behavior (setState + ref read)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open]);
-
   const select = (key: string) => {
-    closeDrawer();
+    setDrawerOpen(false);
     onNavigate?.(key);
   };
 
   return (
     <>
       <nav
-        ref={railRef}
         aria-label="Product navigation"
         data-expanded={inlineExpanded}
         className={clsx(
@@ -338,19 +316,19 @@ export function NavRail({ activeKey, onNavigate, className }: NavRailProps) {
         />
       </nav>
 
-      {open && (
-        <>
-          {/* scrim — tap closes; content keeps full width beneath */}
-          <div
-            role="presentation"
+      {/* Radix Dialog (PR 168 review round 4): modal semantics give the
+          drawer a real focus trap + inert background; Escape and
+          overlay-tap dismissal and focus restoration to the toggle come
+          with the primitive (the headless-behavior allowance, §1). */}
+      <Dialog.Root open={open} onOpenChange={(next) => !next && setDrawerOpen(false)}>
+        <Dialog.Portal>
+          <Dialog.Overlay
             data-testid="rail-scrim"
-            onClick={closeDrawer}
             className="fixed inset-0 z-[var(--z-overlay)] bg-bg/70 md:hidden"
           />
-          <nav
-            ref={drawerRef}
-            tabIndex={-1}
+          <Dialog.Content
             aria-label="Product navigation drawer"
+            aria-describedby={undefined}
             data-testid="rail-drawer"
             className={clsx(
               "fixed inset-y-0 left-0 z-[var(--z-modal)] flex w-60 flex-col gap-1 outline-none",
@@ -358,6 +336,7 @@ export function NavRail({ activeKey, onNavigate, className }: NavRailProps) {
               "animate-[slide-in_var(--duration-entrance)_var(--ease-standard)] motion-reduce:animate-none",
             )}
           >
+            <Dialog.Title className="sr-only">Product navigation</Dialog.Title>
             <RailBody
               expanded
               activeKey={activeKey}
@@ -365,11 +344,11 @@ export function NavRail({ activeKey, onNavigate, className }: NavRailProps) {
               footLabel="Close navigation"
               footTestId="rail-drawer-close"
               footExpanded
-              onToggle={closeDrawer}
+              onToggle={() => setDrawerOpen(false)}
             />
-          </nav>
-        </>
-      )}
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
     </>
   );
 }

--- a/web/src/components/ui/StatusPill.tsx
+++ b/web/src/components/ui/StatusPill.tsx
@@ -71,7 +71,8 @@ export function StatusPill({ status, dotOnly = false, label, className }: Status
       data-status={status}
       className={clsx(
         "font-ui inline-flex items-center gap-1.5 rounded-(--radius) text-[12px] font-medium",
-        dotOnly ? "p-[5px]" : "px-2 py-[3px]",
+        // 4px-grid padding (adjudicated restyle 2026-07-19; was 5px/3px)
+        dotOnly ? "p-1" : "px-2 py-1",
         TINT[status],
         TEXT[status],
         className,

--- a/web/src/components/ui/TraceWaterfall.tsx
+++ b/web/src/components/ui/TraceWaterfall.tsx
@@ -2,14 +2,29 @@
 
 import { clsx } from "clsx";
 import { useMemo, useState } from "react";
-import type { Span, Trace } from "@/models";
+import type { LogEvent, Span, Trace } from "@/models";
 import { SpanDrawer } from "./SpanDrawer";
 import { SpanRow } from "./SpanRow";
 import { TraceMinimap } from "./TraceMinimap";
 
 export interface TraceWaterfallProps {
   trace: Trace;
+  /** Logs correlated to the trace — the span drawer's logs-in-span tab
+   *  shows the lines inside the selected span's service + time window. */
+  logs?: LogEvent[];
   className?: string;
+}
+
+/** Lines within the span's window (±1.5s skew — the correlation window
+ *  the log stream uses) on the span's service. */
+function logsForSpan(logs: LogEvent[], span: Span): LogEvent[] {
+  const start = Date.parse(span.start) - 1_500;
+  const end = Date.parse(span.start) + span.duration_ns / 1e6 + 1_500;
+  return logs.filter((log) => {
+    if (log.service !== span.service) return false;
+    const ts = Date.parse(log.ts);
+    return ts >= start && ts <= end;
+  });
 }
 
 interface PlacedSpan {
@@ -23,7 +38,7 @@ interface PlacedSpan {
  * TraceWaterfall — §3/§8.2: span rows on a shared time axis + time-axis
  * header + SpanDrawer; hover highlights the service in the minimap (MI-7).
  */
-export function TraceWaterfall({ trace, className }: TraceWaterfallProps) {
+export function TraceWaterfall({ trace, logs = [], className }: TraceWaterfallProps) {
   const [selected, setSelected] = useState<Span | null>(null);
   const [hoverService, setHoverService] = useState<string | null>(null);
 
@@ -105,7 +120,11 @@ export function TraceWaterfall({ trace, className }: TraceWaterfallProps) {
         </div>
       </div>
       {selected && (
-        <SpanDrawer span={selected} onClose={() => setSelected(null)} />
+        <SpanDrawer
+          span={selected}
+          logs={logsForSpan(logs, selected)}
+          onClose={() => setSelected(null)}
+        />
       )}
     </div>
   );

--- a/web/src/controllers/dashboards.test.ts
+++ b/web/src/controllers/dashboards.test.ts
@@ -103,6 +103,14 @@ describe("portable dashboard JSON (pages.md B2; api.md §6)", () => {
     ).toThrow(/viz_options must be an object/);
   });
 
+  it("rejects non-string markdown text (PR 168 review round 3)", () => {
+    expect(() =>
+      parsePortableDashboard(
+        '{"version":1,"name":"x","widgets":[{"type":"markdown","viz_options":{"text":{}},"layout":{"x":0,"y":0,"w":4,"h":2}}]}',
+      ),
+    ).toThrow(/markdown viz_options.text must be a string/);
+  });
+
   it("defaults optional fields on import", () => {
     const parsed = parsePortableDashboard(
       '{"version":1,"name":"minimal","widgets":[{"type":"markdown","layout":{"x":0,"y":0,"w":4,"h":2}}]}',

--- a/web/src/controllers/dashboards.test.ts
+++ b/web/src/controllers/dashboards.test.ts
@@ -58,6 +58,33 @@ describe("portable dashboard JSON (pages.md B2; api.md §6)", () => {
     ).toThrow(/layout/);
   });
 
+  it("rejects malformed template_vars and off-grid layouts (PR #168 review)", () => {
+    expect(() =>
+      parsePortableDashboard(
+        '{"version":1,"name":"x","template_vars":{"env":"prod"},"widgets":[]}',
+      ),
+    ).toThrow(/template_vars/);
+    expect(() =>
+      parsePortableDashboard(
+        '{"version":1,"name":"x","template_vars":{"env":[1]},"widgets":[]}',
+      ),
+    ).toThrow(/template_vars/);
+    for (const layout of [
+      '{"x":12,"y":0,"w":1,"h":3}', // x beyond the grid
+      '{"x":8,"y":0,"w":6,"h":3}', // x+w > 12
+      '{"x":0.5,"y":0,"w":4,"h":3}', // fractional
+      '{"x":-1,"y":0,"w":4,"h":3}', // negative
+      '{"x":0,"y":0,"w":0,"h":3}', // zero width
+      '{"x":0,"y":0,"w":4,"h":0}', // zero height
+    ]) {
+      expect(() =>
+        parsePortableDashboard(
+          `{"version":1,"name":"x","widgets":[{"type":"timeseries","layout":${layout}}]}`,
+        ),
+      ).toThrow(/12-column grid/);
+    }
+  });
+
   it("defaults optional fields on import", () => {
     const parsed = parsePortableDashboard(
       '{"version":1,"name":"minimal","widgets":[{"type":"markdown","layout":{"x":0,"y":0,"w":4,"h":2}}]}',

--- a/web/src/controllers/dashboards.test.ts
+++ b/web/src/controllers/dashboards.test.ts
@@ -85,6 +85,24 @@ describe("portable dashboard JSON (pages.md B2; api.md §6)", () => {
     }
   });
 
+  it("rejects non-string display fields (PR #168 review round 2)", () => {
+    expect(() =>
+      parsePortableDashboard(
+        '{"version":1,"name":"x","widgets":[{"type":"timeseries","title":{},"layout":{"x":0,"y":0,"w":4,"h":3}}]}',
+      ),
+    ).toThrow(/title must be a string/);
+    expect(() =>
+      parsePortableDashboard(
+        '{"version":1,"name":"x","widgets":[{"type":"timeseries","query_string":42,"layout":{"x":0,"y":0,"w":4,"h":3}}]}',
+      ),
+    ).toThrow(/query_string must be a string/);
+    expect(() =>
+      parsePortableDashboard(
+        '{"version":1,"name":"x","widgets":[{"type":"timeseries","viz_options":[],"layout":{"x":0,"y":0,"w":4,"h":3}}]}',
+      ),
+    ).toThrow(/viz_options must be an object/);
+  });
+
   it("defaults optional fields on import", () => {
     const parsed = parsePortableDashboard(
       '{"version":1,"name":"minimal","widgets":[{"type":"markdown","layout":{"x":0,"y":0,"w":4,"h":2}}]}',

--- a/web/src/controllers/dashboards.test.ts
+++ b/web/src/controllers/dashboards.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import type { Dashboard } from "@/models";
+import { dashboardToPortableJson, parsePortableDashboard } from "./dashboards";
+
+const DASHBOARD: Dashboard = {
+  id: "dash_x",
+  org_id: "org_upstat",
+  name: "Service overview",
+  favorite: true,
+  shared: true,
+  template_vars: { env: ["prod", "staging"] },
+  updated_at: "2026-07-19T00:00:00Z",
+  widgets: [
+    {
+      id: "wid_1",
+      dashboard_id: "dash_x",
+      type: "timeseries",
+      title: "p95 latency",
+      query: null,
+      query_string: "metric:http.request.duration_ms | p95()",
+      viz_options: { display: "line" },
+      layout: { x: 0, y: 0, w: 8, h: 3 },
+    },
+  ],
+};
+
+describe("portable dashboard JSON (pages.md B2; api.md §6)", () => {
+  it("round-trips export → parse with ids stripped", () => {
+    const text = dashboardToPortableJson(DASHBOARD);
+    expect(text).not.toContain("dash_x");
+    expect(text).not.toContain("wid_1");
+    const parsed = parsePortableDashboard(text);
+    expect(parsed.version).toBe(1);
+    expect(parsed.name).toBe("Service overview");
+    expect(parsed.template_vars).toEqual({ env: ["prod", "staging"] });
+    expect(parsed.widgets).toHaveLength(1);
+    expect(parsed.widgets[0]).toMatchObject({
+      type: "timeseries",
+      title: "p95 latency",
+      layout: { x: 0, y: 0, w: 8, h: 3 },
+    });
+  });
+
+  it("rejects malformed input with readable messages", () => {
+    expect(() => parsePortableDashboard("nope")).toThrow(/not valid JSON/);
+    expect(() => parsePortableDashboard('{"version":2,"name":"x","widgets":[]}')).toThrow(
+      /unsupported version/,
+    );
+    expect(() => parsePortableDashboard('{"version":1,"widgets":[]}')).toThrow(/name/);
+    expect(() => parsePortableDashboard('{"version":1,"name":"x"}')).toThrow(/widgets/);
+    expect(() =>
+      parsePortableDashboard(
+        '{"version":1,"name":"x","widgets":[{"type":"nonsense","layout":{"x":0,"y":0,"w":1,"h":1}}]}',
+      ),
+    ).toThrow(/unknown widget type/);
+    expect(() =>
+      parsePortableDashboard('{"version":1,"name":"x","widgets":[{"type":"timeseries"}]}'),
+    ).toThrow(/layout/);
+  });
+
+  it("defaults optional fields on import", () => {
+    const parsed = parsePortableDashboard(
+      '{"version":1,"name":"minimal","widgets":[{"type":"markdown","layout":{"x":0,"y":0,"w":4,"h":2}}]}',
+    );
+    expect(parsed.template_vars).toEqual({});
+    expect(parsed.widgets[0].title).toBe("markdown");
+    expect(parsed.widgets[0].viz_options).toEqual({});
+  });
+});

--- a/web/src/controllers/dashboards.ts
+++ b/web/src/controllers/dashboards.ts
@@ -2,8 +2,81 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { dashboardsRepo } from "@/models/repositories";
-import type { Widget, WidgetLayout } from "@/models";
+import type { Dashboard, Widget, WidgetLayout } from "@/models";
 import { useRequest } from "./use-request";
+
+/* ------------------------------------------------------------------ */
+/* Portable JSON (pages.md B2; api.md §6 "CRUD + portable JSON")        */
+/* ------------------------------------------------------------------ */
+
+const WIDGET_TYPES = new Set([
+  "timeseries", "query_value", "toplist", "table", "heatmap", "logstream",
+  "trace_latency", "slo", "status", "servicemap", "markdown",
+]);
+
+export interface PortableDashboard {
+  version: 1;
+  name: string;
+  template_vars: Record<string, string[]>;
+  widgets: Omit<Widget, "id" | "dashboard_id">[];
+}
+
+/** Serialize a dashboard to the portable definition (ids stripped). */
+export function dashboardToPortableJson(dashboard: Dashboard): string {
+  const portable: PortableDashboard = {
+    version: 1,
+    name: dashboard.name,
+    template_vars: dashboard.template_vars,
+    widgets: dashboard.widgets.map(({ type, title, query, query_string, viz_options, layout }) => ({
+      type,
+      title,
+      query,
+      query_string,
+      viz_options,
+      layout,
+    })),
+  };
+  return JSON.stringify(portable, null, 2);
+}
+
+/** Parse + validate a portable definition; throws with a readable message. */
+export function parsePortableDashboard(text: string): PortableDashboard {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(text);
+  } catch {
+    throw new Error("not valid JSON");
+  }
+  const obj = raw as Partial<PortableDashboard>;
+  if (obj?.version !== 1) throw new Error("unsupported version — expected 1");
+  if (!obj.name || typeof obj.name !== "string") throw new Error("name is required");
+  if (!Array.isArray(obj.widgets)) throw new Error("widgets must be an array");
+  for (const w of obj.widgets) {
+    if (!w || typeof w !== "object" || !WIDGET_TYPES.has((w as Widget).type)) {
+      throw new Error(`unknown widget type: ${(w as Widget | undefined)?.type ?? "?"}`);
+    }
+    const layout = (w as Widget).layout;
+    if (
+      !layout ||
+      [layout.x, layout.y, layout.w, layout.h].some((n) => typeof n !== "number")
+    ) {
+      throw new Error("every widget needs a numeric x/y/w/h layout");
+    }
+  }
+  return {
+    version: 1,
+    name: obj.name,
+    template_vars: obj.template_vars ?? {},
+    widgets: obj.widgets.map((w) => ({
+      type: w.type,
+      title: w.title ?? w.type,
+      query: w.query ?? null,
+      query_string: w.query_string,
+      viz_options: w.viz_options ?? {},
+      layout: w.layout,
+    })),
+  };
+}
 
 /** Dashboards list controller (pages.md B2). */
 export function useDashboardsController() {
@@ -41,7 +114,24 @@ export function useDashboardsController() {
     [state],
   );
 
-  return { ...state, create, toggleFavorite, remove };
+  /** B2 portable JSON import — parse, create, place every widget. */
+  const importJson = useCallback(
+    async (text: string) => {
+      const portable = parsePortableDashboard(text);
+      const dashboard = await dashboardsRepo.create({ name: portable.name });
+      if (Object.keys(portable.template_vars).length > 0) {
+        await dashboardsRepo.update(dashboard.id, { template_vars: portable.template_vars });
+      }
+      for (const widget of portable.widgets) {
+        await dashboardsRepo.addWidget(dashboard.id, widget);
+      }
+      await state.reload();
+      return dashboard;
+    },
+    [state],
+  );
+
+  return { ...state, create, toggleFavorite, remove, importJson };
 }
 
 function isTypingTarget(target: EventTarget | null): boolean {

--- a/web/src/controllers/dashboards.ts
+++ b/web/src/controllers/dashboards.ts
@@ -51,16 +51,40 @@ export function parsePortableDashboard(text: string): PortableDashboard {
   if (obj?.version !== 1) throw new Error("unsupported version — expected 1");
   if (!obj.name || typeof obj.name !== "string") throw new Error("name is required");
   if (!Array.isArray(obj.widgets)) throw new Error("widgets must be an array");
+  // template_vars must be a record of string arrays — a bare string value
+  // would crash the template-var bar (PR #168 review)
+  if (obj.template_vars !== undefined) {
+    if (
+      typeof obj.template_vars !== "object" ||
+      obj.template_vars === null ||
+      Array.isArray(obj.template_vars) ||
+      Object.values(obj.template_vars).some(
+        (values) => !Array.isArray(values) || values.some((v) => typeof v !== "string"),
+      )
+    ) {
+      throw new Error("template_vars must map names to arrays of strings");
+    }
+  }
   for (const w of obj.widgets) {
     if (!w || typeof w !== "object" || !WIDGET_TYPES.has((w as Widget).type)) {
       throw new Error(`unknown widget type: ${(w as Widget | undefined)?.type ?? "?"}`);
     }
     const layout = (w as Widget).layout;
+    // 12-col grid bounds (PR #168 review): integers, on-grid, in-range —
+    // out-of-range spans render broken CSS grid placements
     if (
       !layout ||
-      [layout.x, layout.y, layout.w, layout.h].some((n) => typeof n !== "number")
+      [layout.x, layout.y, layout.w, layout.h].some((n) => !Number.isInteger(n)) ||
+      layout.x < 0 ||
+      layout.w < 1 ||
+      layout.x + layout.w > 12 ||
+      layout.y < 0 ||
+      layout.h < 1 ||
+      layout.h > 24
     ) {
-      throw new Error("every widget needs a numeric x/y/w/h layout");
+      throw new Error(
+        "every widget needs an integer layout inside the 12-column grid (0 ≤ x, x+w ≤ 12, w ≥ 1, y ≥ 0, 1 ≤ h ≤ 24)",
+      );
     }
   }
   return {
@@ -114,16 +138,28 @@ export function useDashboardsController() {
     [state],
   );
 
-  /** B2 portable JSON import — parse, create, place every widget. */
+  /** B2 portable JSON import — parse, create, place every widget. A
+   *  mid-import failure rolls the created dashboard back (best effort)
+   *  so nothing half-imported persists (PR #168 review). */
   const importJson = useCallback(
     async (text: string) => {
       const portable = parsePortableDashboard(text);
       const dashboard = await dashboardsRepo.create({ name: portable.name });
-      if (Object.keys(portable.template_vars).length > 0) {
-        await dashboardsRepo.update(dashboard.id, { template_vars: portable.template_vars });
-      }
-      for (const widget of portable.widgets) {
-        await dashboardsRepo.addWidget(dashboard.id, widget);
+      try {
+        if (Object.keys(portable.template_vars).length > 0) {
+          await dashboardsRepo.update(dashboard.id, { template_vars: portable.template_vars });
+        }
+        for (const widget of portable.widgets) {
+          await dashboardsRepo.addWidget(dashboard.id, widget);
+        }
+      } catch (error) {
+        try {
+          await dashboardsRepo.remove(dashboard.id);
+        } catch {
+          /* rollback is best effort — surface the original failure */
+        }
+        await state.reload();
+        throw error;
       }
       await state.reload();
       return dashboard;

--- a/web/src/controllers/dashboards.ts
+++ b/web/src/controllers/dashboards.ts
@@ -83,6 +83,15 @@ export function parsePortableDashboard(text: string): PortableDashboard {
     ) {
       throw new Error("widget viz_options must be an object");
     }
+    // markdown renders viz_options.text as a React child — a non-string
+    // value would throw at render time (PR 168 review round 3)
+    if (
+      (w as Widget).type === "markdown" &&
+      w.viz_options?.text !== undefined &&
+      typeof w.viz_options.text !== "string"
+    ) {
+      throw new Error("markdown viz_options.text must be a string");
+    }
     const layout = (w as Widget).layout;
     // 12-col grid bounds (PR #168 review): integers, on-grid, in-range —
     // out-of-range spans render broken CSS grid placements

--- a/web/src/controllers/dashboards.ts
+++ b/web/src/controllers/dashboards.ts
@@ -69,6 +69,20 @@ export function parsePortableDashboard(text: string): PortableDashboard {
     if (!w || typeof w !== "object" || !WIDGET_TYPES.has((w as Widget).type)) {
       throw new Error(`unknown widget type: ${(w as Widget | undefined)?.type ?? "?"}`);
     }
+    // display fields must be strings when present — substituteVars calls
+    // .replace on them at render time (PR #168 review round 2)
+    if (w.title !== undefined && typeof w.title !== "string") {
+      throw new Error("widget title must be a string");
+    }
+    if (w.query_string !== undefined && typeof w.query_string !== "string") {
+      throw new Error("widget query_string must be a string");
+    }
+    if (
+      w.viz_options !== undefined &&
+      (typeof w.viz_options !== "object" || w.viz_options === null || Array.isArray(w.viz_options))
+    ) {
+      throw new Error("widget viz_options must be an object");
+    }
     const layout = (w as Widget).layout;
     // 12-col grid bounds (PR #168 review): integers, on-grid, in-range —
     // out-of-range spans render broken CSS grid placements

--- a/web/src/controllers/logs.ts
+++ b/web/src/controllers/logs.ts
@@ -178,3 +178,43 @@ export function useLogsExplorerController() {
     applyView,
   };
 }
+
+/**
+ * §5 keyboard navigation for the log list — `j`/`k` move focus between
+ * LogLine header buttons (Enter then expands via native button
+ * semantics). The ShortcutCheatsheet advertised j/k with no
+ * implementation behind it (completeness fix 2026-07-19).
+ */
+export function useLogLineKeys(listRef: React.RefObject<HTMLElement | null>) {
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.key !== "j" && e.key !== "k") || e.metaKey || e.ctrlKey || e.altKey) return;
+      const target = e.target;
+      if (
+        target instanceof HTMLElement &&
+        (target.tagName === "INPUT" ||
+          target.tagName === "TEXTAREA" ||
+          target.tagName === "SELECT" ||
+          target.isContentEditable)
+      ) {
+        return;
+      }
+      const list = listRef.current;
+      if (!list) return;
+      // LogLine header buttons carry aria-expanded (the JSON tree's inner
+      // copy buttons don't) — those are the navigable rows
+      const rows = [...list.querySelectorAll<HTMLButtonElement>("button[aria-expanded]")];
+      if (rows.length === 0) return;
+      const current = rows.indexOf(document.activeElement as HTMLButtonElement);
+      const next =
+        e.key === "j"
+          ? Math.min(current + 1, rows.length - 1)
+          : Math.max(current - 1, 0);
+      rows[next]?.focus();
+      rows[next]?.scrollIntoView({ block: "nearest" });
+      e.preventDefault();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [listRef]);
+}

--- a/web/src/controllers/telemetry.ts
+++ b/web/src/controllers/telemetry.ts
@@ -99,12 +99,20 @@ export function useTraceLogsController(trace: Trace | null) {
     async () => {
       if (!trace) return [];
       const startMs = Date.parse(trace.start);
-      const page = await logsRepo.query({
-        from: new Date(startMs - 5_000).toISOString(),
-        to: new Date(startMs + trace.duration_ms + 5_000).toISOString(),
-        limit: 500,
-      });
-      return page.events.filter((e) => e.trace_id === trace.trace_id);
+      const from = new Date(startMs - 5_000).toISOString();
+      const to = new Date(startMs + trace.duration_ms + 5_000).toISOString();
+      // follow next_cursor so busy windows aren't truncated at one page
+      // (PR #168 review); capped — a trace window is seconds long, so the
+      // cap is generous headroom, not a correctness ceiling
+      const matches: LogEvent[] = [];
+      let cursor: string | undefined;
+      for (let pageNo = 0; pageNo < 6; pageNo++) {
+        const page = await logsRepo.query({ from, to, limit: 500, ...(cursor ? { cursor } : {}) });
+        matches.push(...page.events.filter((e) => e.trace_id === trace.trace_id));
+        if (!page.next_cursor) break;
+        cursor = page.next_cursor;
+      }
+      return matches;
     },
     [trace?.trace_id],
   );

--- a/web/src/controllers/telemetry.ts
+++ b/web/src/controllers/telemetry.ts
@@ -7,7 +7,7 @@ import {
   queryRepo,
   tracesRepo,
 } from "@/models/repositories";
-import type { LogQueryPage, QueryRequest, QueryResult } from "@/models";
+import type { LogEvent, LogQueryPage, QueryRequest, QueryResult, Trace } from "@/models";
 import { useRequest } from "./use-request";
 import { useTimeRange } from "./time-range";
 
@@ -86,4 +86,26 @@ export function useTraceController(traceId: string) {
 /** APM service list (pages.md B5). */
 export function useServicesController() {
   return useRequest(() => tracesRepo.services(), []);
+}
+
+/**
+ * Logs correlated to a trace (pages.md B5 span drawer, logs-in-span tab):
+ * fetches the trace's time window and keeps the lines whose `trace_id`
+ * matches. Empty result = honestly no correlated lines (only lines that
+ * really carry the id populate the tab).
+ */
+export function useTraceLogsController(trace: Trace | null) {
+  return useRequest<LogEvent[]>(
+    async () => {
+      if (!trace) return [];
+      const startMs = Date.parse(trace.start);
+      const page = await logsRepo.query({
+        from: new Date(startMs - 5_000).toISOString(),
+        to: new Date(startMs + trace.duration_ms + 5_000).toISOString(),
+        limit: 500,
+      });
+      return page.events.filter((e) => e.trace_id === trace.trace_id);
+    },
+    [trace?.trace_id],
+  );
 }


### PR DESCRIPTION
## Summary

PR3 of the P1 polish series (`feat/demo-completeness`): the pages.md/features.md gap-diff closed, the adjudicated Figma-parity restyles, the Features/Platform nav-anchor differentiation, and the expanded-rail directives (desktop reflow sweep + the clarified mobile overlay drawer).

## Gap-diff implementations

- **B2 portable JSON (api.md §6)** — `Export JSON` on the dashboard view downloads a versioned portable definition (ids stripped); `Import JSON` on the list validates it (version / name / widget types / layout) and lands on the new dashboard with template vars intact. Round-trip + validation unit-tested; import covered e2e (including the malformed-input error path).
- **B5 logs-in-span** — the span drawer's logs tab now carries the trace's correlated log lines: a controller fetches the trace window and keeps `trace_id` matches; spans filter by service + a ±1.5s window matching the log stream's correlation skew. The hero `POST /v1/events` trace demonstrably lights up.
- **B6 devices + geo** — the RUM summary generated devices/countries breakdowns that no view rendered; two TopList panels added.
- **B9 declare-from-alert [Directive]** — active rows in the monitors Triggered feed open the declare-incident modal prefilled (title from the alert, sev mapped); the modal is extracted to a shared `DeclareIncidentModal` used by both surfaces.
- **Nav anchors differentiated** — Features → `/#features` (the A11 feature-highlights band gets the id), Platform → `/#pillars`; footer Product column follows; docs + parity e2e updated.

## Expanded-rail directives

- **Desktop (1280/1440)**: e2e sweep over every dashboard route with the 240px rail expanded — no document side-scroll, no element outside a horizontal-scroll container (the PR1 reflow work held: zero fixes needed); screenshots captured at both rail states on the densest routes.
- **Mobile (<md, clarified canon)**: rail expansion renders as a 240px **overlay drawer** over a scrim — content keeps full width beneath; the persisted desktop `nav.rail.expanded` state does not apply (mobile boots collapsed); scrim tap, Escape, and item selection dismiss; focus moves into the drawer and returns to the toggle. e2e: content-width invariance, scrim/ESC dismissal, persisted-expanded boot renders collapsed, transient drawer never rewrites the desktop preference.

## Adjudicated restyles (code side; design agent updates the masters)

- FAQItem → product radius (`--radius`) + 4px-grid padding (16px)
- StatusPill → 4px-grid padding (was 5px/3px)

## Tests

37 Playwright e2e green (4 new completeness tests + the rail-drawer test + the two expanded-rail sweeps), 220 unit tests (83 files, +3 for portable JSON), lint + check:boundaries, typecheck, TEST_MODE build — all green locally.

Docs: design.md (nav + rail clauses), pages.md A1 (the pillar-map dropdown flagged as a spec gap pending adjudication vs the 4-text-links canon), web-implementation.md as-built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)