### PR TITLE
chore(web): code quality — dead-dependency prune, dead code, docs current-system sweep

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -34,13 +34,10 @@
 
 ## 2. Target surface — monitors & alerts
 
-> **Superseded by U-5 (HTTP-only for new surfaces):** the gRPC `AlertService`
-> sketch below is retired — the alert surface is HTTP (`/v1/channels`,
-> `/v1/monitors/{id}/rules`, openapi.yaml), same semantics. Kept for audit.
-
-| Service / RPC | Purpose |
-| --- | --- |
-| ~~`AlertService.*` (gRPC)~~ | → HTTP per U-5; see flows/alert.md + openapi.yaml |
+The alert surface is HTTP (**U-5: HTTP-only for new surfaces**) —
+`POST /v1/channels`, `/v1/channels/{id}/verify`, `/v1/monitors/{id}/rules`
+per [flows/alert.md](flows/alert.md) and
+[openapi.yaml](api/openapi.yaml). No gRPC alert service exists.
 
 ## 3. Target surface — events & stats (M2/M3, the ecosystem "D2" contract) **[Proposed]**
 

--- a/docs/query-grammar.md
+++ b/docs/query-grammar.md
@@ -65,7 +65,7 @@ indexes ranked by cardinality (design.md MI-13).
 | Explorers (logs/metrics/traces/RUM) | filters + optional aggregation |
 | Dashboard widgets | full query persisted in `WIDGET.query` |
 | Monitor rules | full query + thresholds evaluated on schedule |
-| `/v1/stats` (legacy events path) | sugar over `rum.*` count queries |
+| `/v1/stats` (the events/stats surface, api.md §3.3) | sugar over `rum.*` count queries |
 
 One internal query service parses the grammar into an AST, validates facets
 against the catalog/indexes, then compiles per store: ClickHouse SQL for

--- a/docs/web-implementation.md
+++ b/docs/web-implementation.md
@@ -169,11 +169,10 @@ widths, `e2e/navrail.spec.ts` covers toggle + persistence + viewport
 defaults.
 
 **Nav/footer parity + theme toggle as-built (2026-07-19, SKILL.md
-"Marketing nav, footer & theme parity canon").** MarketingNav converged to
-the canonical shape — Features(/#pillars) · Dashboards(/dashboard) ·
-Docs(GitBook root) · GitHub(repo) + ThemeToggle + Sign in CTA; the pillar
-dropdown and standalone star badge retired (the runtime star count now
-rides the GitHub link, still never static). MarketingFooter owns the
+"Marketing nav, footer & theme parity canon").** MarketingNav carries the
+canonical shape — Features(/#features) · Platform(/#pillars) ·
+Docs(GitBook root) · GitHub star badge (live runtime count, never
+static) + ThemeToggle + Sign in link + Try Cloud CTA. MarketingFooter owns the
 canonical column set (Product / Docs / Community / Legal, ratified URLs)
 plus the legal bar: verbatim "© Cuesoft Inc. 2026. Upstat. CueLABS™
 Division. MIT License." with linked marks, an English-only language
@@ -314,6 +313,24 @@ desktop state does not apply (mobile boots collapsed), scrim/Escape/item
 selection dismiss (`e2e/navrail.spec.ts`). Known spec gap deliberately
 deferred: the A1 Features pillar-map dropdown (pending adjudication
 against the 4-text-links parity canon).
+
+**Code-quality pass as-built (2026-07-19).** The documented dead-dependency
+prune landed: `styled-components` (+ its `next.config.ts` compiler flag),
+`chart.js`, `react-chartjs-2`, `recharts`, `@tanstack/react-query`,
+`js-cookie` (+ `@types/js-cookie`), `@iconify/react`,
+`@react-oauth/google`, and `@floating-ui/react-dom` are removed — zero
+live imports verified first; the X-8 gRPC control-plane pair
+(`grpc-web`, `google-protobuf` + `src/proto`/`src/client.ts`/
+`components/libs/grpc`) stays until monitors-v2 per §8. Dead code:
+MarketingFooter's unused `inline` variant axis removed (no consumer; the
+footer renders the one canonical stacked shape). The docs now describe
+only the current system (api.md §2 states the HTTP alert surface without
+the struck-through gRPC sketch; stale nav enumerations corrected).
+`package.json` scripts already carry the ecosystem-canonical names
+(`dev/build/start/lint/typecheck/test/test:watch/test:e2e/
+check:boundaries`); remaining cross-repo config divergence (vitest plugin
+pattern, playwright port-isolation vars, lint composition) is catalogued
+for the parity pass rather than changed unilaterally.
 
 Screen-state parity **[Directive 2026-07-18, carried from design.md §8.1]**:
 every data-driven screen ships default, empty, and loading states — the
@@ -499,11 +516,9 @@ dedicated `chore(web): retire legacy <area>` PR once its replacement
 passes QA — and it is **currently empty**. The guardrails stay armed:
 `scripts/check-boundaries.mjs` (wired into `npm run lint`) and the
 ESLint `no-restricted-imports` boundary fail any live import of
-`src/legacy/**`. Retired trees' dependencies (`styled-components`,
-`chart.js`, `react-chartjs-2`, `recharts`, `@tanstack/react-query`,
-`js-cookie`, `@iconify/react`, `@react-oauth/google`,
-`@floating-ui/react-dom`) remain in `package.json` unused, pending
-their own prune PR.
+`src/legacy/**`. `package.json` carries no unused dependencies — the
+only intentional exception is the X-8 gRPC pair below (`grpc-web`,
+`google-protobuf`), which backs the kept control-plane tree.
 
 One tree stays live by design: the gRPC-Web control plane. `src/proto/*`,
 `src/client.ts`, and the gRPC libs (`components/libs/grpc`) are

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -2,10 +2,6 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   output: "standalone",
-  compiler: {
-    // Enable the styled-components SWC transform (SSR class matching, display names).
-    styledComponents: true,
-  },
   // The dev indicator's default bottom-LEFT position sits exactly on the
   // expandable rail's foot toggle ([Directive 2026-07-19]) — it intercepts
   // pointer events over the collapsed-rail chevron (dev + e2e). Bottom-right

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,28 +8,19 @@
       "name": "upstat",
       "version": "0.1.0",
       "dependencies": {
-        "@floating-ui/react-dom": "^2.1.9",
-        "@iconify/react": "^6",
         "@radix-ui/react-checkbox": "^1.3.7",
         "@radix-ui/react-dialog": "^1.1.19",
         "@radix-ui/react-popover": "^1.1.19",
         "@radix-ui/react-switch": "^1.3.3",
         "@radix-ui/react-tooltip": "^1.2.12",
-        "@react-oauth/google": "^0.13.5",
-        "@tanstack/react-query": "^5.101.2",
-        "chart.js": "^4",
         "clsx": "^2.1.1",
         "date-fns": "^4.4.0",
         "google-protobuf": "^4",
         "grpc-web": "^2",
-        "js-cookie": "^3.0.8",
         "lucide-react": "^1.25.0",
         "next": "16.2.10",
         "react": "19.2.7",
-        "react-chartjs-2": "^5",
-        "react-dom": "19.2.7",
-        "recharts": "^3.9.2",
-        "styled-components": "^6"
+        "react-dom": "19.2.7"
       },
       "devDependencies": {
         "@playwright/test": "^1.61.1",
@@ -38,7 +29,6 @@
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
         "@types/google-protobuf": "^3.15.12",
-        "@types/js-cookie": "^3.0.6",
         "@types/node": "^26",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -558,21 +548,6 @@
         "tslib": "^2.4.0"
       }
     },
-    "node_modules/@emotion/is-prop-valid": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
-      "integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
-      "license": "MIT",
-      "dependencies": {
-        "@emotion/memoize": "^0.9.0"
-      }
-    },
-    "node_modules/@emotion/memoize": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
-      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
-      "license": "MIT"
-    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
@@ -838,27 +813,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
       }
-    },
-    "node_modules/@iconify/react": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@iconify/react/-/react-6.0.2.tgz",
-      "integrity": "sha512-SMmC2sactfpJD427WJEDN6PMyznTFMhByK9yLW0gOTtnjzzbsi/Ke/XqsumsavFPwNiXs8jSiYeZTmLCLwO+Fg==",
-      "license": "MIT",
-      "dependencies": {
-        "@iconify/types": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/cyberalien"
-      },
-      "peerDependencies": {
-        "react": ">=16"
-      }
-    },
-    "node_modules/@iconify/types": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
-      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
-      "license": "MIT"
     },
     "node_modules/@img/colour": {
       "version": "1.1.0",
@@ -1375,12 +1329,6 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
-    },
-    "node_modules/@kurkle/color": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
-      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
-      "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.6",
@@ -2208,42 +2156,6 @@
       "integrity": "sha512-xnXE7wG13PI+cxieVssYXlQJuYVRhH9NBoxt3KNwzghDIA69GMm7d4wXRouHIYjE+KvS6U/MsMO73NdS2MH9ZA==",
       "license": "MIT"
     },
-    "node_modules/@react-oauth/google": {
-      "version": "0.13.5",
-      "resolved": "https://registry.npmjs.org/@react-oauth/google/-/google-0.13.5.tgz",
-      "integrity": "sha512-xQWri2s/3nNekZJ4uuov2aAfQYu83bN3864KcFqw2pK1nNbFurQIjPFDXhWaKH3IjYJ2r/9yyIIpsn5lMqrheQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
-    "node_modules/@reduxjs/toolkit": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
-      "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
-      "license": "MIT",
-      "dependencies": {
-        "@standard-schema/spec": "^1.0.0",
-        "@standard-schema/utils": "^0.3.0",
-        "immer": "^11.0.0",
-        "redux": "^5.0.1",
-        "redux-thunk": "^3.1.0",
-        "reselect": "^5.1.0"
-      },
-      "peerDependencies": {
-        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
-        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
-      },
-      "peerDependenciesMeta": {
-        "react": {
-          "optional": true
-        },
-        "react-redux": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
@@ -2571,12 +2483,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "license": "MIT"
-    },
-    "node_modules/@standard-schema/utils": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
-      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@swc/helpers": {
@@ -2871,32 +2778,6 @@
         "tailwindcss": "4.3.3"
       }
     },
-    "node_modules/@tanstack/query-core": {
-      "version": "5.101.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.2.tgz",
-      "integrity": "sha512-hH5MLoJhF7KaIGd7q3xTXGXvslI+GYlM1Z/35aSHHWaCJWB7XvTSHYuV3eM7tw+aE0mT/xMro4M4Q9rCGHT0lw==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      }
-    },
-    "node_modules/@tanstack/react-query": {
-      "version": "5.101.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.2.tgz",
-      "integrity": "sha512-seDkr6kzGzX1okaaTtZPtgA688CDPlXUz1C6xSg0ESqn04Vuc8tlrYms1s3de+znBqhPVxFRfpAfUf+6XvfPWg==",
-      "license": "MIT",
-      "dependencies": {
-        "@tanstack/query-core": "5.101.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      },
-      "peerDependencies": {
-        "react": "^18 || ^19"
-      }
-    },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
@@ -3028,69 +2909,6 @@
         "assertion-error": "^2.0.1"
       }
     },
-    "node_modules/@types/d3-array": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
-      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-color": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
-      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-ease": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
-      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-interpolate": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
-      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-color": "*"
-      }
-    },
-    "node_modules/@types/d3-path": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
-      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-scale": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
-      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-time": "*"
-      }
-    },
-    "node_modules/@types/d3-shape": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
-      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-path": "*"
-      }
-    },
-    "node_modules/@types/d3-time": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
-      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-timer": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
-      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
-      "license": "MIT"
-    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -3109,13 +2927,6 @@
       "version": "3.15.12",
       "resolved": "https://registry.npmjs.org/@types/google-protobuf/-/google-protobuf-3.15.12.tgz",
       "integrity": "sha512-40um9QqwHjRS92qnOaDpL7RmDK15NuZYo9HihiJRbYkMQZlWnuH8AdvbMy8/o6lgLmKbDUKa+OALCltHdbOTpQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/js-cookie": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-3.0.6.tgz",
-      "integrity": "sha512-wkw9yd1kEXOPnvEeEV1Go1MmxtBJL0RR79aOTAApecWFVu7w0NNXNqhcWgvw2YgZDYadliXkl14pa3WXw5jlCQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -3162,12 +2973,6 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
-    },
-    "node_modules/@types/use-sync-external-store": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
-      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
-      "license": "MIT"
     },
     "node_modules/@typescript-eslint/scope-manager": {
       "version": "8.63.0",
@@ -4167,15 +3972,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/camelize": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
-      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001793",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
@@ -4221,18 +4017,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/chart.js": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
-      "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
-      "license": "MIT",
-      "dependencies": {
-        "@kurkle/color": "^0.3.0"
-      },
-      "engines": {
-        "pnpm": ">=8"
       }
     },
     "node_modules/client-only": {
@@ -4299,26 +4083,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/css-color-keywords": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
-      "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/css-to-react-native": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
-      "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
-      "license": "MIT",
-      "dependencies": {
-        "camelize": "^1.0.0",
-        "css-color-keywords": "^1.0.0",
-        "postcss-value-parser": "^4.0.2"
-      }
-    },
     "node_modules/css-tree": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
@@ -4344,128 +4108,8 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "devOptional": true,
       "license": "MIT"
-    },
-    "node_modules/d3-array": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
-      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
-      "license": "ISC",
-      "dependencies": {
-        "internmap": "1 - 2"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-color": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
-      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-ease": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
-      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-format": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
-      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-interpolate": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
-      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-color": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-path": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
-      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-scale": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
-      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-array": "2.10.0 - 3",
-        "d3-format": "1 - 3",
-        "d3-interpolate": "1.2.0 - 3",
-        "d3-time": "2.1.1 - 3",
-        "d3-time-format": "2 - 4"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-shape": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
-      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-path": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-time": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
-      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-array": "2 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-time-format": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
-      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-time": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-timer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
-      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -4575,12 +4219,6 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/decimal.js-light": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
-      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
     "node_modules/deep-is": {
@@ -4913,16 +4551,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/es-toolkit": {
-      "version": "1.49.0",
-      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.49.0.tgz",
-      "integrity": "sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g==",
-      "license": "MIT",
-      "workspaces": [
-        "docs",
-        "benchmarks"
-      ]
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -5645,12 +5273,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/eventemitter3": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
-      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
-      "license": "MIT"
-    },
     "node_modules/expect-type": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
@@ -6165,16 +5787,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/immer": {
-      "version": "11.1.11",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.11.tgz",
-      "integrity": "sha512-qzXuyXAkPySAGYkfsAwodDPWT8Zm7/Uo5BNt4BjhMhG5WlWyZZ4wQqnWwdS8kjlQ1Cwu6gjw3A6+0gTQwlyYtw==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/immer"
-      }
-    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -6225,15 +5837,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/internmap": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
-      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/is-array-buffer": {
@@ -6699,12 +6302,6 @@
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
-    },
-    "node_modules/js-cookie": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.8.tgz",
-      "integrity": "sha512-yeJd4aNAdYZQjaon2bpD/Gb0B/omw7HQOsynXXcOiWVCacbBcPlgn8S/d1X6blFSaHao7ozqtW7NZW19xpCtIw==",
-      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -7801,12 +7398,6 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "node_modules/postcss-value-parser": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "license": "MIT"
-    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -7907,16 +7498,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/react-chartjs-2": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.3.1.tgz",
-      "integrity": "sha512-h5IPXKg9EXpjoBzUfyWJvllMjG2mQ4EiuHQFhms/AjUm0XSZHhyRy2xVmLXHKrtcdrPO4mnGqRtYoD0vp95A0A==",
-      "license": "MIT",
-      "peerDependencies": {
-        "chart.js": "^4.1.1",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
     "node_modules/react-dom": {
       "version": "19.2.7",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
@@ -7933,30 +7514,8 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true,
       "license": "MIT"
-    },
-    "node_modules/react-redux": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
-      "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/use-sync-external-store": "^0.0.6",
-        "use-sync-external-store": "^1.4.0"
-      },
-      "peerDependencies": {
-        "@types/react": "^18.2.25 || ^19",
-        "react": "^18.0 || ^19",
-        "redux": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "redux": {
-          "optional": true
-        }
-      }
     },
     "node_modules/react-remove-scroll": {
       "version": "2.7.2",
@@ -8027,36 +7586,6 @@
         }
       }
     },
-    "node_modules/recharts": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.9.2.tgz",
-      "integrity": "sha512-G4fy+Pk46RaXgwWMh+Nzhyo/lbFAVqXo9gtetlyehe6Ehge9CsgDuOTwQDD+i1+llaLktNBiNq4bhnGlDRXFtw==",
-      "license": "MIT",
-      "workspaces": [
-        "www"
-      ],
-      "dependencies": {
-        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
-        "clsx": "^2.1.1",
-        "decimal.js-light": "^2.5.1",
-        "es-toolkit": "^1.39.3",
-        "eventemitter3": "^5.0.1",
-        "immer": "^11.1.8",
-        "react-redux": "8.x.x || 9.x.x",
-        "reselect": "5.2.0",
-        "tiny-invariant": "^1.3.3",
-        "use-sync-external-store": "^1.2.2",
-        "victory-vendor": "^37.0.2"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -8069,21 +7598,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/redux": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
-      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
-    },
-    "node_modules/redux-thunk": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
-      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "redux": "^5.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -8139,12 +7653,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/reselect": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
-      "integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
-      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "2.0.0-next.7",
@@ -8749,42 +8257,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/styled-components": {
-      "version": "6.4.4",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.4.4.tgz",
-      "integrity": "sha512-tJk5CmKUPMDoTsZQ8m0hHInBk9HFKUPSusqmbBuefDX+yUbMBWea2Ob/wdXFyHW8XZqXkprJscysAdKeGWNqlA==",
-      "license": "MIT",
-      "dependencies": {
-        "@emotion/is-prop-valid": "1.4.0",
-        "css-to-react-native": "3.2.0",
-        "csstype": "3.2.3",
-        "stylis": "4.3.6"
-      },
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/styled-components"
-      },
-      "peerDependencies": {
-        "css-to-react-native": ">= 3.2.0",
-        "react": ">= 16.8.0",
-        "react-dom": ">= 16.8.0",
-        "react-native": ">= 0.68.0"
-      },
-      "peerDependenciesMeta": {
-        "css-to-react-native": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        },
-        "react-native": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -8807,12 +8279,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/stylis": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
-      "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
-      "license": "MIT"
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -8867,12 +8333,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
-    },
-    "node_modules/tiny-invariant": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
-      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
-      "license": "MIT"
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -9314,37 +8774,6 @@
         "@types/react": {
           "optional": true
         }
-      }
-    },
-    "node_modules/use-sync-external-store": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
-      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/victory-vendor": {
-      "version": "37.3.6",
-      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
-      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
-      "license": "MIT AND ISC",
-      "dependencies": {
-        "@types/d3-array": "^3.0.3",
-        "@types/d3-ease": "^3.0.0",
-        "@types/d3-interpolate": "^3.0.1",
-        "@types/d3-scale": "^4.0.2",
-        "@types/d3-shape": "^3.1.0",
-        "@types/d3-time": "^3.0.0",
-        "@types/d3-timer": "^3.0.0",
-        "d3-array": "^3.1.6",
-        "d3-ease": "^3.0.1",
-        "d3-interpolate": "^3.0.1",
-        "d3-scale": "^4.0.2",
-        "d3-shape": "^3.1.0",
-        "d3-time": "^3.0.0",
-        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/web/package.json
+++ b/web/package.json
@@ -14,28 +14,19 @@
     "test:e2e": "playwright test"
   },
   "dependencies": {
-    "@floating-ui/react-dom": "^2.1.9",
-    "@iconify/react": "^6",
     "@radix-ui/react-checkbox": "^1.3.7",
     "@radix-ui/react-dialog": "^1.1.19",
     "@radix-ui/react-popover": "^1.1.19",
     "@radix-ui/react-switch": "^1.3.3",
     "@radix-ui/react-tooltip": "^1.2.12",
-    "@react-oauth/google": "^0.13.5",
-    "@tanstack/react-query": "^5.101.2",
-    "chart.js": "^4",
     "clsx": "^2.1.1",
     "date-fns": "^4.4.0",
     "google-protobuf": "^4",
     "grpc-web": "^2",
-    "js-cookie": "^3.0.8",
     "lucide-react": "^1.25.0",
     "next": "16.2.10",
     "react": "19.2.7",
-    "react-chartjs-2": "^5",
-    "react-dom": "19.2.7",
-    "recharts": "^3.9.2",
-    "styled-components": "^6"
+    "react-dom": "19.2.7"
   },
   "devDependencies": {
     "@playwright/test": "^1.61.1",
@@ -44,7 +35,6 @@
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
     "@types/google-protobuf": "^3.15.12",
-    "@types/js-cookie": "^3.0.6",
     "@types/node": "^26",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/web/src/app/signin/page.tsx
+++ b/web/src/app/signin/page.tsx
@@ -5,9 +5,9 @@ import { GoogleAuthButton } from "@/components/ui/GoogleAuthButton";
 
 /**
  * /signin — the single auth screen (X-1: Google sign-in only, product-wide;
- * flows/auth.md; route standard: /signin is the only auth route). One CTA,
- * nothing else. /signup is retired; the /login stub is gone too (user
- * decision 2026-07-19) — stale links 404 on the branded page.
+ * flows/auth.md; route standard: /signin is the ONLY auth route — no
+ * /login or /signup exists, and stale links 404 on the branded page
+ * [Directive 2026-07-19]). One CTA, nothing else.
  */
 export default function SignInPage() {
   const { signInWithGoogle, loading, error } = useAuthController();

--- a/web/src/components/ui/MarketingFooter.test.tsx
+++ b/web/src/components/ui/MarketingFooter.test.tsx
@@ -70,23 +70,4 @@ describe("MarketingFooter (parity canon, SKILL.md 2026-07-19)", () => {
     );
   });
 
-  it("keeps the inline landing variant rendering for custom columns", () => {
-    render(
-      <MarketingFooter
-        inline
-        showBrand={false}
-        columns={[
-          {
-            heading: "Product",
-            links: [
-              { label: "Uptime", href: "/#pillars" },
-              { label: "Logs", href: "/#pillars" },
-            ],
-          },
-        ]}
-      />,
-    );
-    expect(screen.queryByText(/MIT licensed/)).toBeNull();
-    expect(screen.getByRole("link", { name: "Uptime" })).toHaveAttribute("href", "/#pillars");
-  });
 });

--- a/web/src/components/ui/MarketingFooter.tsx
+++ b/web/src/components/ui/MarketingFooter.tsx
@@ -2,7 +2,6 @@
 
 import { clsx } from "clsx";
 import { ShieldCheck } from "lucide-react";
-import { Fragment } from "react";
 
 export interface FooterLink {
   label: string;
@@ -17,11 +16,6 @@ export interface FooterColumn {
 export interface MarketingFooterProps {
   /** Column set — defaults to the canonical parity columns (SKILL.md). */
   columns?: FooterColumn[];
-  /**
-   * Landing v2 rendering (Figma 135:770): links inline, dot-joined.
-   * Defaults keep the stacked-column shape.
-   */
-  inline?: boolean;
   showBrand?: boolean;
   className?: string;
 }
@@ -80,7 +74,6 @@ const LICENSE_URL = "https://github.com/cuesoftinc/upstat/blob/main/LICENSE";
  */
 export function MarketingFooter({
   columns = COLUMNS,
-  inline = false,
   showBrand = true,
   className,
 }: MarketingFooterProps) {
@@ -91,16 +84,9 @@ export function MarketingFooter({
           Sibling-parity mobile structure (2026-07-19): brand + 4 columns in
           ONE responsive grid — full-width brand row at 390, 2-col link
           columns, one 5-col row at md+ (apparule/expendit stacking) */}
-      <div
-        className={clsx(
-          "mx-auto max-w-[1152px]",
-          inline
-            ? "flex flex-wrap justify-between gap-8"
-            : "grid grid-cols-2 gap-8 md:grid-cols-5",
-        )}
-      >
+      <div className="mx-auto grid max-w-[1152px] grid-cols-2 gap-8 md:grid-cols-5">
         {showBrand && (
-          <div className={clsx("flex max-w-56 flex-col gap-2", !inline && "col-span-2 md:col-span-1")}>
+          <div className="col-span-2 flex max-w-56 flex-col gap-2 md:col-span-1">
             <span className="flex items-center gap-2 text-[16px] font-semibold text-text">
               <span
                 aria-hidden="true"
@@ -117,41 +103,18 @@ export function MarketingFooter({
         )}
         {columns.map((col) => (
           <nav key={col.heading} aria-label={col.heading} className="flex flex-col gap-1.5">
-            <span
-              className={
-                inline
-                  ? // landing v2 headings (135:770): sentence case, text ink
-                    "text-[13px] font-semibold text-text"
-                  : "text-[12px] font-semibold uppercase tracking-wide text-text-2"
-              }
-            >
+            <span className="text-[12px] font-semibold uppercase tracking-wide text-text-2">
               {col.heading}
             </span>
-            {inline ? (
-              <span className="text-[13px] text-text-2">
-                {col.links.map((link, i) => (
-                  <Fragment key={link.label}>
-                    {i > 0 && " · "}
-                    <a
-                      href={link.href}
-                      className="transition-colors duration-[var(--duration-fast)] hover:text-text"
-                    >
-                      {link.label}
-                    </a>
-                  </Fragment>
-                ))}
-              </span>
-            ) : (
-              col.links.map((link) => (
-                <a
-                  key={link.label}
-                  href={link.href}
-                  className="text-[13px] text-text-2 transition-colors duration-[var(--duration-fast)] hover:text-text"
-                >
-                  {link.label}
-                </a>
-              ))
-            )}
+            {col.links.map((link) => (
+              <a
+                key={link.label}
+                href={link.href}
+                className="text-[13px] text-text-2 transition-colors duration-[var(--duration-fast)] hover:text-text"
+              >
+                {link.label}
+              </a>
+            ))}
           </nav>
         ))}
       </div>


### PR DESCRIPTION
## Summary

PR4 of the P1 polish series (`chore/code-quality`): the documented dead-dependency prune, a dead-code/smells sweep, the docs current-system sweep, and the cross-repo config-divergence catalog (for the parity pass — catalogued, not changed unilaterally).

## Dependency prune

Zero live imports verified per dep before removal (`grep` over `src`, `e2e`, `scripts`, configs):

Removed: `styled-components` (+ its `next.config.ts` compiler flag), `chart.js`, `react-chartjs-2`, `recharts`, `@tanstack/react-query`, `js-cookie` (+ `@types/js-cookie`), `@iconify/react`, `@react-oauth/google`, `@floating-ui/react-dom`.

**Kept (X-8, until monitors-v2):** `grpc-web` + `google-protobuf` and the control-plane tree (`src/proto`, `src/client.ts`, `components/libs/grpc`) — verified intact.

## Dead code & smells

- `MarketingFooter`'s unused `inline` variant axis removed (no consumer outside its own test; the footer renders the one canonical stacked shape)
- signin header comment de-archaeologized
- Sweep results (clean): no TODO/FIXME/console noise, no `as any` outside generated proto, two justified `eslint-disable`s, no orphan modules, no clickable divs, TS `strict` on, contract-type exports retained by design

## Docs current-system sweep

Keep `[Decided]`/`[Directive]` markers and the X-8 passages; remove replaced-system archaeology:
- api.md §2 now states the HTTP alert surface plainly (the struck-through retired gRPC `AlertService` sketch is gone)
- query-grammar.md: `/v1/stats` described as the events/stats surface, not a "legacy path"
- web-implementation.md: stale nav enumeration corrected to the current canonical shape; §8 no longer lists the pruned deps as pending; PR4 as-built note added

## Scripts & parity

`package.json` scripts already carry the ecosystem-canonical names (`dev/build/start/lint/typecheck/test/test:watch/test:e2e/check:boundaries`) — no upstat-local names to converge. Remaining cross-repo config divergence catalogued for the parity pass (reported to the coordinator): vitest plugin pattern, playwright port-isolation vars, lint composition, `check:boundaries` implementation language, `next typegen` in typecheck.

## Tests

All gates green locally: lint + check:boundaries (313 files), typecheck, 222 unit tests (−1: the removed dead-variant test), 38 Playwright e2e, TEST_MODE build. Diff: −679 lines (mostly lockfile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)