### PR TITLE
docs: Wave B designed — synthetics builder, status-page builder, log patterns, usage metering, RUM drill-down

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -402,6 +402,13 @@ project license, the copy reads **MIT**.
 | ThresholdOverlay | warn band / crit band / would-have-fired marker — composes over TimeseriesPanel (MI-9 test replay) — **as built (2026-07-17):** exemplar single, not a variant set |
 | ServiceCatalogRow | telemetry presence dots per pillar (present/absent ×4) · owner + repo/runbook links · default / hover |
 | ErrorGroupRow | fingerprint msg (mono) + count + sparkline + last-seen · new / ongoing / regressed |
+| **Wave B rows (designed 2026-07-20)** | |
+| SyntheticStepRow | kind: http / assertion / wait · drag grip + step index + kind chip (Mono/Micro 10) + summary (Mono/Data 13) + delete — the B7 multi-step check builder row; add via quiet "Add step" |
+| StepResultRow | result: pass / fail · step index + StatusPill ("PASS"/"FAIL") + summary + duration bar (brand; crit on fail; width ∝ duration) + fixed-precision duration — the B7 run-view timeline row |
+| StatusPageBuilderRow | drag grip + component name (inline rename) + monitor-mapping Select + delete · row order = public page order — the B7 status-page builder row; output is the existing /status/{slug} construction |
+| LogPatternRow | expand chevron + count (tnum) + 7-bucket trend sparkline + template with `<placeholders>` + dominant-level meta · expands to sample LogLine rows — the B4 Patterns tab row |
+| UsageMeterRow | pillar + unit label + MTD value (tnum) + bar vs trailing-3-month peak + plan column ("Self-host: unlimited · Cloud: announced at GA" — accuracy canon, no invented quotas/pricing) — B12 usage |
+| FunnelStageCard | stage label + count (PageTitle/20 tnum) + share-of-previous meta · stages compose with "→ n%" connectors — B6 RUM drill-down funnel |
 | ZoomStackChip | depth ×n label · default / hover (reset affordance) — MI-3 zoom breadcrumb; a QueryPill re-skin is acceptable |
 | TraceMinimap | default / span-service highlight (series color) — MI-7 |
 | WidgetTypeCell | state: default / selected · icon + label tile, one per widget type — iteration-1 addition **[built 2026-07-18]** |

--- a/docs/pages.md
+++ b/docs/pages.md
@@ -84,7 +84,7 @@ design.md §8.1.
 - Explorer: FacetSidebar (service, level, host, custom) + QueryBar + LogLine
   list (virtualized) + histogram header (MI-6); live tail (MI-4); expand
   pivots (MI-5).
-- Patterns view: auto-grouped similar lines with counts **[Later]**.
+- Patterns view **[Designed 2026-07-20]**: the Patterns tab clusters similar lines into templates — LogPatternRow (expand chevron · count · 7-bucket trend sparkline · template with `<placeholders>` · dominant level), expanding to sample LogLine rows; shares the explorer's QueryBar/facets/histogram chrome (Figma `B4 — Logs (patterns)`).
 - Retention/indexing settings per source; archive-to-object-storage
   **[Later]**.
 
@@ -103,6 +103,11 @@ design.md §8.1.
   grouped by fingerprint).
 - Website-traffic analytics live in this pillar — B6 is the product's
   analytics surface (ANA-002).
+- Analytics drill-down (U6-2) **[Designed 2026-07-20]**: per-property page —
+  funnel row (FunnelStageCard ×3: page views → sessions → conversions, demo
+  framing) · weekly-cohort retention grid (reuses the Heatmap construction;
+  cohort axes land in code) · top pages / top referrers (TopList
+  construction) (Figma `B6 — RUM analytics (drill-down, U6-2)`).
 - Property create **[Directive 2026-07-18]**: RUM property-create screen
   (site/domain → property key issuance + browser-SDK snippet; keys managed
   in B12).
@@ -114,13 +119,13 @@ design.md §8.1.
   both until migration completes within the release). B7 reads the unified
   view.
 - Monitors (existing CRUD) → "Uptime checks" within Synthetics: HTTP checks
-  (existing), multi-step API checks **[Later]**, browser checks **[Later]**.
+  (existing), multi-step API checks and browser checks **[Designed 2026-07-20]**: builder = step list (HTTP request / assertion / wait — SyntheticStepRow: add/reorder/delete) + browser-check panel (start URL · viewport Select · screenshot-on-failure toggle); run view = per-step pass/fail timeline (StepResultRow: StatusPill + duration bar) + failure screenshot (Figma `B7 — Synthetics check builder` / `B7 — Synthetic check run`).
 - UptimeCards + per-monitor page: check history, response-time chart,
   incidents, insight panel (existing ML insight surfaces here).
 - Public status pages: URL scheme **[Decided]** `status.upstat.cuesoft.io/{slug}`
   (owner-chosen slug, unique; never raw owner ids in URLs); upstat's own page
   = slug `upstat` (U0-5 config = create the slugged page over the existing
-  `GetStatusPage` data). Builder (logo, components, subscribe) **[Later]**.
+  `GetStatusPage` data). Builder **[Designed 2026-07-20]**: branding (page name · slug) + component list (StatusPageBuilderRow: rename/reorder, map to monitors via Select) + public-URL preview row — output is the existing /status/{slug} construction (Figma `B7 — Status page builder`); logo upload + subscribe remain **[Later]**.
 
 ### B8 Monitors (alerting on any signal)
 - Monitor types: uptime state (exists conceptually), metric threshold,
@@ -156,7 +161,7 @@ design.md §8.1.
 ### B12 Settings
 - Org/members/roles; **API keys & ingestion tokens** (per-pillar scopes);
   property keys (RUM); integrations (webhooks, Slack); retention per signal;
-  usage metering per pillar **[Proposed]**; privacy/data controls.
+  usage metering per pillar **[Designed 2026-07-20]** (UsageMeterRow: pillar + unit · MTD value · bar vs trailing-3-month peak · plan column reads "Self-host: unlimited · Cloud: announced at GA" per the accuracy canon — Figma `B12 — Settings (usage metering)`); privacy/data controls.
 - **Organization profile**: name, **timezone (IANA)** — all report rendering
   and time-bucketing (dashboards, uptime day boundaries, rollup display,
   scheduled reports) resolve in the org timezone; storage stays UTC


### PR DESCRIPTION
## Summary

The ratified Wave B catalog is now designed in Figma — this PR flips the deferred spec rows to **[Designed 2026-07-20]** with construction notes, and adds the six new §8.2b component rows.

**pages.md**
- **B4 Patterns view** — LogPatternRow clusters (count · trend sparkline · template with `<placeholders>`), expanding to sample LogLines; shares the explorer chrome. Frame: `B4 — Logs (patterns)`.
- **B7 multi-step + browser checks** — builder (SyntheticStepRow list: HTTP / assertion / wait, add/reorder/delete; browser panel: start URL · viewport · screenshot-on-failure) + run view (StepResultRow pass/fail timeline + failure screenshot). Frames: `B7 — Synthetics check builder`, `B7 — Synthetic check run`.
- **B7 status-page builder** — branding (name · slug) + StatusPageBuilderRow list (rename/reorder/map-to-monitor) + public-URL preview; output is the existing /status/{slug} construction. Logo upload + subscribe stay [Later]. Frame: `B7 — Status page builder`.
- **B12 usage metering** — UsageMeterRow per pillar; plan column reads "Self-host: unlimited · Cloud: announced at GA" (accuracy canon — no invented quotas/pricing). Frame: `B12 — Settings (usage metering)`.
- **B6 analytics drill-down (U6-2)** — FunnelStageCard funnel (page views → sessions → conversions, demo framing) · weekly-cohort retention (Heatmap construction) · top pages/referrers (TopList). Frame: `B6 — RUM analytics (drill-down, U6-2)`.

**design.md §8.2b** — new rows: SyntheticStepRow · StepResultRow · StatusPageBuilderRow · LogPatternRow · UsageMeterRow · FunnelStageCard (all token-bound, composed from the existing form/widget kits; descriptions on the masters carry the same contracts).

All six frames sit in the second column beside their pillar's screens, follow the container/type/token canons (micro/10 + Display styles), and were screenshot-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)