### PR TITLE
feat(web): deferred catalog Wave B — synthetics builder + runs, status-page builder, log patterns, usage metering, RUM drill-down

### DIFF
--- a/docs/pages.md
+++ b/docs/pages.md
@@ -87,11 +87,17 @@ design.md §8.1.
   URL-addressable `?limit=` up to 10k; MI-4 pause/buffer and MI-5
   expansion semantics preserved, expansion lifted to the list) + histogram
   header (MI-6); live tail (MI-4); expand pivots (MI-5).
-- Patterns view **[Designed 2026-07-20]**: a "Patterns" tab beside the
-  explorer list — LogPatternRow per clustered template (expand chevron ·
-  count · 7-bucket trend sparkline · Mono template with `<placeholders>`),
-  expanding to indented sample LogLines (Figma "B4 — Logs (patterns)");
-  implementation stays scheduled with OBS-012.
+- Patterns view **[Designed 2026-07-20; as built 2026-07-20]**: a
+  "Patterns" tab beside the explorer list (`?tab=patterns`, deep-linkable)
+  — LogPatternRow per clustered template (expand chevron · count ·
+  7-bucket trend sparkline · Mono template with `<placeholders>` ·
+  dominant-level chip), expanding to indented sample LogLines (Figma "B4 —
+  Logs (patterns)"). As built the clustering runs in the mock over the
+  same per-second line generator as the stream; shares the QueryBar/facet
+  chrome and the global time range (LIVE clusters the last 15 minutes);
+  **[Decided 2026-07-20]** ranges wider than the enumeration budget sample
+  every nth second with stride-scaled counts (rendered with a `~`). The
+  real backend clustering lands with OBS-012.
 - Retention/indexing settings per source; archive-to-object-storage
   **[Later]**.
 
@@ -113,11 +119,16 @@ design.md §8.1.
 - Property create **[Directive 2026-07-18]**: RUM property-create screen
   (site/domain → property key issuance + browser-SDK snippet; keys managed
   in B12).
-- Deeper analytics drill-down (U6-2) **[Designed 2026-07-20]**: funnel row
-  (FunnelStageCard chain — page views → sessions → conversions, per-stage
-  conversion %), retention weekly-cohort grid (the Heatmap construction
-  re-axised to cohort weeks), top pages / top referrers TopLists (Figma
-  "B6 — RUM analytics drill-down (U6-2)").
+- Deeper analytics drill-down (U6-2) **[Designed 2026-07-20; as built
+  2026-07-20]**: `/dashboard/rum/drilldown`, routed from the pillar header
+  — funnel row (FunnelStageCard chain — page views → sessions →
+  conversions, per-stage conversion %), retention weekly-cohort grid (the
+  Heatmap construction re-axised to 8 Monday-aligned cohorts × wk 0–6),
+  top pages / top referrers TopLists (Figma "B6 — RUM analytics drill-down
+  (U6-2)"). **[Decided 2026-07-20]** the conversion stage counts the
+  registered signup event (`auth_signin_completed`, api.md §3.4) and the
+  definition is labeled in-page (accuracy canon); page views/sessions are
+  the B6 summary's own numbers.
 
 ### B7 Synthetics / Uptime (the current core, absorbed)
 - **Coexistence contract [Decided]**: existing gRPC monitors ARE the uptime
@@ -127,22 +138,35 @@ design.md §8.1.
   view.
 - Monitors (existing CRUD) → "Uptime checks" within Synthetics: HTTP checks
   (existing), multi-step API checks and browser checks **[Designed
-  2026-07-20]** — the builder composes SyntheticStepRow steps (HTTP request /
-  assertion / wait; add, reorder, delete) plus a browser-check panel (URL ·
-  viewport Select · screenshot-on-failure Switch); the run view is a per-step
-  pass/fail timeline (StepResultRow + UptimeCard context + failure-screenshot
-  card). Figma "B7 — Synthetic check builder (multi-step)" and "B7 —
-  Synthetic check run (multi-step results)"; implementation stays OBS-011.
+  2026-07-20; as built 2026-07-20]** — the builder
+  (`/dashboard/uptime/new`, type tabs HTTP / Multi-step / Browser) composes
+  SyntheticStepRow steps (HTTP request / assertion / wait; add, reorder —
+  keyboard grip + pointer drag —, delete) plus a browser-check panel (URL ·
+  viewport Select · screenshot-on-failure Switch); the run view
+  (`/dashboard/uptime/checks/{id}`, `?run=` selects) is a per-step
+  pass/fail timeline (StepResultRow + UptimeCard context + failure-
+  screenshot card) with stop-at-first-failure semantics. Figma "B7 —
+  Synthetic check builder (multi-step)" and "B7 — Synthetic check run
+  (multi-step results)". **[Decided 2026-07-20]** the HTTP tab stays the
+  classic Monitor create; multi-step/browser checks are a separate
+  `/v1/synthetics` entity until monitors-v2 unifies signals; the run
+  view's UptimeCard context is derived — the monitor watching the first
+  HTTP step's host — not a configured link. The real runner lands with
+  OBS-011.
 - UptimeCards + per-monitor page: check history, response-time chart,
   incidents, insight panel (existing ML insight surfaces here).
 - Public status pages: URL scheme **[Decided]** `status.upstat.cuesoft.io/{slug}`
   (owner-chosen slug, unique; never raw owner ids in URLs); upstat's own page
   = slug `upstat` (U0-5 config = create the slugged page over the existing
-  `GetStatusPage` data). Builder **[Designed 2026-07-20]**: settings surface — branding rows (page
-  name · slug), StatusPageBuilderRow component list (add/rename/reorder,
-  monitor mapping via Select) and a public-URL preview row; the public page
-  it produces is the existing `/status/{slug}` construction (Figma "B7 —
-  Status page builder"). Subscribe affordance **[Later]**.
+  `GetStatusPage` data). Builder **[Designed 2026-07-20; as built
+  2026-07-20]**: settings surface (`/dashboard/settings/status-page`,
+  linked from the overview) — branding rows (page name · slug),
+  StatusPageBuilderRow component list (add/rename/reorder, monitor mapping
+  via Select) and a public-URL preview row; the public page it produces is
+  the existing `/status/{slug}` construction — saved names, order and the
+  page-name header render there directly (orgs without a saved document
+  keep deriving components from their live monitors). Subscribe affordance
+  **[Later]**.
 
 ### B8 Monitors (alerting on any signal)
 - Monitor types: uptime state (exists conceptually), metric threshold,
@@ -188,11 +212,15 @@ design.md §8.1.
 ### B12 Settings
 - Org/members/roles; **API keys & ingestion tokens** (per-pillar scopes);
   property keys (RUM); integrations (webhooks, Slack); retention per signal;
-  usage metering per pillar **[Designed 2026-07-20]** — /settings/usage:
-  UsageMeterRow per pillar (measure · MTD value · MTD bar scaled to the
-  largest meter · plan column verbatim "Self-host: unlimited · Cloud:
-  announced at GA", accuracy canon; Figma "B12 — Settings (usage
-  metering)"); privacy/data controls.
+  usage metering per pillar **[Designed 2026-07-20; as built 2026-07-20]**
+  — /settings/usage: UsageMeterRow per pillar (measure · MTD value · MTD
+  bar · plan column verbatim "Self-host: unlimited · Cloud: announced at
+  GA", accuracy canon; Figma "B12 — Settings (usage metering)"); values
+  computed from the seeded telemetry volumes, month boundaries in the org
+  timezone (X-10). **[Decided 2026-07-20]** the bar denominators are
+  per-pillar trailing-3-month peaks (the design.md §8.2b contract) — the
+  earlier "scaled to the largest meter" phrasing is cross-unit and
+  unimplementable as stated; privacy/data controls.
 - **Organization profile**: name, **timezone (IANA)** — all report rendering
   and time-bucketing (dashboards, uptime day boundaries, rollup display,
   scheduled reports) resolve in the org timezone; storage stays UTC

--- a/docs/web-implementation.md
+++ b/docs/web-implementation.md
@@ -389,6 +389,70 @@ homepage-uptime rule carries a weekend maintenance mute so the bucket is
 visible from boot (`e2e/monitors-grouped.spec.ts`). Interpretation
 recorded as the pages.md B8 **[Decided 2026-07-20]** line.
 
+**Wave B as-built (2026-07-20) — B7 synthetics builder + status-page
+builder · B4 log patterns · B12 usage metering · B6 RUM drill-down.**
+(1) **B7 multi-step/browser checks (OBS-011)** — `/dashboard/uptime/new`
+is the check builder (type tabs HTTP / Multi-step / Browser; the HTTP tab
+stays the classic Monitor create, replacing the old modal): SyntheticStepRow
+step list (add via the quiet composer, delete, reorder via keyboard grip
+ArrowUp/Down + pointer drag) beside the browser-check panel (URL ·
+viewport Select · screenshot-on-failure Switch); "Run once" saves then
+executes. The run view (`/dashboard/uptime/checks/{id}`, `?run=` selects a
+run, latest by default) renders the StepResultRow timeline with
+stop-at-first-failure copy ("Steps n–m not run"), a failure-screenshot
+card when the browser stage captured one, a derived UptimeCard context
+(the monitor watching the first HTTP step's host) and the run history;
+edit/delete live at `…/edit`. Mock: `/v1/synthetics` CRUD +
+`/v1/synthetics/{id}/runs` deterministic replay (codes `name_required`,
+`invalid_kind`, `steps_required`, `invalid_step_kind`, `invalid_target`,
+`invalid_expression`, `invalid_wait`, `invalid_viewport`, `name_taken`);
+seeded "checkout flow — api + web" runs every 30m and its run #482 fails
+the `body.ok == true` assertion inside the INC-42 window (neighbours
+pass — MONITORING means mitigated). (2) **B7 status-page builder** —
+`/dashboard/settings/status-page` (linked from the settings overview):
+branding rows (page name · slug), StatusPageBuilderRow list (inline
+rename, monitor-mapping Select, delete, keyboard reorder; row order =
+public page order), public-URL preview + "Open public page →". Persists
+via `GET/PUT /v1/status-page` (`name_required`, `invalid_slug`,
+`slug_taken`, `component_name_required`, `monitor_not_found`);
+`buildStatusPage` renders the saved document, so names/order/page-name
+reflect on `/status/{slug}` immediately; orgs without a document keep the
+pre-builder derive-from-monitors construction; the store's `statusSlug`
+routing key mirrors the saved slug. (3) **B4 patterns tab (OBS-012)** —
+"Logs | Patterns" tabs above the stream (`?tab=patterns`, resolved
+post-mount per the NavRail pattern); LogPatternRow (count · 7-bucket
+trend sparkline · Mono template with dimmed `<placeholders>` ·
+dominant-level chip) expands to indented sample LogLines. Clustering runs
+in the mock (`GET /v1/logs/patterns`) over the SAME per-second generator
+as the stream (`logLinesAtSecond`, extracted from `generateLogs`);
+template extraction collapses numeric/hex/version values and
+known-variable `key=` values into placeholders; ranges beyond the 3600s
+enumeration budget sample every nth second with stride-scaled counts
+(`sampled: true`, rendered with `~`); shares the QueryBar/facet subset
+(service:/level:/free text) and the global time range (LIVE = last 15m).
+(4) **B12 usage metering (OBS-012)** — `/dashboard/settings/usage`:
+UsageMeterRow per pillar; the MTD values are honest derivations of the
+seed (metrics = Σ catalog cardinality; logs = 3 lines/s × seconds MTD ×
+measured mean line bytes; traces = the APM req/s series integrated hourly
+× mean seeded span count; RUM = the B6 summary's page-view math); bars
+scale to per-pillar trailing-3-month peaks (§8.2b); plan column verbatim
+"Self-host: unlimited · Cloud: announced at GA"; month boundaries + the
+heading month resolve in the org timezone (X-10). Mock `GET /v1/usage`.
+(5) **B6 RUM drill-down (U6-2)** — `/dashboard/rum/drilldown`, routed
+from the pillar header: FunnelStageCard chain (page views → sessions →
+conversions) with → connectors; page views/sessions are the summary's own
+numbers and conversions count the registered `auth_signin_completed`
+event (~9–13% of sessions, deterministic per bucket), with the definition
+labeled in-page; weekly cohort retention re-axises the Heatmap (8
+Monday-aligned cohorts × wk 0–6, % returning, unlived weeks blank);
+sessions panel + top pages/referrers TopLists share the summary read.
+Mock `GET /v1/rum/drilldown`. Unit tests pin every computation to the
+seed (clustering determinism + count conservation, usage sums recomputed
+from source, funnel/cohort math); `e2e/wave-b.spec.ts` walks all five
+surfaces (builder CRUD round-trip + Run once, seeded failing run,
+builder→public-page reflection, patterns expand, usage vs the API's own
+sums, funnel/cohort render).
+
 **Public API reference as-built (2026-07-20, ratified).** `/docs/api` is
 the public Scalar reference (X-2): the `@scalar/api-reference-react`
 embed (`ScalarApiReference` view inside `DocsApiView`) under the
@@ -458,16 +522,16 @@ order per pages.md Part B.
 | B1 first-run | `/dashboard/onboarding` | create-org (name + IANA timezone, X-10) → send-your-first-data (ingestion key + snippet + MI-16 waiting-for-data; resolves to `/dashboard` on first datapoint) |
 | B2 | `/dashboard/dashboards` · `/dashboard/dashboards/{id}` | List (org-shared, favorites) · grid editor (MI-11/12); create flow = name → widget-picker overlay → edit mode |
 | B3 | `/dashboard/metrics` · `/dashboard/metrics/summary` | Metrics explorer (QueryBar + MI-2/3, save-to-dashboard) · metrics catalog/tag explorer |
-| B4 | `/dashboard/logs` | Logs explorer — FacetSidebar + QueryBar + virtualized LogLine list + histogram (MI-4/5/6) |
+| B4 | `/dashboard/logs` | Logs explorer — FacetSidebar + QueryBar + virtualized LogLine list + histogram (MI-4/5/6) · `?tab=patterns` = the Patterns tab (LogPatternRow clusters, OBS-012) |
 | B5 | `/dashboard/traces` · `/dashboard/traces/services/{service}` · `/dashboard/traces/explorer` · `/dashboard/traces/map` | Service list · service page (endpoints, latency distribution, deps) · trace explorer + TraceWaterfall/span drawer (MI-7) · service map |
-| B6 | `/dashboard/rum` · `/dashboard/rum/new` | RUM/analytics (pages, vitals, errors) · property create (key issuance + SDK snippet) |
-| B7 | `/dashboard/uptime` · `/dashboard/uptime/{id}` | Uptime checks (the absorbed monitor core) · per-monitor page (90d strip, response-time chart, incidents, insight panel) |
+| B6 | `/dashboard/rum` · `/dashboard/rum/new` · `/dashboard/rum/drilldown` | RUM/analytics (pages, vitals, errors) · property create (key issuance + SDK snippet) · U6-2 drill-down (funnel, weekly cohort retention, top lists) |
+| B7 | `/dashboard/uptime` · `/dashboard/uptime/{id}` · `/dashboard/uptime/new` · `/dashboard/uptime/checks/{id}` (+ `/edit`) | Uptime checks (the absorbed monitor core) · per-monitor page (90d strip, response-time chart, incidents, insight panel) · synthetic check builder (HTTP / Multi-step / Browser tabs, OBS-011) · synthetic run view (`?run=` selects; StepResultRow timeline) + builder edit |
 | B7 public | `status.upstat.cuesoft.io/{slug}` → `/status/{slug}` | Public status page — host-based rewrite onto the same app **[Proposed]**; unauthenticated, deliberately outside `/dashboard` (a separate entry point, design.md §8.4) |
 | B8 | `/dashboard/monitors` · `/dashboard/monitors/new` · `/dashboard/monitors/{id}` | Monitors list + triggered feed (MI-14) · type picker → rule editor · detail with MI-9 test-replay frame |
 | B9 | `/dashboard/incidents` · `/dashboard/incidents/{id}` | Incident feed · timeline composer (MI-10); declare-incident is a modal, not a route |
 | B10 | `/dashboard/slos` | SLO list + define (SLI source, target, window) |
 | B11 | `/dashboard/services` | Service catalog (telemetry-presence, owner, repo/runbook) |
-| B12 | `/dashboard/settings` + sub-screens `/dashboard/settings/members` · `/dashboard/settings/keys` · `/dashboard/settings/properties` · `/dashboard/settings/integrations` · `/dashboard/settings/retention` · `/dashboard/settings/org` | Org/members/roles · API keys & ingestion tokens · property keys · integrations · retention per signal · org profile (IANA timezone, X-10) |
+| B12 | `/dashboard/settings` + sub-screens `/dashboard/settings/members` · `/dashboard/settings/keys` · `/dashboard/settings/properties` · `/dashboard/settings/integrations` · `/dashboard/settings/retention` · `/dashboard/settings/org` · `/dashboard/settings/status-page` · `/dashboard/settings/usage` | Org/members/roles · API keys & ingestion tokens · property keys · integrations · retention per signal · org profile (IANA timezone, X-10) · status-page builder (B7) · usage metering per pillar (OBS-012) |
 
 Part C (mobile on-call companion) has no web routes — later phase, out of
 W0–W3 (§8). Deep-linkable state rides the query string, not new routes:
@@ -526,6 +590,11 @@ even while the real backend is still gRPC (§8).
 | Keys | ingest-key CRUD (per-pillar scopes, quotas, 24h rotation grace) · property keys + origin allowlists + rejection counters (B12, U1-7) |
 | Org & members | org profile (name + IANA timezone, X-10) · members/roles per the engineering.md §2 matrix |
 | Status page (public) | status-page read by slug — powers `/status/{slug}` unauthenticated (B7; the `GetStatusPage` data shape) |
+| Status page (builder) | `GET/PUT /v1/status-page` — the B7 builder document (branding + ordered component list; `invalid_slug`, `slug_taken`, `monitor_not_found`); the public read renders it |
+| Synthetics | `/v1/synthetics` CRUD · `GET/POST /v1/synthetics/{id}/runs` + `GET …/runs/{runId}` — multi-step/browser checks with deterministic per-step run replay, stop-at-first-failure (OBS-011; step/browser validation codes) |
+| Log patterns | `GET /v1/logs/patterns` — deterministic template clustering over the stream's own line generator (B4 Patterns tab, OBS-012) |
+| Usage | `GET /v1/usage` — month-to-date meters per pillar, computed from the seeded telemetry volumes; org-timezone month boundaries (B12, OBS-012) |
+| RUM drill-down | `GET /v1/rum/drilldown` — funnel (page views → sessions → `auth_signin_completed` conversions) + weekly cohort retention (B6 U6-2) |
 
 **Seed narrative — the docs-coherent Figma dataset.** The store seeds the
 same mock content the Figma screens render (design.md §8.3 design-prep), so
@@ -560,7 +629,13 @@ a TEST_MODE boot looks like the designs:
   active/rotation-grace/revoked states and a property key with nonzero
   rejection counters.
 - **The public status page** seeded as slug `upstat` (U0-5) — components,
-  90-day strips, incident history.
+  90-day strips, incident history; its builder document (B7) seeds the
+  same five components mapped to the live monitors, so the pre-builder
+  page and the built one are byte-coherent.
+- **One multi-step synthetic check** ("checkout flow — api + web", five
+  steps + a browser stage) with a 30m run history whose run #482 FAILS the
+  `body.ok == true` assertion inside the INC-42 window and captures a
+  failure screenshot — neighbours pass (MONITORING = mitigated).
 - **A second, empty org** reachable from the TopBar org switcher — walks
   the B1 first-run onboarding and every pillar's MI-16 empty state without
   wiping the primary seed (the mock resolves waiting-for-data to populated

--- a/web/e2e/wave-b.spec.ts
+++ b/web/e2e/wave-b.spec.ts
@@ -1,0 +1,267 @@
+import { expect, test, type Page } from "@playwright/test";
+
+/**
+ * Wave B surfaces (pages.md [Designed 2026-07-20]):
+ *  - B7 synthetics: seeded failing run + builder CRUD round-trip + Run once
+ *  - B7 status-page builder → the public /status/{slug} page reflects it
+ *  - B4 log patterns tab: clusters render, expand shows sample lines
+ *  - B12 usage metering: the rendered meters are the API's own honest sums
+ *  - B6 RUM drill-down: funnel + weekly cohort retention + top lists
+ *
+ * Shared mutable mock narrative — serial by design (playwright.config).
+ */
+test.describe.configure({ mode: "serial" });
+
+async function signIn(page: Page) {
+  await page.goto("/signin");
+  await page.getByRole("button", { name: /continue with google/i }).click();
+  await page.waitForURL("**/dashboard**");
+}
+
+async function reset(page: Page) {
+  await page.request.post("/api/mock/v1/reset");
+}
+
+/* ------------------------------------------------------------------ */
+/* B7 synthetics                                                        */
+/* ------------------------------------------------------------------ */
+
+test("B7: seeded multi-step check — failing run #482 stops at first failure", async ({
+  page,
+}) => {
+  await reset(page);
+  await signIn(page);
+
+  await page.goto("/dashboard/uptime");
+  const row = page.getByTestId("synthetic-syn_checkout");
+  await expect(row).toBeVisible();
+  await expect(row).toContainText("checkout flow — api + web");
+  await expect(row).toContainText("MULTI-STEP");
+  await row.click();
+  await page.waitForURL("**/dashboard/uptime/checks/syn_checkout**");
+  await expect(page.getByTestId("synthetic-run")).toBeVisible();
+
+  // latest run passed (INC-42 is mitigated) — run history carries the fail
+  await expect(page.getByText("PASS").first()).toBeVisible();
+  await page
+    .getByRole("list", { name: "Run history" })
+    .getByText("#482")
+    .click();
+  await expect(page.getByText("stopped at first failure")).toBeVisible();
+
+  // three executed steps; the third FAILs; 4–5 never ran
+  const steps = page.getByRole("list", { name: "Step results" });
+  await expect(steps.locator("[data-result]")).toHaveCount(3);
+  await expect(steps.locator('[data-result="fail"]')).toHaveCount(1);
+  await expect(steps.getByText("assert body.ok == true")).toBeVisible();
+  await expect(
+    page.getByText("Steps 4–5 not run — the check stops at the first failure."),
+  ).toBeVisible();
+
+  // failure-screenshot card (browser stage, screenshot-on-failure ON)
+  const screenshot = page.getByTestId("failure-screenshot");
+  await expect(screenshot).toBeVisible();
+  await expect(screenshot).toContainText(
+    "Failure screenshot — step 3 · viewport 1440 × 900",
+  );
+
+  // UptimeCard context — the monitor watching the first step's host
+  await expect(page.getByLabel("API health uptime context")).toBeVisible();
+});
+
+test("B7: builder CRUD round-trip — create, run once, edit, delete", async ({
+  page,
+}) => {
+  await reset(page);
+  await signIn(page);
+
+  await page.goto("/dashboard/uptime");
+  await page.getByTestId("new-check").click();
+  await page.waitForURL("**/dashboard/uptime/new**");
+  await expect(page.getByTestId("synthetic-builder")).toBeVisible();
+
+  // Multi-step is the default tab; compose name + two steps
+  await page.getByTestId("synthetic-name").fill("api journey e2e");
+  await page.getByTestId("step-url").fill("https://api.cuesoft.io/health");
+  await page.getByTestId("add-step").click();
+  await page.getByRole("combobox", { name: "Step kind" }).click();
+  await page.getByRole("option", { name: "Assertion" }).click();
+  await page.getByTestId("step-expression").fill("status == 200");
+  await page.getByTestId("add-step").click();
+  await expect(
+    page.getByRole("list", { name: "Check steps" }).locator("[data-kind]"),
+  ).toHaveCount(2);
+
+  // browser-check panel: URL + viewport + screenshot-on-failure
+  await page.getByTestId("browser-url").fill("https://upstat.cuesoft.io/");
+
+  // Run once — saves, executes, lands on the run view with per-step PASSes
+  await page.getByTestId("run-once").click();
+  await page.waitForURL("**/dashboard/uptime/checks/*?run=*");
+  await expect(page.getByTestId("synthetic-run")).toBeVisible();
+  await expect(page.getByText("api journey e2e · run #1")).toBeVisible();
+  const steps = page.getByRole("list", { name: "Step results" });
+  await expect(steps.locator('[data-result="pass"]')).toHaveCount(2);
+
+  // edit: rename + verify the list reflects it
+  await page.getByTestId("edit-check").click();
+  await page.waitForURL("**/edit");
+  await page.getByTestId("synthetic-name").fill("api journey e2e renamed");
+  await page.getByTestId("save-check").click();
+  await page.waitForURL("**/dashboard/uptime");
+  await expect(page.getByText("api journey e2e renamed")).toBeVisible();
+
+  // delete: the check leaves the list
+  await page.getByText("api journey e2e renamed").click();
+  await page.waitForURL("**/dashboard/uptime/checks/*");
+  await page.getByTestId("edit-check").click();
+  await page.waitForURL("**/edit");
+  await page.getByTestId("delete-check").click();
+  await page.waitForURL("**/dashboard/uptime");
+  await expect(page.getByText("api journey e2e renamed")).toHaveCount(0);
+});
+
+/* ------------------------------------------------------------------ */
+/* B7 status-page builder                                               */
+/* ------------------------------------------------------------------ */
+
+test("B7: status-page builder edits reflect on the public page", async ({
+  page,
+}) => {
+  await reset(page);
+  await signIn(page);
+
+  // reachable from the settings overview
+  await page.goto("/dashboard/settings");
+  await page.getByTestId("open-status-page-builder").click();
+  await page.waitForURL("**/dashboard/settings/status-page");
+  await expect(page.getByTestId("status-page-builder")).toBeVisible();
+
+  // rename the first component and push it one row down (keyboard grip)
+  const firstName = page.getByLabel("Component name").first();
+  await expect(firstName).toHaveValue("Homepage");
+  await firstName.fill("Web frontend");
+  await page
+    .getByRole("button", { name: "Reorder Web frontend" })
+    .press("ArrowDown");
+  await page.getByTestId("save-status-page").click();
+  await expect(page.getByText("Saved")).toBeVisible();
+
+  // public-URL preview links the slugged public construction
+  await expect(page.getByTestId("open-public-page")).toHaveAttribute(
+    "href",
+    "/status/upstat",
+  );
+
+  // the public page renders builder names in builder order
+  await page.goto("/status/upstat");
+  await expect(page.getByTestId("status-page")).toBeVisible();
+  const components = page.getByRole("list", { name: "Components" });
+  await expect(components.getByText("Web frontend")).toBeVisible();
+  const names = await components
+    .locator("li")
+    .evaluateAll((items) => items.map((li) => li.textContent ?? ""));
+  expect(names[0]).toContain("API health"); // moved above the renamed row
+  expect(names[1]).toContain("Web frontend");
+});
+
+/* ------------------------------------------------------------------ */
+/* B4 log patterns                                                      */
+/* ------------------------------------------------------------------ */
+
+test("B4: patterns tab clusters the range; rows expand to sample lines", async ({
+  page,
+}) => {
+  await reset(page);
+  await signIn(page);
+
+  await page.goto("/dashboard/logs?range=1h&tab=patterns");
+  await expect(page.getByTestId("patterns-panel")).toBeVisible();
+  const rows = page
+    .getByRole("list", { name: "Log patterns" })
+    .getByRole("button");
+  await expect(rows.first()).toBeVisible();
+  expect(await rows.count()).toBeGreaterThan(3);
+
+  // clustered variables read as <placeholders>; footer states the math
+  await expect(
+    page.getByText("<placeholders> mark the clustered variables."),
+  ).toBeVisible();
+  await expect(page.getByText(/lines into \d+ templates/)).toBeVisible();
+
+  // expand → indented sample LogLines matching the stream's shape
+  await rows.first().click();
+  const samples = page.getByRole("list", { name: "Sample lines" });
+  await expect(samples.locator("[data-level]").first()).toBeVisible();
+
+  // the tab bar swaps back to the stream
+  await page.getByTestId("logs-tab-logs").click();
+  await expect(page.getByTestId("log-list")).toBeVisible();
+});
+
+/* ------------------------------------------------------------------ */
+/* B12 usage metering                                                   */
+/* ------------------------------------------------------------------ */
+
+test("B12: usage meters render the API's own honest sums, plan verbatim", async ({
+  page,
+}) => {
+  await reset(page);
+  await signIn(page);
+
+  const report = await (await page.request.get("/api/mock/v1/usage")).json();
+  expect(report.rows).toHaveLength(4);
+
+  await page.goto("/dashboard/settings/usage");
+  await expect(page.getByTestId("settings-usage")).toBeVisible();
+  await expect(
+    page.getByText(`Month-to-date usage — ${report.month_label}`),
+  ).toBeVisible();
+
+  const meters = page.getByRole("list", { name: "Usage meters" });
+  for (const row of report.rows) {
+    const meterRow = meters.locator(`[data-pillar="${row.pillar}"]`);
+    await expect(meterRow).toContainText(row.label);
+    await expect(meterRow).toContainText(row.display); // the computed sum
+    // accuracy canon: the plan column is verbatim
+    await expect(meterRow).toContainText(
+      "Self-host: unlimited · Cloud: announced at GA",
+    );
+  }
+});
+
+/* ------------------------------------------------------------------ */
+/* B6 RUM drill-down                                                    */
+/* ------------------------------------------------------------------ */
+
+test("B6: drill-down renders funnel, honest conversion label, cohorts, top lists", async ({
+  page,
+}) => {
+  await reset(page);
+  await signIn(page);
+
+  // routed from the RUM pillar
+  await page.goto("/dashboard/rum");
+  await page.getByTestId("open-drilldown").click();
+  await page.waitForURL("**/dashboard/rum/drilldown");
+  await expect(page.getByTestId("rum-drilldown")).toBeVisible();
+
+  // funnel — three narrowing stages with share-of-previous meta
+  const funnel = page.getByLabel("Conversion funnel");
+  await expect(funnel.getByText("Page views")).toBeVisible();
+  await expect(funnel.getByText("Sessions")).toBeVisible();
+  await expect(funnel.getByText("Conversions — signup")).toBeVisible();
+  await expect(funnel.getByText(/% of previous stage/).first()).toBeVisible();
+  // the conversion definition is labeled honestly in-page
+  await expect(funnel.getByText("auth_signin_completed")).toBeVisible();
+
+  // weekly cohort retention grid (Heatmap re-axised to cohort weeks)
+  await expect(page.getByText("Retention — weekly cohorts")).toBeVisible();
+  await expect(page.getByText("cohort week 0–6 · % returning")).toBeVisible();
+  await expect(page.getByText("wk 0")).toBeVisible();
+  await expect(page.getByText("wk 6")).toBeVisible();
+
+  // top pages / referrers TopLists share the summary read
+  await expect(page.getByText("/pricing")).toBeVisible();
+  await expect(page.getByText("google.com")).toBeVisible();
+});

--- a/web/src/app/api/mock/v1/logs/patterns/route.ts
+++ b/web/src/app/api/mock/v1/logs/patterns/route.ts
@@ -1,0 +1,62 @@
+import { jsonError, jsonOk } from "@/mocks/http";
+import { clusterLogs } from "@/mocks/log-patterns";
+import { getDb, telemetryReady } from "@/mocks/store";
+import { HOUR } from "@/mocks/util";
+
+/**
+ * GET /v1/logs/patterns — B4 Patterns tab (pages.md B4 [Designed
+ * 2026-07-20], OBS-012): clusters the range's lines into templates with
+ * `<placeholders>`; shares the explorer's query grammar subset
+ * (service:/level: facets + free text) and time-range params.
+ */
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const q = url.searchParams.get("q") ?? "";
+  const now = Date.now();
+
+  let service: string | undefined;
+  let level: string | undefined;
+  const text: string[] = [];
+  for (const term of q.split(/\s+/).filter(Boolean)) {
+    const idx = term.indexOf(":");
+    if (idx === -1) {
+      text.push(term.replace(/^"|"$/g, ""));
+      continue;
+    }
+    const facet = term.slice(0, idx);
+    const value = term.slice(idx + 1);
+    if (facet === "service" && value) service = value;
+    else if (facet === "level" && value) level = value;
+    else if (value) text.push(value); // unsupported facets degrade to text
+  }
+
+  const from = url.searchParams.get("from");
+  const to = url.searchParams.get("to");
+  const fromMs = from ? Date.parse(from) : now - HOUR;
+  const toMs = to ? Date.parse(to) : now;
+  if (Number.isNaN(fromMs) || Number.isNaN(toMs) || toMs <= fromMs) {
+    return jsonError(422, "ts_out_of_range", "from/to must be RFC3339");
+  }
+
+  const db = getDb();
+  if (!telemetryReady(db)) {
+    return jsonOk({
+      patterns: [],
+      total_lines: 0,
+      bucket_ms: 0,
+      sampled: false,
+    });
+  }
+  const hero = db.heroTrace
+    ? {
+        id: db.heroTrace.trace_id,
+        startMs: Date.parse(db.heroTrace.start),
+        durationMs: db.heroTrace.duration_ms,
+        services: [...new Set(db.heroTrace.spans.map((s) => s.service))],
+      }
+    : undefined;
+
+  return jsonOk(
+    clusterLogs(fromMs, toMs, db.outage, { service, level, text }, hero),
+  );
+}

--- a/web/src/app/api/mock/v1/rum/drilldown/route.ts
+++ b/web/src/app/api/mock/v1/rum/drilldown/route.ts
@@ -1,0 +1,29 @@
+import { jsonError, jsonOk } from "@/mocks/http";
+import { buildRumDrilldown } from "@/mocks/rum-drilldown";
+import { getDb, telemetryReady } from "@/mocks/store";
+import { HOUR } from "@/mocks/util";
+
+/**
+ * GET /v1/rum/drilldown — B6 analytics drill-down (U6-2, pages.md B6
+ * [Designed 2026-07-20]): funnel (page views → sessions → conversions)
+ * + weekly-cohort retention over the queried range.
+ */
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const now = Date.now();
+  const from = url.searchParams.get("from");
+  const to = url.searchParams.get("to");
+  const fromMs = from ? Date.parse(from) : now - 4 * HOUR;
+  const toMs = to ? Date.parse(to) : now;
+  if (Number.isNaN(fromMs) || Number.isNaN(toMs) || toMs <= fromMs) {
+    return jsonError(422, "ts_out_of_range", "from/to must be RFC3339");
+  }
+  const db = getDb();
+  if (!telemetryReady(db)) {
+    return jsonOk({
+      funnel: { stages: [], conversion_event: "auth_signin_completed" },
+      retention: { weeks: 7, cohorts: [] },
+    });
+  }
+  return jsonOk(buildRumDrilldown(fromMs, toMs, now));
+}

--- a/web/src/app/api/mock/v1/status-page/route.ts
+++ b/web/src/app/api/mock/v1/status-page/route.ts
@@ -1,0 +1,77 @@
+import type { StatusPageConfig } from "@/models";
+import { jsonError, jsonOk, readJson } from "@/mocks/http";
+import { allStores, getDb } from "@/mocks/store";
+import { nextId } from "@/mocks/util";
+
+const SLUG_RE = /^[a-z0-9][a-z0-9-]{1,62}$/;
+
+/**
+ * GET /v1/status-page — the active org's builder document (pages.md B7
+ * [Designed 2026-07-20]). Orgs that never published get a blank draft
+ * (name prefilled from the org, no slug, no components).
+ */
+export async function GET() {
+  const db = getDb();
+  return jsonOk(
+    db.statusPage ?? { name: db.org.name, slug: "", components: [] },
+  );
+}
+
+/**
+ * PUT /v1/status-page — persist branding + the ordered component list.
+ * Row order is the public page order; `statusSlug` (the public routing
+ * key) mirrors the saved slug.
+ */
+export async function PUT(req: Request) {
+  const body = await readJson<Partial<StatusPageConfig>>(req);
+  if (!body) return jsonError(400, "bad_shape", "malformed JSON body");
+  const db = getDb();
+
+  const name = body.name?.trim();
+  if (!name) return jsonError(422, "name_required", "page name is required");
+  const slug = body.slug?.trim().toLowerCase();
+  if (!slug || !SLUG_RE.test(slug)) {
+    return jsonError(
+      422,
+      "invalid_slug",
+      "slug must be lowercase letters, digits and hyphens",
+    );
+  }
+  if (allStores().some((s) => s !== db && s.statusSlug === slug)) {
+    return jsonError(422, "slug_taken", "this slug belongs to another org");
+  }
+
+  const components = body.components ?? [];
+  for (const row of components) {
+    if (!row.name?.trim()) {
+      return jsonError(
+        422,
+        "component_name_required",
+        "every component needs a name",
+      );
+    }
+    if (
+      row.monitor_id !== null &&
+      !db.monitors.some((m) => m.id === row.monitor_id)
+    ) {
+      return jsonError(
+        422,
+        "monitor_not_found",
+        `no uptime check ${row.monitor_id}`,
+      );
+    }
+  }
+
+  db.statusPage = {
+    name,
+    slug,
+    components: components.map((row) => ({
+      // client drafts arrive as draft_* — the store re-keys them
+      id: row.id && !row.id.startsWith("draft_") ? row.id : nextId("spc"),
+      name: row.name.trim(),
+      monitor_id: row.monitor_id ?? null,
+    })),
+  };
+  db.statusSlug = slug;
+  return jsonOk(db.statusPage);
+}

--- a/web/src/app/api/mock/v1/synthetics/[id]/route.ts
+++ b/web/src/app/api/mock/v1/synthetics/[id]/route.ts
@@ -1,0 +1,66 @@
+import type { SyntheticCheckInput } from "@/models";
+import { jsonError, jsonOk, notFound, readJson } from "@/mocks/http";
+import { getDb } from "@/mocks/store";
+import { normalizeSteps, validateCheckInput } from "@/mocks/synthetics";
+import { iso } from "@/mocks/util";
+
+type Params = { params: Promise<{ id: string }> };
+
+/** GET /v1/synthetics/{id}. */
+export async function GET(_req: Request, { params }: Params) {
+  const { id } = await params;
+  const check = getDb().synthetics.find((c) => c.id === id);
+  return check ? jsonOk(check) : notFound("synthetic check");
+}
+
+/** PATCH /v1/synthetics/{id} — rename / edit steps / browser panel. */
+export async function PATCH(req: Request, { params }: Params) {
+  const { id } = await params;
+  const db = getDb();
+  const check = db.synthetics.find((c) => c.id === id);
+  if (!check) return notFound("synthetic check");
+  const body = await readJson<Partial<SyntheticCheckInput>>(req);
+  if (!body) return jsonError(400, "bad_shape", "malformed JSON body");
+  const merged: Partial<SyntheticCheckInput> = {
+    name: body.name ?? check.name,
+    kind: body.kind ?? check.kind,
+    steps:
+      body.steps ??
+      (check.steps.map((s) =>
+        s.kind === "http"
+          ? { kind: "http", method: s.method!, url: s.url! }
+          : s.kind === "assertion"
+            ? { kind: "assertion", expression: s.expression! }
+            : { kind: "wait", wait_ms: s.wait_ms! },
+      ) as SyntheticCheckInput["steps"]),
+    browser: body.browser === undefined ? check.browser : body.browser,
+  };
+  const invalid = validateCheckInput(merged);
+  if (invalid) return jsonError(422, invalid.code, invalid.message);
+  const name = merged.name!.trim();
+  if (
+    db.synthetics.some(
+      (c) => c.id !== id && c.name.toLowerCase() === name.toLowerCase(),
+    )
+  ) {
+    return jsonError(422, "name_taken", "a check with this name exists");
+  }
+  check.name = name;
+  check.kind = merged.kind!;
+  if (body.steps) check.steps = normalizeSteps(body.steps);
+  if (body.browser !== undefined) check.browser = body.browser;
+  if (body.interval_seconds) check.interval_seconds = body.interval_seconds;
+  check.updated_at = iso(Date.now());
+  return jsonOk(check);
+}
+
+/** DELETE /v1/synthetics/{id}. */
+export async function DELETE(_req: Request, { params }: Params) {
+  const { id } = await params;
+  const db = getDb();
+  const idx = db.synthetics.findIndex((c) => c.id === id);
+  if (idx === -1) return notFound("synthetic check");
+  db.synthetics.splice(idx, 1);
+  delete db.syntheticRuns[id];
+  return jsonOk({ deleted: true });
+}

--- a/web/src/app/api/mock/v1/synthetics/[id]/runs/[runId]/route.ts
+++ b/web/src/app/api/mock/v1/synthetics/[id]/runs/[runId]/route.ts
@@ -1,0 +1,11 @@
+import { jsonOk, notFound } from "@/mocks/http";
+import { getDb } from "@/mocks/store";
+
+type Params = { params: Promise<{ id: string; runId: string }> };
+
+/** GET /v1/synthetics/{id}/runs/{runId} — one run's per-step results. */
+export async function GET(_req: Request, { params }: Params) {
+  const { id, runId } = await params;
+  const run = (getDb().syntheticRuns[id] ?? []).find((r) => r.id === runId);
+  return run ? jsonOk(run) : notFound("synthetic run");
+}

--- a/web/src/app/api/mock/v1/synthetics/[id]/runs/route.ts
+++ b/web/src/app/api/mock/v1/synthetics/[id]/runs/route.ts
@@ -1,0 +1,37 @@
+import { jsonError, jsonOk, notFound } from "@/mocks/http";
+import { getDb } from "@/mocks/store";
+import { executeRun } from "@/mocks/synthetics";
+
+type Params = { params: Promise<{ id: string }> };
+
+/** GET /v1/synthetics/{id}/runs — newest first. */
+export async function GET(_req: Request, { params }: Params) {
+  const { id } = await params;
+  const db = getDb();
+  if (!db.synthetics.some((c) => c.id === id)) {
+    return notFound("synthetic check");
+  }
+  return jsonOk(db.syntheticRuns[id] ?? []);
+}
+
+/**
+ * POST /v1/synthetics/{id}/runs — "Run once": executes the check's steps
+ * deterministically (per-step results, stop-at-first-failure semantics).
+ */
+export async function POST(_req: Request, { params }: Params) {
+  const { id } = await params;
+  const db = getDb();
+  const check = db.synthetics.find((c) => c.id === id);
+  if (!check) return notFound("synthetic check");
+  if (check.steps.length === 0 && check.kind === "multi_step") {
+    return jsonError(422, "steps_required", "the check has no steps to run");
+  }
+  const runs = (db.syntheticRuns[id] ??= []);
+  const nextNumber = runs.length > 0 ? runs[0].number + 1 : 1;
+  const run = executeRun(check, nextNumber, Date.now());
+  runs.unshift(run);
+  check.last_run_id = run.id;
+  check.last_run_status = run.status;
+  check.last_run_at = run.started_at;
+  return jsonOk(run, 201);
+}

--- a/web/src/app/api/mock/v1/synthetics/route.ts
+++ b/web/src/app/api/mock/v1/synthetics/route.ts
@@ -1,0 +1,40 @@
+import type { SyntheticCheck, SyntheticCheckInput } from "@/models";
+import { jsonError, jsonOk, readJson } from "@/mocks/http";
+import { getDb } from "@/mocks/store";
+import { normalizeSteps, validateCheckInput } from "@/mocks/synthetics";
+import { iso, nextId } from "@/mocks/util";
+
+/** GET /v1/synthetics — multi-step + browser checks (pages.md B7, OBS-011). */
+export async function GET() {
+  return jsonOk(getDb().synthetics);
+}
+
+/** POST /v1/synthetics — the builder's Save check. */
+export async function POST(req: Request) {
+  const body = await readJson<Partial<SyntheticCheckInput>>(req);
+  if (!body) return jsonError(400, "bad_shape", "malformed JSON body");
+  const invalid = validateCheckInput(body);
+  if (invalid) return jsonError(422, invalid.code, invalid.message);
+  const db = getDb();
+  const name = body.name!.trim();
+  if (db.synthetics.some((c) => c.name.toLowerCase() === name.toLowerCase())) {
+    return jsonError(422, "name_taken", "a check with this name exists");
+  }
+  const now = Date.now();
+  const check: SyntheticCheck = {
+    id: nextId("syn"),
+    name,
+    kind: body.kind!,
+    steps: normalizeSteps(body.steps ?? []),
+    browser: body.browser ?? null,
+    interval_seconds: body.interval_seconds ?? 1800,
+    last_run_id: null,
+    last_run_status: null,
+    last_run_at: null,
+    created_at: iso(now),
+    updated_at: iso(now),
+  };
+  db.synthetics.unshift(check);
+  db.syntheticRuns[check.id] = [];
+  return jsonOk(check, 201);
+}

--- a/web/src/app/api/mock/v1/usage/route.ts
+++ b/web/src/app/api/mock/v1/usage/route.ts
@@ -1,0 +1,20 @@
+import { jsonOk } from "@/mocks/http";
+import { getDb, telemetryReady } from "@/mocks/store";
+import { buildUsageReport, monthLabel } from "@/mocks/usage";
+
+/**
+ * GET /v1/usage — B12 usage metering (pages.md B12 [Designed 2026-07-20],
+ * OBS-012): month-to-date meters per pillar computed from the seeded
+ * telemetry volumes (accuracy canon).
+ */
+export async function GET() {
+  const db = getDb();
+  const now = Date.now();
+  if (!telemetryReady(db)) {
+    return jsonOk({
+      month_label: monthLabel(now, db.org.timezone || "UTC"),
+      rows: [],
+    });
+  }
+  return jsonOk(buildUsageReport(db, now));
+}

--- a/web/src/app/dashboard/logs/PatternsPanel.tsx
+++ b/web/src/app/dashboard/logs/PatternsPanel.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { EmptyState } from "@/components/ui/EmptyState";
+import { LogPatternRow } from "@/components/ui/LogPatternRow";
+import { Skeleton } from "@/components/ui/Skeleton";
+import { useLogPatternsController } from "@/controllers/logs";
+
+function fmtLines(n: number): string {
+  return n >= 1000 ? `${(n / 1000).toFixed(1)}k` : String(n);
+}
+
+/**
+ * B4 Patterns tab (Figma "B4 — Logs (patterns)", 333:14165) — LogPatternRow
+ * per clustered template; expand shows indented sample lines. Shares the
+ * explorer's QueryBar/facets/histogram chrome (the page renders those);
+ * time-range aware via the global TimePicker (LIVE = the last 15 minutes).
+ */
+export function PatternsPanel({
+  activeQuery,
+  live,
+}: {
+  activeQuery: string;
+  live: boolean;
+}) {
+  const patterns = useLogPatternsController(activeQuery, true);
+  const result = patterns.data;
+
+  if (patterns.loading || !result) {
+    return (
+      <div className="flex flex-col gap-2" data-testid="patterns-panel">
+        {Array.from({ length: 6 }, (_, i) => (
+          <Skeleton key={i} kind="line" />
+        ))}
+      </div>
+    );
+  }
+
+  if (result.patterns.length === 0) {
+    return (
+      <div data-testid="patterns-panel">
+        <EmptyState pillar="logs" />
+      </div>
+    );
+  }
+
+  const windowLabel = live ? "the last 15 minutes" : "the selected range";
+
+  return (
+    <div
+      className="flex min-h-0 flex-col overflow-y-auto"
+      data-testid="patterns-panel"
+    >
+      <ul aria-label="Log patterns">
+        {result.patterns.map((pattern) => (
+          <li key={pattern.template}>
+            <LogPatternRow
+              template={pattern.template}
+              count={pattern.count}
+              dominantLevel={pattern.dominant_level}
+              trend={pattern.trend}
+              samples={pattern.samples}
+            />
+          </li>
+        ))}
+      </ul>
+      <p className="px-2 py-3 text-[12px] text-text-2">
+        Patterns cluster {windowLabel} — {result.sampled ? "~" : ""}
+        {fmtLines(result.total_lines)} lines into {result.patterns.length}{" "}
+        templates. &lt;placeholders&gt; mark the clustered variables.
+      </p>
+    </div>
+  );
+}

--- a/web/src/app/dashboard/logs/page.tsx
+++ b/web/src/app/dashboard/logs/page.tsx
@@ -14,9 +14,19 @@ import {
   computeVirtualWindow,
   type WindowExtra,
 } from "@/controllers/virtual-window";
+import { PatternsPanel } from "./PatternsPanel";
 
 /** Pre-measurement estimate for an expanded row (corrected on paint). */
 const EXPANDED_FALLBACK_PX = 180;
+
+type LogsTab = "logs" | "patterns";
+
+/** `?tab=patterns` — deep-linkable tab state (design.md §1 query duality). */
+function tabFromUrl(): LogsTab {
+  if (typeof window === "undefined") return "logs";
+  const raw = new URLSearchParams(window.location.search).get("tab");
+  return raw === "patterns" ? "patterns" : "logs";
+}
 
 /**
  * B4 logs explorer (Figma 128:1236) — FacetSidebar + QueryBar + LogLine
@@ -28,6 +38,21 @@ export default function LogsPage() {
   const listRef = useRef<HTMLDivElement>(null);
   // §5: j/k walk the log lines; Enter expands (MI-17 cheatsheet rows)
   useLogLineKeys(listRef);
+
+  // B4 Patterns tab ([Designed 2026-07-20]) beside the explorer list
+  const [tab, setTab] = useState<LogsTab>(tabFromUrl);
+  const switchTab = (next: LogsTab) => {
+    setTab(next);
+    const params = new URLSearchParams(window.location.search);
+    if (next === "patterns") params.set("tab", "patterns");
+    else params.delete("tab");
+    const qsStr = params.toString();
+    window.history.replaceState(
+      null,
+      "",
+      `${window.location.pathname}${qsStr ? `?${qsStr}` : ""}`,
+    );
+  };
 
   const facets = ctrl.base.data?.facets ?? {};
   const histogram = ctrl.base.data?.histogram ?? [];
@@ -193,76 +218,109 @@ export default function LogsPage() {
             )}
           </header>
 
+          {/* Logs | Patterns tab bar (B4 [Designed 2026-07-20]) */}
           <div
-            ref={listRef}
-            onScroll={onScroll}
-            data-testid="log-list"
-            className="min-h-0 flex-1 overflow-y-auto"
+            role="tablist"
+            aria-label="Explorer view"
+            className="flex gap-5 border-b border-border"
           >
-            {ctrl.base.loading && !ctrl.live ? (
-              <div className="flex flex-col gap-1">
-                {Array.from({ length: 10 }, (_, i) => (
-                  <Skeleton key={i} kind="line" />
-                ))}
-              </div>
-            ) : empty ? (
-              <EmptyState pillar="logs" waiting={ctrl.live} />
-            ) : (
-              <ul aria-label="Log lines" data-testid="log-lines">
-                {win.padTop > 0 && (
-                  <li
-                    aria-hidden="true"
-                    data-testid="log-spacer-top"
-                    style={{ height: win.padTop }}
-                  />
-                )}
-                {ascending.slice(win.start, win.end).map((event) => {
-                  const expanded = expandedIds.has(event.id);
-                  return (
-                    <li
-                      key={event.id}
-                      // measure expanded rows for exact spacer math (an
-                      // off-screen expanded row keeps its last measurement)
-                      ref={
-                        expanded
-                          ? (el) => {
-                              if (!el) return;
-                              const px = el.offsetHeight;
-                              setMeasured((prev) =>
-                                prev.get(event.id) === px
-                                  ? prev
-                                  : new Map(prev).set(event.id, px),
-                              );
-                            }
-                          : undefined
-                      }
-                    >
-                      <LogLine
-                        event={event}
-                        onPivot={ctrl.pivot}
-                        expanded={expanded}
-                        onExpandedChange={(next) =>
-                          setExpandedIds((prev) => {
-                            const set = new Set(prev);
-                            if (next) set.add(event.id);
-                            else set.delete(event.id);
-                            return set;
-                          })
-                        }
-                      />
-                    </li>
-                  );
-                })}
-                {win.padBottom > 0 && (
-                  <li
-                    aria-hidden="true"
-                    data-testid="log-spacer-bottom"
-                    style={{ height: win.padBottom }}
-                  />
-                )}
-              </ul>
-            )}
+            {(
+              [
+                ["logs", "Logs"],
+                ["patterns", "Patterns"],
+              ] as const
+            ).map(([value, label]) => (
+              <button
+                key={value}
+                role="tab"
+                aria-selected={tab === value}
+                onClick={() => switchTab(value)}
+                data-testid={`logs-tab-${value}`}
+                className={
+                  tab === value
+                    ? "-mb-px border-b-2 border-brand pb-2 text-[13px] font-medium text-brand"
+                    : "pb-2 text-[13px] text-text-2 transition-colors duration-[var(--duration-fast)] hover:text-text"
+                }
+              >
+                {label}
+              </button>
+            ))}
           </div>
+
+          {tab === "patterns" ? (
+            <PatternsPanel activeQuery={ctrl.activeQuery} live={ctrl.live} />
+          ) : (
+            <div
+              ref={listRef}
+              onScroll={onScroll}
+              data-testid="log-list"
+              className="min-h-0 flex-1 overflow-y-auto"
+            >
+              {ctrl.base.loading && !ctrl.live ? (
+                <div className="flex flex-col gap-1">
+                  {Array.from({ length: 10 }, (_, i) => (
+                    <Skeleton key={i} kind="line" />
+                  ))}
+                </div>
+              ) : empty ? (
+                <EmptyState pillar="logs" waiting={ctrl.live} />
+              ) : (
+                <ul aria-label="Log lines" data-testid="log-lines">
+                  {win.padTop > 0 && (
+                    <li
+                      aria-hidden="true"
+                      data-testid="log-spacer-top"
+                      style={{ height: win.padTop }}
+                    />
+                  )}
+                  {ascending.slice(win.start, win.end).map((event) => {
+                    const expanded = expandedIds.has(event.id);
+                    return (
+                      <li
+                        key={event.id}
+                        // measure expanded rows for exact spacer math (an
+                        // off-screen expanded row keeps its last measurement)
+                        ref={
+                          expanded
+                            ? (el) => {
+                                if (!el) return;
+                                const px = el.offsetHeight;
+                                setMeasured((prev) =>
+                                  prev.get(event.id) === px
+                                    ? prev
+                                    : new Map(prev).set(event.id, px),
+                                );
+                              }
+                            : undefined
+                        }
+                      >
+                        <LogLine
+                          event={event}
+                          onPivot={ctrl.pivot}
+                          expanded={expanded}
+                          onExpandedChange={(next) =>
+                            setExpandedIds((prev) => {
+                              const set = new Set(prev);
+                              if (next) set.add(event.id);
+                              else set.delete(event.id);
+                              return set;
+                            })
+                          }
+                        />
+                      </li>
+                    );
+                  })}
+                  {win.padBottom > 0 && (
+                    <li
+                      aria-hidden="true"
+                      data-testid="log-spacer-bottom"
+                      style={{ height: win.padBottom }}
+                    />
+                  )}
+                </ul>
+              )}
+            </div>
+          )}
         </section>
       </div>
     </div>

--- a/web/src/app/dashboard/logs/page.tsx
+++ b/web/src/app/dashboard/logs/page.tsx
@@ -39,8 +39,14 @@ export default function LogsPage() {
   // §5: j/k walk the log lines; Enter expands (MI-17 cheatsheet rows)
   useLogLineKeys(listRef);
 
-  // B4 Patterns tab ([Designed 2026-07-20]) beside the explorer list
-  const [tab, setTab] = useState<LogsTab>(tabFromUrl);
+  // B4 Patterns tab ([Designed 2026-07-20]) beside the explorer list.
+  // Server renders the Logs tab; ?tab= resolves after mount, deferred a
+  // tick (the NavRail/use-request pattern) so SSR stays deterministic.
+  const [tab, setTab] = useState<LogsTab>("logs");
+  useEffect(() => {
+    const t = window.setTimeout(() => setTab(tabFromUrl()), 0);
+    return () => window.clearTimeout(t);
+  }, []);
   const switchTab = (next: LogsTab) => {
     setTab(next);
     const params = new URLSearchParams(window.location.search);

--- a/web/src/app/dashboard/rum/drilldown/page.tsx
+++ b/web/src/app/dashboard/rum/drilldown/page.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { Fragment, useMemo, useState } from "react";
+import { ArrowRight } from "lucide-react";
+import { Button } from "@/components/ui/Button";
+import { FunnelStageCard } from "@/components/ui/FunnelStageCard";
+import { Heatmap } from "@/components/ui/Heatmap";
+import { Select } from "@/components/ui/Select";
+import { Skeleton } from "@/components/ui/Skeleton";
+import { TimeseriesPanel } from "@/components/ui/TimeseriesPanel";
+import { TopList } from "@/components/ui/TopList";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { useRumDrilldownController } from "@/controllers/rum";
+import { useTimeRange } from "@/controllers/time-range";
+
+function fmtK(n: number): string {
+  return n >= 1000 ? `${(n / 1000).toFixed(1)}k` : String(n);
+}
+
+/** "2026-06-08T00:00:00.000Z" → "Jun 8" (cohort axis labels). */
+function cohortLabel(startIso: string): string {
+  const d = new Date(startIso);
+  return d.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+/**
+ * B6 RUM drill-down (U6-2; Figma "B6 — RUM analytics drill-down", 335:2) —
+ * funnel (FunnelStageCard chain: page views → sessions → conversions),
+ * sessions panel, top pages / top referrers TopLists, and the weekly-
+ * cohort retention grid (the Heatmap construction re-axised to cohort
+ * weeks). Conversions count the registered signup event — labeled
+ * honestly in-page.
+ */
+export default function RumDrilldownPage() {
+  const router = useRouter();
+  const time = useTimeRange();
+  const { summary, drilldown, properties } = useRumDrilldownController({
+    from: time.fromIso,
+    to: time.toIso,
+  });
+  const [property, setProperty] = useState<string | null>(null);
+
+  const s = summary.data;
+  const d = drilldown.data;
+  const activeProperty = property ?? (properties.data ?? [])[0]?.id ?? null;
+  const propertyName =
+    (properties.data ?? []).find((p) => p.id === activeProperty)?.name ?? "—";
+
+  const sessionSeries = useMemo(() => {
+    const points = (s?.series ?? []).map((b) => ({
+      ts: b.bucket,
+      value: Math.round(b.count / 2.6),
+    }));
+    return [{ name: "sessions", tags: {}, points }];
+  }, [s?.series]);
+
+  const retentionGrid = useMemo(() => {
+    const cohorts = d?.retention.cohorts ?? [];
+    const weeks = d?.retention.weeks ?? 7;
+    return {
+      columns: cohorts.map((c) => cohortLabel(c.start)),
+      rows: Array.from({ length: weeks }, (_, w) => `wk ${w}`),
+      // Heatmap wants values[row][col] — rows are week offsets here
+      values: Array.from({ length: weeks }, (_, w) =>
+        cohorts.map((c) => c.values[w] ?? 0),
+      ),
+    };
+  }, [d?.retention]);
+
+  const noData = !summary.loading && (s?.page_views ?? 0) === 0;
+
+  return (
+    <div className="flex flex-col gap-6 px-6 py-5" data-testid="rum-drilldown">
+      <header className="flex flex-wrap items-center gap-4">
+        <h1 className="text-[20px] font-semibold">RUM — drill-down</h1>
+        <Select
+          options={(properties.data ?? []).map((p) => ({
+            value: p.id,
+            label: p.name,
+          }))}
+          value={activeProperty}
+          onValueChange={setProperty}
+          placeholder="No properties"
+          aria-label="Property"
+          className="min-w-56"
+        />
+        <Button
+          className="ml-auto"
+          onClick={() => router.push("/dashboard/rum/new")}
+          data-testid="add-property"
+        >
+          Add property
+        </Button>
+      </header>
+
+      {noData ? (
+        <EmptyState pillar="rum" />
+      ) : (
+        <>
+          {/* funnel — FunnelStageCard chain with → connectors */}
+          <section
+            aria-label="Conversion funnel"
+            className="flex flex-col gap-2"
+          >
+            <div className="flex flex-wrap items-center gap-3">
+              {drilldown.loading || !d
+                ? Array.from({ length: 3 }, (_, i) => (
+                    <Skeleton key={i} kind="value" className="min-w-56" />
+                  ))
+                : d.funnel.stages.map((stage, i) => (
+                    <Fragment key={stage.key}>
+                      {i > 0 && (
+                        <ArrowRight
+                          aria-hidden="true"
+                          className="size-4 shrink-0 text-text-2"
+                        />
+                      )}
+                      <FunnelStageCard
+                        label={stage.label}
+                        count={stage.count}
+                        pctOfPrevious={stage.pct_of_previous}
+                      />
+                    </Fragment>
+                  ))}
+            </div>
+            {/* the honest conversion definition (accuracy canon) */}
+            {d && (
+              <p className="text-[12px] text-text-2">
+                Conversion ={" "}
+                <code className="font-data">{d.funnel.conversion_event}</code>{" "}
+                events (signup) over the selected range.
+              </p>
+            )}
+          </section>
+
+          <div className="grid grid-cols-1 gap-5 xl:grid-cols-[minmax(0,1.2fr)_minmax(0,1fr)_minmax(0,1fr)]">
+            <TimeseriesPanel
+              title={`Sessions — ${propertyName}`}
+              query={`rum:sessions{property:${propertyName}} by device`}
+              series={sessionSeries}
+              mode="bars"
+              loading={summary.loading}
+              height={200}
+              onZoomRange={time.zoomBy}
+              onZoomReset={time.resetZoom}
+            />
+            <section
+              aria-labelledby="dd-top-pages-heading"
+              className="rounded-(--radius) border border-border bg-bg-elev p-4"
+            >
+              <h2
+                id="dd-top-pages-heading"
+                className="mb-3 text-[13px] text-text-2"
+              >
+                Top pages
+              </h2>
+              <TopList
+                loading={summary.loading}
+                entries={(s?.top_pages ?? []).map((p) => ({
+                  label: p.value,
+                  value: p.count,
+                  display: fmtK(p.count),
+                }))}
+              />
+            </section>
+            <section
+              aria-labelledby="dd-top-referrers-heading"
+              className="rounded-(--radius) border border-border bg-bg-elev p-4"
+            >
+              <h2
+                id="dd-top-referrers-heading"
+                className="mb-3 text-[13px] text-text-2"
+              >
+                Top referrers
+              </h2>
+              <TopList
+                loading={summary.loading}
+                entries={(s?.top_referrers ?? []).map((p) => ({
+                  label: p.value,
+                  value: p.count,
+                  display: fmtK(p.count),
+                }))}
+              />
+            </section>
+          </div>
+
+          <section
+            aria-labelledby="retention-heading"
+            className="flex flex-col gap-3"
+          >
+            <h2 id="retention-heading" className="text-[16px] font-semibold">
+              Retention — weekly cohorts
+            </h2>
+            <div className="w-fit max-w-full rounded-(--radius) border border-border bg-bg-elev p-4">
+              <p className="mb-3 text-[12px] text-text-2">
+                cohort week 0–6 · % returning
+              </p>
+              {drilldown.loading || !d ? (
+                <Skeleton kind="panel-axis" style={{ height: 140 }} />
+              ) : (
+                <Heatmap
+                  columns={retentionGrid.columns}
+                  rows={retentionGrid.rows}
+                  values={retentionGrid.values}
+                />
+              )}
+            </div>
+          </section>
+        </>
+      )}
+    </div>
+  );
+}

--- a/web/src/app/dashboard/rum/page.tsx
+++ b/web/src/app/dashboard/rum/page.tsx
@@ -87,7 +87,14 @@ export default function RumPage() {
           className="min-w-56"
         />
         <Button
+          kind="quiet"
           className="ml-auto"
+          onClick={() => router.push("/dashboard/rum/drilldown")}
+          data-testid="open-drilldown"
+        >
+          Drill-down →
+        </Button>
+        <Button
           onClick={() => router.push("/dashboard/rum/new")}
           data-testid="add-property"
         >

--- a/web/src/app/dashboard/settings/page.tsx
+++ b/web/src/app/dashboard/settings/page.tsx
@@ -9,6 +9,7 @@ import {
   PrivacySection,
   RetentionSection,
   StatusPageSection,
+  UsageLinkSection,
 } from "./sections";
 
 /**
@@ -28,6 +29,7 @@ export default function SettingsPage() {
         <div className="flex min-w-0 flex-col gap-10">
           <IntegrationsSection />
           <StatusPageSection />
+          <UsageLinkSection />
           <RetentionSection />
           <AppearanceSection />
           <PrivacySection />

--- a/web/src/app/dashboard/settings/page.tsx
+++ b/web/src/app/dashboard/settings/page.tsx
@@ -8,6 +8,7 @@ import {
   OrgSection,
   PrivacySection,
   RetentionSection,
+  StatusPageSection,
 } from "./sections";
 
 /**
@@ -26,6 +27,7 @@ export default function SettingsPage() {
         </div>
         <div className="flex min-w-0 flex-col gap-10">
           <IntegrationsSection />
+          <StatusPageSection />
           <RetentionSection />
           <AppearanceSection />
           <PrivacySection />

--- a/web/src/app/dashboard/settings/sections.tsx
+++ b/web/src/app/dashboard/settings/sections.tsx
@@ -461,6 +461,30 @@ export function StatusPageSection() {
 }
 
 /* ------------------------------------------------------------------ */
+/* Usage metering (B12 [Designed 2026-07-20], OBS-012)                  */
+/* ------------------------------------------------------------------ */
+
+export function UsageLinkSection() {
+  return (
+    <section aria-labelledby="usage-heading" className="flex flex-col gap-3">
+      <SectionHeading id="usage-heading">Usage metering</SectionHeading>
+      <div className="flex items-center justify-between gap-4 rounded-(--radius) border border-border bg-bg-elev px-3 py-2">
+        <span className="text-[13px] leading-[1.45] text-text-2">
+          Month-to-date ingestion per pillar
+        </span>
+        <Link
+          href="/dashboard/settings/usage"
+          className="shrink-0 rounded-(--radius) border border-border px-3 py-1.5 text-[13px] text-text transition-colors duration-[var(--duration-fast)] hover:bg-bg"
+          data-testid="open-usage"
+        >
+          View usage →
+        </Link>
+      </div>
+    </section>
+  );
+}
+
+/* ------------------------------------------------------------------ */
 /* Appearance (theme-parity canon, SKILL.md 2026-07-19)                 */
 /* ------------------------------------------------------------------ */
 

--- a/web/src/app/dashboard/settings/sections.tsx
+++ b/web/src/app/dashboard/settings/sections.tsx
@@ -6,6 +6,7 @@
  * Views render controller state only; all mutations ride the controllers.
  */
 
+import Link from "next/link";
 import { useMemo, useState } from "react";
 import { APIKeyRow } from "@/components/ui/APIKeyRow";
 import { AlertChannelCard } from "@/components/ui/AlertChannelCard";
@@ -431,6 +432,33 @@ const PRIVACY_ROWS = [
   { label: "Raw IP addresses", value: "never stored" },
   { label: "Export & delete", value: "self-serve via API, org-scoped" },
 ];
+
+/* ------------------------------------------------------------------ */
+/* Status page (B7 builder handoff, [Designed 2026-07-20])              */
+/* ------------------------------------------------------------------ */
+
+export function StatusPageSection() {
+  return (
+    <section
+      aria-labelledby="status-page-heading"
+      className="flex flex-col gap-3"
+    >
+      <SectionHeading id="status-page-heading">Status page</SectionHeading>
+      <div className="flex items-center justify-between gap-4 rounded-(--radius) border border-border bg-bg-elev px-3 py-2">
+        <span className="text-[13px] leading-[1.45] text-text-2">
+          Branding, slug and the published component list
+        </span>
+        <Link
+          href="/dashboard/settings/status-page"
+          className="shrink-0 rounded-(--radius) border border-border px-3 py-1.5 text-[13px] text-text transition-colors duration-[var(--duration-fast)] hover:bg-bg"
+          data-testid="open-status-page-builder"
+        >
+          Open builder →
+        </Link>
+      </div>
+    </section>
+  );
+}
 
 /* ------------------------------------------------------------------ */
 /* Appearance (theme-parity canon, SKILL.md 2026-07-19)                 */

--- a/web/src/app/dashboard/settings/status-page/ids.ts
+++ b/web/src/app/dashboard/settings/status-page/ids.ts
@@ -1,0 +1,7 @@
+let counter = 0;
+
+/** Client-side draft ids for new builder rows (server re-keys on save). */
+export function nextComponentId(): string {
+  counter += 1;
+  return `draft_spc_${counter}`;
+}

--- a/web/src/app/dashboard/settings/status-page/page.tsx
+++ b/web/src/app/dashboard/settings/status-page/page.tsx
@@ -1,0 +1,228 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import { Button } from "@/components/ui/Button";
+import { Input } from "@/components/ui/Input";
+import { SettingsRow } from "@/components/ui/SettingsRow";
+import { Skeleton } from "@/components/ui/Skeleton";
+import { StatusPageBuilderRow } from "@/components/ui/StatusPageBuilderRow";
+import type { StatusPageConfig } from "@/models";
+import { useMonitorsController } from "@/controllers/monitors";
+import { useStatusPageBuilderController } from "@/controllers/status";
+import { nextComponentId } from "./ids";
+
+/**
+ * B7 status-page builder (Figma "B7 — Status page builder", 331:12857) —
+ * branding rows (page name · slug), StatusPageBuilderRow component list
+ * (add / rename / reorder / monitor mapping / delete; row order = public
+ * page order) and the public-URL preview. The public page it produces is
+ * the existing /status/{slug} construction.
+ */
+export default function StatusPageBuilderPage() {
+  const { config, save } = useStatusPageBuilderController();
+  const monitors = useMonitorsController();
+  const [draft, setDraft] = useState<StatusPageConfig | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [saved, setSaved] = useState(false);
+
+  if (config.loading || monitors.loading || !config.data) {
+    return (
+      <div className="flex flex-col gap-4 px-6 py-5">
+        <Skeleton kind="line" className="w-64" />
+        <Skeleton kind="panel-axis" style={{ height: 320 }} />
+      </div>
+    );
+  }
+
+  const current = draft ?? config.data;
+  const dirty = draft !== null;
+
+  const monitorOptions = (monitors.data ?? []).map((m) => ({
+    value: m.id,
+    label: m.name,
+  }));
+
+  const mutate = (next: StatusPageConfig) => setDraft(next);
+
+  const persist = async () => {
+    setError(null);
+    try {
+      await save(current);
+      setDraft(null);
+      setSaved(true);
+      window.setTimeout(() => setSaved(false), 1200);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "could not save the page");
+    }
+  };
+
+  const move = (index: number, delta: -1 | 1) => {
+    const to = index + delta;
+    if (to < 0 || to >= current.components.length) return;
+    const components = [...current.components];
+    [components[index], components[to]] = [components[to], components[index]];
+    mutate({ ...current, components });
+  };
+
+  return (
+    <div
+      className="flex max-w-[760px] flex-col gap-6 px-6 py-5"
+      data-testid="status-page-builder"
+    >
+      <header className="flex items-center gap-3">
+        <h1 className="text-[20px] font-semibold">Status page — builder</h1>
+        {saved && (
+          <span className="rounded-(--radius) bg-ok/15 px-2 py-0.5 text-[12px] text-ok">
+            Saved
+          </span>
+        )}
+        <Button
+          className="ml-auto"
+          onClick={() => void persist()}
+          disabled={!dirty}
+          data-testid="save-status-page"
+        >
+          Save changes
+        </Button>
+      </header>
+
+      <section aria-labelledby="branding-heading" className="flex flex-col">
+        <h2 id="branding-heading" className="text-[16px] font-semibold">
+          Branding
+        </h2>
+        <SettingsRow
+          label="Page name"
+          description="Shown in the public page header"
+          control={
+            <Input
+              value={current.name}
+              onChange={(e) => mutate({ ...current, name: e.target.value })}
+              aria-label="Page name"
+              className="w-56"
+              data-testid="status-page-name"
+            />
+          }
+        />
+        <SettingsRow
+          label="Slug"
+          description="public at /status/{slug}"
+          control={
+            <Input
+              mono
+              value={current.slug}
+              onChange={(e) => mutate({ ...current, slug: e.target.value })}
+              aria-label="Slug"
+              className="w-56"
+              data-testid="status-page-slug"
+            />
+          }
+        />
+      </section>
+
+      <section
+        aria-labelledby="components-heading"
+        className="flex flex-col gap-3"
+      >
+        <h2 id="components-heading" className="text-[16px] font-semibold">
+          Components
+        </h2>
+        {current.components.length === 0 ? (
+          <p className="text-[13px] text-text-2">
+            No components yet — each row publishes one uptime check.
+          </p>
+        ) : (
+          <ol
+            aria-label="Status page components"
+            className="flex flex-col gap-2"
+          >
+            {current.components.map((row, i) => (
+              <li key={row.id}>
+                <StatusPageBuilderRow
+                  name={row.name}
+                  onRename={(name) =>
+                    mutate({
+                      ...current,
+                      components: current.components.map((c, j) =>
+                        j === i ? { ...c, name } : c,
+                      ),
+                    })
+                  }
+                  monitorId={row.monitor_id}
+                  monitorOptions={monitorOptions}
+                  onMonitorChange={(monitorId) =>
+                    mutate({
+                      ...current,
+                      components: current.components.map((c, j) =>
+                        j === i ? { ...c, monitor_id: monitorId } : c,
+                      ),
+                    })
+                  }
+                  onDelete={() =>
+                    mutate({
+                      ...current,
+                      components: current.components.filter((_, j) => j !== i),
+                    })
+                  }
+                  onMove={(delta) => move(i, delta)}
+                />
+              </li>
+            ))}
+          </ol>
+        )}
+        <div>
+          <Button
+            kind="quiet"
+            size="sm"
+            onClick={() =>
+              mutate({
+                ...current,
+                components: [
+                  ...current.components,
+                  {
+                    id: nextComponentId(),
+                    name: "New component",
+                    monitor_id: null,
+                  },
+                ],
+              })
+            }
+            data-testid="add-component"
+          >
+            + Add component
+          </Button>
+        </div>
+      </section>
+
+      {error && (
+        <p role="alert" className="text-[13px] text-crit">
+          {error}
+        </p>
+      )}
+
+      <section
+        aria-label="Public URL"
+        className="flex flex-wrap items-center gap-3 rounded-(--radius) border border-border bg-bg-elev px-4 py-3"
+      >
+        <span className="text-[12px] text-text-2">Public URL</span>
+        <code className="font-data text-[13px] text-text">
+          upstat.cuesoft.io/status/{config.data.slug || "…"}
+        </code>
+        {config.data.slug && (
+          <Link
+            href={`/status/${config.data.slug}`}
+            target="_blank"
+            className="ml-auto rounded-(--radius) border border-border px-3 py-1.5 text-[13px] text-text transition-colors duration-[var(--duration-fast)] hover:bg-bg"
+            data-testid="open-public-page"
+          >
+            Open public page →
+          </Link>
+        )}
+      </section>
+      <p className="text-[12px] text-text-2">
+        Saved changes publish immediately — component order and names render on
+        the public page as listed here.
+      </p>
+    </div>
+  );
+}

--- a/web/src/app/dashboard/settings/usage/page.tsx
+++ b/web/src/app/dashboard/settings/usage/page.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { Skeleton } from "@/components/ui/Skeleton";
+import { UsageMeterRow } from "@/components/ui/UsageMeterRow";
+import { useUsageController } from "@/controllers/settings";
+
+/**
+ * B12 usage metering (Figma "B12 — Settings (usage metering)", 334:14499)
+ * — UsageMeterRow per pillar; month-to-date values computed from the
+ * seeded telemetry volumes (accuracy canon: honest numbers), bars scaled
+ * to each pillar's trailing-3-month peak, plan column verbatim.
+ */
+export default function UsagePage() {
+  const usage = useUsageController();
+  const report = usage.data;
+
+  return (
+    <div className="flex flex-col gap-5 px-6 py-5" data-testid="settings-usage">
+      <h1 className="text-[20px] font-semibold">Settings — usage</h1>
+
+      {usage.loading || !report ? (
+        <>
+          <Skeleton kind="line" className="w-72" />
+          {Array.from({ length: 4 }, (_, i) => (
+            <Skeleton key={i} kind="panel-axis" style={{ height: 72 }} />
+          ))}
+        </>
+      ) : (
+        <>
+          <h2 className="text-[16px] font-semibold">
+            Month-to-date usage — {report.month_label}
+          </h2>
+          {report.rows.length === 0 ? (
+            <p className="text-[13px] text-text-2">
+              No usage yet — meters populate once telemetry flows.
+            </p>
+          ) : (
+            <ul aria-label="Usage meters" className="flex flex-col gap-3">
+              {report.rows.map((meter) => (
+                <li key={meter.pillar}>
+                  <UsageMeterRow meter={meter} />
+                </li>
+              ))}
+            </ul>
+          )}
+          <p className="text-[12px] leading-[1.45] text-text-2">
+            Meters show month-to-date ingestion per pillar, scaled to each
+            pillar&apos;s trailing-3-month peak. Self-hosting is unmetered;
+            Cloud plan quotas are announced at GA.
+          </p>
+        </>
+      )}
+    </div>
+  );
+}

--- a/web/src/app/dashboard/uptime/SyntheticCheckBuilder.tsx
+++ b/web/src/app/dashboard/uptime/SyntheticCheckBuilder.tsx
@@ -1,0 +1,505 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useRef, useState } from "react";
+import { Button } from "@/components/ui/Button";
+import { Input } from "@/components/ui/Input";
+import { Select } from "@/components/ui/Select";
+import { Switch } from "@/components/ui/Switch";
+import { SyntheticStepRow } from "@/components/ui/SyntheticStepRow";
+import {
+  stepSummary,
+  type BrowserCheckConfig,
+  type HttpStepMethod,
+  type MonitorType,
+  type SyntheticCheck,
+  type SyntheticCheckKind,
+  type SyntheticStepInput,
+  type SyntheticStepKind,
+} from "@/models";
+import { useMonitorsController } from "@/controllers/monitors";
+import { useSyntheticsController } from "@/controllers/synthetics";
+
+const VIEWPORT_OPTIONS = [
+  { value: "1440x900", label: "1440 × 900 (desktop)" },
+  { value: "768x1024", label: "768 × 1024 (tablet)" },
+  { value: "390x844", label: "390 × 844 (mobile)" },
+];
+
+type BuilderTab = "http" | SyntheticCheckKind;
+
+/** Stored steps → builder-editable inputs. */
+function toInputs(check: SyntheticCheck): SyntheticStepInput[] {
+  return check.steps.map((s) =>
+    s.kind === "http"
+      ? { kind: "http", method: s.method ?? "GET", url: s.url ?? "" }
+      : s.kind === "assertion"
+        ? { kind: "assertion", expression: s.expression ?? "" }
+        : { kind: "wait", wait_ms: s.wait_ms ?? 500 },
+  );
+}
+
+/**
+ * B7 synthetic check builder (Figma "B7 — Synthetic check builder
+ * (multi-step)") — type tabs HTTP / Multi-step / Browser; the multi-step
+ * form composes SyntheticStepRow steps (add / reorder / delete) beside the
+ * browser-check panel (URL · viewport Select · screenshot-on-failure
+ * Switch). The HTTP tab stays the classic single-URL Monitor create.
+ */
+export function SyntheticCheckBuilder({
+  editing,
+}: {
+  editing?: SyntheticCheck;
+}) {
+  const router = useRouter();
+  const monitors = useMonitorsController();
+  const synthetics = useSyntheticsController();
+
+  const [tab, setTab] = useState<BuilderTab>(editing?.kind ?? "multi_step");
+  const [name, setName] = useState(editing?.name ?? "");
+  const [steps, setSteps] = useState<SyntheticStepInput[]>(
+    editing ? toInputs(editing) : [],
+  );
+  const [browserOn, setBrowserOn] = useState(
+    editing ? editing.browser !== null : true,
+  );
+  const [browser, setBrowser] = useState<BrowserCheckConfig>(
+    editing?.browser ?? {
+      url: "",
+      viewport: "1440x900",
+      screenshot_on_failure: true,
+    },
+  );
+  // classic HTTP check fields (Monitor create)
+  const [httpTarget, setHttpTarget] = useState("");
+  const [httpType, setHttpType] = useState<string | null>("website");
+  const [httpInterval, setHttpInterval] = useState<string | null>("60");
+
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState<"save" | "run" | null>(null);
+
+  /* ---------------- steps: add / reorder / delete ---------------- */
+
+  const [draftKind, setDraftKind] = useState<SyntheticStepKind>("http");
+  const [draftMethod, setDraftMethod] = useState<HttpStepMethod>("GET");
+  const [draftUrl, setDraftUrl] = useState("");
+  const [draftExpression, setDraftExpression] = useState("");
+  const [draftWaitMs, setDraftWaitMs] = useState("500");
+
+  const addStep = () => {
+    const step: SyntheticStepInput =
+      draftKind === "http"
+        ? { kind: "http", method: draftMethod, url: draftUrl.trim() }
+        : draftKind === "assertion"
+          ? { kind: "assertion", expression: draftExpression.trim() }
+          : { kind: "wait", wait_ms: Number(draftWaitMs) };
+    setSteps((prev) => [...prev, step]);
+    setDraftUrl("");
+    setDraftExpression("");
+  };
+
+  const draftValid =
+    draftKind === "http"
+      ? /^https?:\/\/.+/.test(draftUrl.trim())
+      : draftKind === "assertion"
+        ? draftExpression.trim().length > 0
+        : Number(draftWaitMs) > 0;
+
+  const move = (index: number, delta: -1 | 1) => {
+    setSteps((prev) => {
+      const next = [...prev];
+      const to = index + delta;
+      if (to < 0 || to >= next.length) return prev;
+      [next[index], next[to]] = [next[to], next[index]];
+      return next;
+    });
+  };
+
+  // pointer drag (HTML5 dnd) — keyboard reorder lives on the row grip
+  const dragFrom = useRef<number | null>(null);
+  const dropAt = (index: number) => {
+    const from = dragFrom.current;
+    dragFrom.current = null;
+    if (from === null || from === index) return;
+    setSteps((prev) => {
+      const next = [...prev];
+      const [moved] = next.splice(from, 1);
+      next.splice(index, 0, moved);
+      return next;
+    });
+  };
+
+  /* ---------------- submit ---------------- */
+
+  const kind: SyntheticCheckKind = tab === "browser" ? "browser" : "multi_step";
+  const payload = () => ({
+    name: name.trim(),
+    kind,
+    steps: tab === "browser" ? [] : steps,
+    browser: tab === "browser" || browserOn ? browser : null,
+  });
+
+  const saveCheck = async (): Promise<SyntheticCheck | null> => {
+    setError(null);
+    try {
+      return editing
+        ? await synthetics.update(editing.id, payload())
+        : await synthetics.create(payload());
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "could not save the check");
+      return null;
+    }
+  };
+
+  const onSave = async () => {
+    setBusy("save");
+    try {
+      if (tab === "http") {
+        const monitor = await monitors.create({
+          name: name.trim(),
+          target: httpTarget.trim(),
+          type: (httpType ?? "website") as MonitorType,
+          interval_seconds: Number(httpInterval ?? 60),
+        });
+        router.push(`/dashboard/uptime/${monitor.id}`);
+        return;
+      }
+      const check = await saveCheck();
+      if (check) router.push("/dashboard/uptime");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "could not save the check");
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const onRunOnce = async () => {
+    setBusy("run");
+    try {
+      const check = await saveCheck();
+      if (!check) return;
+      const run = await synthetics.runOnce(check.id);
+      router.push(`/dashboard/uptime/checks/${check.id}?run=${run.id}`);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "could not run the check");
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const saveDisabled =
+    busy !== null ||
+    !name.trim() ||
+    (tab === "http"
+      ? !httpTarget.trim()
+      : tab === "multi_step"
+        ? steps.length === 0
+        : !/^https?:\/\/.+/.test(browser.url));
+
+  const browserPanel = (
+    <aside
+      aria-labelledby="browser-check-heading"
+      className="flex h-fit w-full flex-col gap-4 rounded-(--radius) border border-border bg-bg-elev p-5 xl:max-w-[620px]"
+    >
+      <div className="flex items-center justify-between gap-3">
+        <h2 id="browser-check-heading" className="text-[16px] font-semibold">
+          Browser check
+        </h2>
+        {tab === "multi_step" && (
+          <Switch
+            checked={browserOn}
+            onCheckedChange={setBrowserOn}
+            aria-label="Run in a browser"
+          />
+        )}
+      </div>
+      {(tab === "browser" || browserOn) && (
+        <>
+          <label className="flex flex-col gap-1 text-[13px]">
+            <span className="text-text-2">URL</span>
+            <Input
+              mono
+              value={browser.url}
+              onChange={(e) => setBrowser({ ...browser, url: e.target.value })}
+              placeholder="https://upstat.cuesoft.io/checkout"
+              data-testid="browser-url"
+            />
+          </label>
+          <div className="flex items-center gap-4">
+            <span className="text-[13px] text-text-2">Viewport</span>
+            <Select
+              options={VIEWPORT_OPTIONS}
+              value={browser.viewport}
+              onValueChange={(v) => setBrowser({ ...browser, viewport: v })}
+              aria-label="Viewport"
+              className="min-w-48"
+            />
+          </div>
+          <div className="flex items-center justify-between gap-4">
+            <span className="text-[13px] text-text">Screenshot on failure</span>
+            <Switch
+              checked={browser.screenshot_on_failure}
+              onCheckedChange={(v) =>
+                setBrowser({ ...browser, screenshot_on_failure: v })
+              }
+              aria-label="Screenshot on failure"
+            />
+          </div>
+          <p className="text-[12px] leading-[1.45] text-text-2">
+            Runs in a headless browser on the check schedule.
+          </p>
+        </>
+      )}
+    </aside>
+  );
+
+  return (
+    <div
+      className="flex flex-col gap-5 px-6 py-5"
+      data-testid="synthetic-builder"
+    >
+      <h1 className="text-[20px] font-semibold">
+        {editing ? "Edit synthetic check" : "Create synthetic check"}
+      </h1>
+
+      {!editing && (
+        <div role="tablist" aria-label="Check type" className="flex gap-2">
+          {(
+            [
+              ["http", "HTTP"],
+              ["multi_step", "Multi-step"],
+              ["browser", "Browser"],
+            ] as const
+          ).map(([value, label]) => (
+            <button
+              key={value}
+              role="tab"
+              aria-selected={tab === value}
+              onClick={() => {
+                setTab(value);
+                setError(null); // stale API errors don't outlive the tab
+              }}
+              data-testid={`check-kind-${value}`}
+              className={
+                tab === value
+                  ? "rounded-(--radius) border border-brand px-3 py-1.5 text-[13px] font-medium text-brand"
+                  : "rounded-(--radius) border border-border px-3 py-1.5 text-[13px] text-text-2 transition-colors duration-[var(--duration-fast)] hover:text-text"
+              }
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      )}
+
+      <label className="flex w-full max-w-[640px] flex-col gap-1 text-[13px]">
+        <span className="text-text-2">Check name</span>
+        <Input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="checkout flow — api + web"
+          data-testid="synthetic-name"
+        />
+      </label>
+
+      <div className="flex flex-col gap-6 xl:flex-row">
+        {tab === "http" && (
+          <section
+            aria-label="HTTP check"
+            className="flex w-full max-w-[640px] flex-col gap-4"
+          >
+            <label className="flex flex-col gap-1 text-[13px]">
+              <span className="text-text-2">URL</span>
+              <Input
+                mono
+                value={httpTarget}
+                onChange={(e) => setHttpTarget(e.target.value)}
+                placeholder="https://api.cuesoft.io/healthz"
+                data-testid="http-target"
+              />
+            </label>
+            <div className="grid grid-cols-2 gap-4">
+              <label className="flex flex-col gap-1 text-[13px]">
+                <span className="text-text-2">Check type</span>
+                <Select
+                  options={[
+                    { value: "website", label: "Website" },
+                    { value: "api", label: "API" },
+                    { value: "server", label: "Server" },
+                  ]}
+                  value={httpType}
+                  onValueChange={setHttpType}
+                  aria-label="Check type"
+                />
+              </label>
+              <label className="flex flex-col gap-1 text-[13px]">
+                <span className="text-text-2">Interval</span>
+                <Select
+                  options={[
+                    { value: "30", label: "30s" },
+                    { value: "60", label: "60s" },
+                    { value: "300", label: "5m" },
+                  ]}
+                  value={httpInterval}
+                  onValueChange={setHttpInterval}
+                  aria-label="Interval"
+                />
+              </label>
+            </div>
+          </section>
+        )}
+
+        {tab === "multi_step" && (
+          <section
+            aria-labelledby="steps-heading"
+            className="flex w-full max-w-[640px] flex-col gap-3"
+          >
+            <h2 id="steps-heading" className="text-[16px] font-semibold">
+              Steps
+            </h2>
+            {steps.length === 0 ? (
+              <p className="text-[13px] text-text-2">
+                No steps yet — add an HTTP request, an assertion or a wait.
+              </p>
+            ) : (
+              <ol aria-label="Check steps" className="flex flex-col gap-2">
+                {steps.map((step, i) => (
+                  <li
+                    key={`${step.kind}-${i}`}
+                    draggable
+                    onDragStart={() => {
+                      dragFrom.current = i;
+                    }}
+                    onDragOver={(e) => e.preventDefault()}
+                    onDrop={() => dropAt(i)}
+                  >
+                    <SyntheticStepRow
+                      index={i + 1}
+                      kind={step.kind}
+                      summary={stepSummary(step)}
+                      onDelete={() =>
+                        setSteps((prev) => prev.filter((_, j) => j !== i))
+                      }
+                      onMove={(delta) => move(i, delta)}
+                    />
+                  </li>
+                ))}
+              </ol>
+            )}
+
+            {/* quiet "Add step" composer */}
+            <div className="flex flex-wrap items-end gap-2 rounded-(--radius) border border-dashed border-border p-3">
+              <label className="flex flex-col gap-1 text-[12px] text-text-2">
+                Step kind
+                <Select
+                  options={[
+                    { value: "http", label: "HTTP request" },
+                    { value: "assertion", label: "Assertion" },
+                    { value: "wait", label: "Wait" },
+                  ]}
+                  value={draftKind}
+                  onValueChange={(v) => setDraftKind(v as SyntheticStepKind)}
+                  aria-label="Step kind"
+                  className="min-w-36"
+                />
+              </label>
+              {draftKind === "http" && (
+                <>
+                  <label className="flex flex-col gap-1 text-[12px] text-text-2">
+                    Method
+                    <Select
+                      options={["GET", "POST", "HEAD"].map((m) => ({
+                        value: m,
+                        label: m,
+                      }))}
+                      value={draftMethod}
+                      onValueChange={(v) => setDraftMethod(v as HttpStepMethod)}
+                      aria-label="Method"
+                      className="min-w-24"
+                    />
+                  </label>
+                  <label className="flex min-w-56 flex-1 flex-col gap-1 text-[12px] text-text-2">
+                    URL
+                    <Input
+                      mono
+                      value={draftUrl}
+                      onChange={(e) => setDraftUrl(e.target.value)}
+                      placeholder="https://api.cuesoft.io/health"
+                      data-testid="step-url"
+                    />
+                  </label>
+                </>
+              )}
+              {draftKind === "assertion" && (
+                <label className="flex min-w-56 flex-1 flex-col gap-1 text-[12px] text-text-2">
+                  Expression
+                  <Input
+                    mono
+                    value={draftExpression}
+                    onChange={(e) => setDraftExpression(e.target.value)}
+                    placeholder="status == 200 && body.ok == true"
+                    data-testid="step-expression"
+                  />
+                </label>
+              )}
+              {draftKind === "wait" && (
+                <label className="flex flex-col gap-1 text-[12px] text-text-2">
+                  Wait (ms)
+                  <Input
+                    mono
+                    type="number"
+                    value={draftWaitMs}
+                    onChange={(e) => setDraftWaitMs(e.target.value)}
+                    className="w-28"
+                    data-testid="step-wait-ms"
+                  />
+                </label>
+              )}
+              <Button
+                kind="quiet"
+                size="sm"
+                onClick={addStep}
+                disabled={!draftValid}
+                data-testid="add-step"
+              >
+                + Add step
+              </Button>
+            </div>
+          </section>
+        )}
+
+        {tab !== "http" && browserPanel}
+      </div>
+
+      {error && (
+        <p role="alert" className="text-[13px] text-crit">
+          {error}
+        </p>
+      )}
+
+      <footer className="flex items-center gap-3">
+        <Button
+          onClick={() => void onSave()}
+          disabled={saveDisabled}
+          data-testid="save-check"
+        >
+          {busy === "save"
+            ? "Saving…"
+            : editing
+              ? "Save changes"
+              : "Save check"}
+        </Button>
+        {tab !== "http" && (
+          <Button
+            kind="quiet"
+            onClick={() => void onRunOnce()}
+            disabled={saveDisabled}
+            data-testid="run-once"
+          >
+            {busy === "run" ? "Running…" : "Run once"}
+          </Button>
+        )}
+      </footer>
+    </div>
+  );
+}

--- a/web/src/app/dashboard/uptime/checks/[id]/edit/page.tsx
+++ b/web/src/app/dashboard/uptime/checks/[id]/edit/page.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useParams, useRouter } from "next/navigation";
+import { Button } from "@/components/ui/Button";
+import { Skeleton } from "@/components/ui/Skeleton";
+import {
+  useSyntheticCheckController,
+  useSyntheticsController,
+} from "@/controllers/synthetics";
+import { SyntheticCheckBuilder } from "../../../SyntheticCheckBuilder";
+
+/** B7 edit — the builder over an existing multi-step/browser check. */
+export default function EditSyntheticCheckPage() {
+  const { id } = useParams<{ id: string }>();
+  const router = useRouter();
+  const check = useSyntheticCheckController(id);
+  const synthetics = useSyntheticsController();
+
+  if (check.loading) {
+    return (
+      <div className="flex flex-col gap-4 px-6 py-5">
+        <Skeleton kind="line" className="w-64" />
+        <Skeleton kind="panel-axis" style={{ height: 280 }} />
+      </div>
+    );
+  }
+  if (!check.data) {
+    return (
+      <div className="px-6 py-5">
+        <p className="text-[13px] text-text-2">
+          This synthetic check no longer exists.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <SyntheticCheckBuilder key={check.data.id} editing={check.data} />
+      <footer className="px-6 pb-6">
+        <Button
+          kind="destructive"
+          onClick={() =>
+            void synthetics.remove(check.data!.id).then(() => {
+              router.push("/dashboard/uptime");
+            })
+          }
+          data-testid="delete-check"
+        >
+          Delete check
+        </Button>
+      </footer>
+    </>
+  );
+}

--- a/web/src/app/dashboard/uptime/checks/[id]/page.tsx
+++ b/web/src/app/dashboard/uptime/checks/[id]/page.tsx
@@ -1,0 +1,211 @@
+"use client";
+
+import Link from "next/link";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
+import { Button } from "@/components/ui/Button";
+import { Skeleton } from "@/components/ui/Skeleton";
+import { StatusPill } from "@/components/ui/StatusPill";
+import { StepResultRow } from "@/components/ui/StepResultRow";
+import { UptimeCard } from "@/components/ui/UptimeCard";
+import { ageLabel } from "@/controllers/shell";
+import { monitorPillStatus } from "@/controllers/monitors";
+import {
+  useSyntheticContext,
+  useSyntheticRunController,
+  useSyntheticsController,
+} from "@/controllers/synthetics";
+
+function totalLabel(ms: number): string {
+  return ms >= 1000 ? `${(ms / 1000).toFixed(2)} s` : `${ms} ms`;
+}
+
+/** `1440x900` → `1440 × 900`. */
+function viewportLabel(viewport: string): string {
+  return viewport.replace("x", " × ");
+}
+
+/**
+ * B7 synthetic run view (Figma "B7 — Synthetic check run (multi-step
+ * results)") — per-step pass/fail timeline (StepResultRow), stop-at-first-
+ * failure copy, UptimeCard context and the failure-screenshot card.
+ * `?run=` selects a run; the latest renders by default.
+ */
+export default function SyntheticRunPage() {
+  const { id } = useParams<{ id: string }>();
+  const router = useRouter();
+  const runId = useSearchParams().get("run");
+  const { check, runs, selected } = useSyntheticRunController(id, runId);
+  const context = useSyntheticContext(check.data);
+  const synthetics = useSyntheticsController();
+
+  if (check.loading || runs.loading) {
+    return (
+      <div className="flex flex-col gap-4 px-6 py-5">
+        <Skeleton kind="line" className="w-72" />
+        <Skeleton kind="panel-axis" style={{ height: 260 }} />
+      </div>
+    );
+  }
+  if (!check.data) {
+    return (
+      <div className="px-6 py-5">
+        <p className="text-[13px] text-text-2">
+          This synthetic check no longer exists.
+        </p>
+      </div>
+    );
+  }
+
+  const c = check.data;
+  const run = selected;
+  const maxMs = Math.max(...(run?.steps ?? []).map((s) => s.duration_ms), 1);
+  const notRunFrom = run ? run.steps.length + 1 : 0;
+  const notRunCopy =
+    run && run.status === "fail" && notRunFrom <= run.steps_total
+      ? notRunFrom === run.steps_total
+        ? `Step ${notRunFrom} not run — the check stops at the first failure.`
+        : `Steps ${notRunFrom}–${run.steps_total} not run — the check stops at the first failure.`
+      : null;
+
+  return (
+    <div className="flex flex-col gap-5 px-6 py-5" data-testid="synthetic-run">
+      <header className="flex flex-wrap items-center gap-3">
+        <h1 className="text-[20px] font-semibold">
+          {c.name}
+          {run ? ` · run #${run.number}` : ""}
+        </h1>
+        <Link
+          href={`/dashboard/uptime/checks/${c.id}/edit`}
+          className="text-[13px] text-text-2 underline-offset-2 transition-colors duration-[var(--duration-fast)] hover:text-text hover:underline"
+          data-testid="edit-check"
+        >
+          Edit check
+        </Link>
+        <Button
+          kind="quiet"
+          size="sm"
+          className="ml-auto"
+          onClick={() =>
+            void synthetics.runOnce(c.id).then((r) => {
+              router.push(`/dashboard/uptime/checks/${c.id}?run=${r.id}`);
+              void runs.reload();
+            })
+          }
+          data-testid="run-once"
+        >
+          Run once
+        </Button>
+      </header>
+
+      {run ? (
+        <>
+          <div className="flex flex-wrap items-center gap-3">
+            <StatusPill
+              status={run.status === "pass" ? "ok" : "crit"}
+              label={run.status === "pass" ? "PASS" : "FAIL"}
+            />
+            <span className="font-data text-[12px] text-text-2">
+              ran {ageLabel(run.started_at)} ago · {totalLabel(run.total_ms)}{" "}
+              total
+              {run.status === "fail" ? " · stopped at first failure" : ""}
+            </span>
+          </div>
+
+          {context.monitor && context.history.data && (
+            <section
+              aria-label={`${context.monitor.name} uptime context`}
+              className="max-w-[420px]"
+            >
+              <UptimeCard
+                name={context.monitor.name}
+                days={context.history.data.days}
+                uptimePct={context.history.data.uptime_90d_pct}
+                p95Ms={context.monitor.last_response_time_ms ?? undefined}
+                status={monitorPillStatus(context.monitor.status)}
+              />
+            </section>
+          )}
+
+          <div className="flex flex-col gap-6 xl:flex-row">
+            <section
+              aria-labelledby="run-steps-heading"
+              className="w-full max-w-[880px]"
+            >
+              <h2
+                id="run-steps-heading"
+                className="mb-3 text-[16px] font-semibold"
+              >
+                Steps
+              </h2>
+              <ol aria-label="Step results">
+                {run.steps.map((step) => (
+                  <li key={step.index}>
+                    <StepResultRow
+                      index={step.index}
+                      kind={step.kind}
+                      summary={step.summary}
+                      result={step.status}
+                      durationMs={step.duration_ms}
+                      durationFraction={step.duration_ms / maxMs}
+                    />
+                  </li>
+                ))}
+              </ol>
+              {notRunCopy && (
+                <p className="mt-2 text-[12px] text-text-2">{notRunCopy}</p>
+              )}
+            </section>
+
+            {run.failure_screenshot && (
+              <aside
+                aria-label="Failure screenshot"
+                className="flex h-fit w-full max-w-[390px] flex-col gap-2 rounded-(--radius) border border-border bg-bg-elev p-4"
+                data-testid="failure-screenshot"
+              >
+                {/* seeded placeholder frame — the mock captures no real
+                    pixels; the card is the contract (Figma 330:12405) */}
+                <div className="aspect-[16/10] w-full rounded-(--radius) bg-nodata/20" />
+                <p className="text-[12px] text-text-2">
+                  Failure screenshot — step {run.failure_screenshot.step_index}{" "}
+                  · viewport {viewportLabel(run.failure_screenshot.viewport)}
+                </p>
+              </aside>
+            )}
+          </div>
+        </>
+      ) : (
+        <p className="text-[13px] text-text-2">
+          No runs yet — Run once to execute the steps now.
+        </p>
+      )}
+
+      <section aria-labelledby="runs-heading" className="max-w-[420px]">
+        <h2 id="runs-heading" className="mb-2 text-[16px] font-semibold">
+          Runs
+        </h2>
+        <ul aria-label="Run history" className="flex flex-col">
+          {(runs.data ?? []).map((r) => (
+            <li key={r.id}>
+              <Link
+                href={`/dashboard/uptime/checks/${c.id}?run=${r.id}`}
+                className="flex h-9 items-center gap-3 border-b border-border px-2 transition-colors duration-[var(--duration-fast)] hover:bg-bg-elev"
+                aria-current={run?.id === r.id ? "true" : undefined}
+              >
+                <StatusPill
+                  status={r.status === "pass" ? "ok" : "crit"}
+                  dotOnly
+                />
+                <span className="font-data text-[13px] text-text">
+                  #{r.number}
+                </span>
+                <span className="font-data ml-auto text-[12px] text-text-2">
+                  {ageLabel(r.started_at)} ago · {totalLabel(r.total_ms)}
+                </span>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </div>
+  );
+}

--- a/web/src/app/dashboard/uptime/new/page.tsx
+++ b/web/src/app/dashboard/uptime/new/page.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { SyntheticCheckBuilder } from "../SyntheticCheckBuilder";
+
+/**
+ * B7 create — "Create synthetic check" (Figma 329:12262): type tabs
+ * HTTP / Multi-step / Browser over one builder (pages.md B7, OBS-011).
+ */
+export default function NewSyntheticCheckPage() {
+  return <SyntheticCheckBuilder />;
+}

--- a/web/src/app/dashboard/uptime/page.tsx
+++ b/web/src/app/dashboard/uptime/page.tsx
@@ -1,57 +1,30 @@
 "use client";
 
+import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
 import { Button } from "@/components/ui/Button";
-import { Input } from "@/components/ui/Input";
-import { Modal } from "@/components/ui/Modal";
 import { MonitorRow } from "@/components/ui/MonitorRow";
-import { Select } from "@/components/ui/Select";
 import { Skeleton } from "@/components/ui/Skeleton";
+import { StatusPill } from "@/components/ui/StatusPill";
 import { UptimeCard } from "@/components/ui/UptimeCard";
-import type { MonitorType } from "@/models";
 import {
   monitorPillStatus,
   useMonitorsController,
   useUptimeCardsController,
 } from "@/controllers/monitors";
+import { useSyntheticsController } from "@/controllers/synthetics";
 import { ageLabel } from "@/controllers/shell";
 
 /**
  * B7 Synthetics & Uptime (Figma 130:2120) — UptimeCards + the check list
- * (MonitorRow states ×6, mute toggles); "New check" creates an HTTP check
- * (the absorbed monitor core).
+ * (MonitorRow states ×6, mute toggles) + the multi-step/browser Synthetic
+ * checks section (OBS-011); "New check" opens the B7 builder.
  */
 export default function UptimePage() {
   const router = useRouter();
   const ctrl = useMonitorsController();
   const cards = useUptimeCardsController(ctrl.data);
-  const [createOpen, setCreateOpen] = useState(false);
-  const [name, setName] = useState("");
-  const [target, setTarget] = useState("");
-  const [type, setType] = useState<string | null>("website");
-  const [interval, setIntervalSec] = useState<string | null>("60");
-  const [error, setError] = useState<string | null>(null);
-  const [creating, setCreating] = useState(false);
-
-  const submit = async () => {
-    setCreating(true);
-    setError(null);
-    try {
-      const monitor = await ctrl.create({
-        name: name.trim(),
-        target: target.trim(),
-        type: (type ?? "website") as MonitorType,
-        interval_seconds: Number(interval ?? 60),
-      });
-      setCreateOpen(false);
-      router.push(`/dashboard/uptime/${monitor.id}`);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "could not create the check");
-    } finally {
-      setCreating(false);
-    }
-  };
+  const synthetics = useSyntheticsController();
 
   const monitorsById = new Map((ctrl.data ?? []).map((m) => [m.id, m]));
 
@@ -59,7 +32,10 @@ export default function UptimePage() {
     <div className="flex flex-col gap-6 px-6 py-5" data-testid="uptime-page">
       <header className="flex items-center justify-between">
         <h1 className="text-[20px] font-semibold">Synthetics &amp; Uptime</h1>
-        <Button onClick={() => setCreateOpen(true)} data-testid="new-check">
+        <Button
+          onClick={() => router.push("/dashboard/uptime/new")}
+          data-testid="new-check"
+        >
           New check
         </Button>
       </header>
@@ -92,6 +68,58 @@ export default function UptimePage() {
               />
             );
           })
+        )}
+      </section>
+
+      {/* B7 multi-step / browser checks (OBS-011, Figma 329:12262) */}
+      <section aria-labelledby="synthetics-heading">
+        <h2 id="synthetics-heading" className="mb-3 text-[16px] font-semibold">
+          Synthetic checks
+        </h2>
+        {synthetics.loading ? (
+          <Skeleton kind="line" />
+        ) : (synthetics.data ?? []).length === 0 ? (
+          <p className="rounded-(--radius) border border-border bg-bg-elev p-6 text-[13px] text-text-2">
+            No multi-step or browser checks yet — New check → Multi-step.
+          </p>
+        ) : (
+          <ul aria-label="Synthetic checks">
+            {(synthetics.data ?? []).map((check) => (
+              <li key={check.id} data-testid={`synthetic-${check.id}`}>
+                <Link
+                  href={`/dashboard/uptime/checks/${check.id}`}
+                  className="flex h-10 items-center gap-3 border-b border-border px-3 transition-colors duration-[var(--duration-fast)] ease-standard hover:bg-bg-elev"
+                >
+                  <StatusPill
+                    status={
+                      check.last_run_status === null
+                        ? "pending"
+                        : check.last_run_status === "pass"
+                          ? "ok"
+                          : "crit"
+                    }
+                    dotOnly
+                  />
+                  <span className="w-64 truncate text-[13px] font-medium text-text">
+                    {check.name}
+                  </span>
+                  <span className="font-data rounded-(--radius) border border-border px-1.5 py-0.5 text-[10px] tracking-wide text-text-2">
+                    {check.kind === "browser" ? "BROWSER" : "MULTI-STEP"}
+                  </span>
+                  <span className="font-data min-w-0 flex-1 truncate text-[12px] text-text-2">
+                    {check.steps.length} step
+                    {check.steps.length === 1 ? "" : "s"}
+                    {check.browser ? " · headless browser" : ""}
+                  </span>
+                  <span className="font-data text-[12px] text-text-2">
+                    {check.last_run_at
+                      ? `ran ${ageLabel(check.last_run_at)} ago`
+                      : "never run"}
+                  </span>
+                </Link>
+              </li>
+            ))}
+          </ul>
         )}
       </section>
 
@@ -135,81 +163,6 @@ export default function UptimePage() {
           </ul>
         )}
       </section>
-
-      <Modal
-        open={createOpen}
-        onClose={() => setCreateOpen(false)}
-        title="New uptime check"
-        footer={
-          <>
-            <Button kind="quiet" onClick={() => setCreateOpen(false)}>
-              Cancel
-            </Button>
-            <Button
-              onClick={() => void submit()}
-              disabled={creating || !name.trim() || !target.trim()}
-              data-testid="create-check"
-            >
-              {creating ? "Creating…" : "Create check"}
-            </Button>
-          </>
-        }
-      >
-        <div className="flex flex-col gap-4">
-          <label className="flex flex-col gap-1 text-[13px]">
-            <span className="text-text-2">Name</span>
-            <Input
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              placeholder="api.cuesoft.io heartbeat"
-              data-testid="check-name"
-            />
-          </label>
-          <label className="flex flex-col gap-1 text-[13px]">
-            <span className="text-text-2">URL</span>
-            <Input
-              mono
-              value={target}
-              onChange={(e) => setTarget(e.target.value)}
-              placeholder="https://api.cuesoft.io/healthz"
-              data-testid="check-target"
-            />
-          </label>
-          <div className="grid grid-cols-2 gap-4">
-            <label className="flex flex-col gap-1 text-[13px]">
-              <span className="text-text-2">Check type</span>
-              <Select
-                options={[
-                  { value: "website", label: "Website" },
-                  { value: "api", label: "API" },
-                  { value: "server", label: "Server" },
-                ]}
-                value={type}
-                onValueChange={setType}
-                aria-label="Check type"
-              />
-            </label>
-            <label className="flex flex-col gap-1 text-[13px]">
-              <span className="text-text-2">Interval</span>
-              <Select
-                options={[
-                  { value: "30", label: "30s" },
-                  { value: "60", label: "60s" },
-                  { value: "300", label: "5m" },
-                ]}
-                value={interval}
-                onValueChange={setIntervalSec}
-                aria-label="Interval"
-              />
-            </label>
-          </div>
-          {error && (
-            <p role="alert" className="text-[13px] text-crit">
-              {error}
-            </p>
-          )}
-        </div>
-      </Modal>
     </div>
   );
 }

--- a/web/src/components/ui/FunnelStageCard.test.tsx
+++ b/web/src/components/ui/FunnelStageCard.test.tsx
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { FunnelStageCard } from "./FunnelStageCard";
+
+describe("FunnelStageCard", () => {
+  it("renders label, abbreviated tnum count and share-of-previous meta", () => {
+    render(
+      <FunnelStageCard label="Page views" count={48200} pctOfPrevious={100} />,
+    );
+    expect(screen.getByText("Page views")).toBeInTheDocument();
+    expect(screen.getByText("48.2k")).toBeInTheDocument();
+    expect(screen.getByText("100% of previous stage")).toBeInTheDocument();
+  });
+
+  it("shows fractional conversion shares", () => {
+    render(
+      <FunnelStageCard
+        label="Conversions — signup"
+        count={1400}
+        pctOfPrevious={11.2}
+      />,
+    );
+    expect(screen.getByText("1.4k")).toBeInTheDocument();
+    expect(screen.getByText("11.2% of previous stage")).toBeInTheDocument();
+  });
+});

--- a/web/src/components/ui/FunnelStageCard.tsx
+++ b/web/src/components/ui/FunnelStageCard.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { clsx } from "clsx";
+
+export interface FunnelStageCardProps {
+  label: string;
+  count: number;
+  /** Share of the previous stage (first stage = 100). */
+  pctOfPrevious: number;
+  className?: string;
+}
+
+function fmtCount(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return String(n);
+}
+
+/**
+ * FunnelStageCard — design.md §8.2b: stage label · count (PageTitle/20,
+ * tnum) · share-of-previous meta; stages compose with "→" connectors
+ * (Figma "B6 — RUM analytics drill-down (U6-2)").
+ */
+export function FunnelStageCard({
+  label,
+  count,
+  pctOfPrevious,
+  className,
+}: FunnelStageCardProps) {
+  return (
+    <div
+      className={clsx(
+        "font-ui flex min-w-56 flex-col gap-1.5 rounded-(--radius) border border-border bg-bg-elev px-5 py-4",
+        className,
+      )}
+    >
+      <span className="text-[12px] text-text-2">{label}</span>
+      <span className="font-data text-[20px] font-semibold tabular-nums text-text">
+        {fmtCount(count)}
+      </span>
+      <span className="font-data text-[12px] tabular-nums text-text-2">
+        {pctOfPrevious}% of previous stage
+      </span>
+    </div>
+  );
+}

--- a/web/src/components/ui/LogPatternRow.test.tsx
+++ b/web/src/components/ui/LogPatternRow.test.tsx
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { LogEvent } from "@/models";
+import { LogPatternRow } from "./LogPatternRow";
+
+const SAMPLE: LogEvent = {
+  id: "log_1",
+  ts: "2026-07-20T11:59:58.100Z",
+  service: "api-common",
+  level: "ERROR",
+  host: "gcp-lagos-1",
+  message: "request failed method=POST path=/v1/events status=503",
+  attrs: { env: "prod" },
+};
+
+describe("LogPatternRow", () => {
+  it("renders count, dominant level and the template with dimmed placeholders", () => {
+    render(
+      <LogPatternRow
+        template="request failed method=POST path=<path> status=<num>"
+        count={12400}
+        dominantLevel="ERROR"
+        trend={[1, 2, 3, 4, 5, 6, 7]}
+        samples={[SAMPLE]}
+      />,
+    );
+    expect(screen.getByText("12.4k")).toBeInTheDocument();
+    expect(screen.getByText("ERROR")).toBeInTheDocument();
+    expect(screen.getByText("<path>")).toBeInTheDocument();
+    expect(screen.getByText("<num>")).toBeInTheDocument();
+    // collapsed by default
+    expect(screen.getByRole("button", { expanded: false })).toBeInTheDocument();
+    expect(screen.queryByLabelText("Sample lines")).not.toBeInTheDocument();
+  });
+
+  it("expands to indented sample LogLines", () => {
+    render(
+      <LogPatternRow
+        template="request failed method=POST path=<path> status=<num>"
+        count={204}
+        dominantLevel="ERROR"
+        trend={[0, 0, 1, 9, 4, 2, 1]}
+        samples={[SAMPLE]}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { expanded: false }));
+    const samples = screen.getByLabelText("Sample lines");
+    expect(samples).toBeInTheDocument();
+    expect(samples.textContent).toContain(
+      "request failed method=POST path=/v1/events status=503",
+    );
+  });
+
+  it("draws one sparkline bar per trend bucket", () => {
+    const { container } = render(
+      <LogPatternRow
+        template="wait <num> ms"
+        count={7}
+        dominantLevel="DEBUG"
+        trend={[1, 1, 1, 1, 1, 1, 1]}
+        samples={[]}
+      />,
+    );
+    expect(container.querySelectorAll("svg rect")).toHaveLength(7);
+  });
+});

--- a/web/src/components/ui/LogPatternRow.tsx
+++ b/web/src/components/ui/LogPatternRow.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { clsx } from "clsx";
+import { ChevronRight } from "lucide-react";
+import { useState } from "react";
+import type { LogEvent, LogLevel } from "@/models";
+import { LevelChip } from "./LevelChip";
+import { LogLine } from "./LogLine";
+
+export interface LogPatternRowProps {
+  /** Message template with `<placeholders>` marking clustered variables. */
+  template: string;
+  count: number;
+  dominantLevel: LogLevel;
+  /** 7-bucket trend, oldest → newest. */
+  trend: number[];
+  /** Sample lines rendered indented when expanded. */
+  samples: LogEvent[];
+  defaultExpanded?: boolean;
+  className?: string;
+}
+
+function fmtCount(n: number): string {
+  if (n >= 1000) {
+    const k = n / 1000;
+    return `${k >= 100 ? Math.round(k) : k.toFixed(1)}k`;
+  }
+  return String(n);
+}
+
+/** Placeholder tokens render dimmed — the clustered variables read apart. */
+function TemplateText({ template }: { template: string }) {
+  return (
+    <>
+      {template.split(/(<[a-z_]+>)/g).map((part, i) =>
+        /^<[a-z_]+>$/.test(part) ? (
+          <span key={i} className="text-text-2">
+            {part}
+          </span>
+        ) : (
+          <span key={i}>{part}</span>
+        ),
+      )}
+    </>
+  );
+}
+
+/**
+ * LogPatternRow — design.md §8.2b: expand chevron · count (tnum) · 7-bucket
+ * trend sparkline · Mono template with `<placeholders>` · dominant-level
+ * meta; expands to indented sample LogLines (Figma "B4 — Logs (patterns)").
+ */
+export function LogPatternRow({
+  template,
+  count,
+  dominantLevel,
+  trend,
+  samples,
+  defaultExpanded = false,
+  className,
+}: LogPatternRowProps) {
+  const [expanded, setExpanded] = useState(defaultExpanded);
+  const max = Math.max(...trend, 1);
+
+  return (
+    <div className={clsx("font-ui border-b border-border", className)}>
+      <button
+        type="button"
+        aria-expanded={expanded}
+        onClick={() => setExpanded((x) => !x)}
+        className="flex h-10 w-full items-center gap-3 px-2 text-left transition-colors duration-[var(--duration-fast)] hover:bg-bg-elev"
+      >
+        <ChevronRight
+          aria-hidden="true"
+          className={clsx(
+            "size-3.5 shrink-0 text-text-2 transition-transform duration-[var(--duration-fast)]",
+            expanded && "rotate-90",
+          )}
+        />
+        <span className="font-data w-14 shrink-0 text-right text-[13px] tabular-nums text-text">
+          {fmtCount(count)}
+        </span>
+        {/* 7-bucket trend sparkline (bespoke SVG, brand fill) */}
+        <svg
+          aria-hidden="true"
+          width={7 * 5 - 2}
+          height={14}
+          className="shrink-0"
+        >
+          {trend.map((v, i) => {
+            const h = Math.max(2, Math.round((v / max) * 14));
+            return (
+              <rect
+                key={i}
+                x={i * 5}
+                y={14 - h}
+                width={3}
+                height={h}
+                className="fill-brand"
+              />
+            );
+          })}
+        </svg>
+        <span className="font-data min-w-0 flex-1 truncate text-[13px] text-text">
+          <TemplateText template={template} />
+        </span>
+        <LevelChip level={dominantLevel} className="shrink-0" />
+      </button>
+      {expanded && (
+        <ul aria-label="Sample lines" className="pb-2 pl-8">
+          {samples.map((event) => (
+            <li key={event.id}>
+              <LogLine event={event} />
+            </li>
+          ))}
+          {samples.length === 0 && (
+            <li className="px-2 py-1 text-[12px] text-text-2">
+              No sample lines captured for this pattern.
+            </li>
+          )}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/ui/StatusPageBuilderRow.test.tsx
+++ b/web/src/components/ui/StatusPageBuilderRow.test.tsx
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { StatusPageBuilderRow } from "./StatusPageBuilderRow";
+
+const MONITORS = [
+  { value: "mon_api", label: "API health" },
+  { value: "mon_homepage", label: "Homepage" },
+];
+
+describe("StatusPageBuilderRow", () => {
+  it("renders the inline-rename input and the mapped monitor", () => {
+    render(
+      <StatusPageBuilderRow
+        name="API"
+        onRename={() => {}}
+        monitorId="mon_api"
+        monitorOptions={MONITORS}
+        onMonitorChange={() => {}}
+      />,
+    );
+    expect(screen.getByLabelText("Component name")).toHaveValue("API");
+    expect(screen.getByText("API health")).toBeInTheDocument();
+    expect(screen.getByText("monitor:")).toBeInTheDocument();
+  });
+
+  it("renames inline", () => {
+    const onRename = vi.fn();
+    render(
+      <StatusPageBuilderRow
+        name="API"
+        onRename={onRename}
+        monitorId={null}
+        monitorOptions={MONITORS}
+        onMonitorChange={() => {}}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText("Component name"), {
+      target: { value: "Public API" },
+    });
+    expect(onRename).toHaveBeenCalledWith("Public API");
+  });
+
+  it("deletes and reorders via grip keys", () => {
+    const onDelete = vi.fn();
+    const onMove = vi.fn();
+    render(
+      <StatusPageBuilderRow
+        name="Ingestion"
+        onRename={() => {}}
+        monitorId={null}
+        monitorOptions={MONITORS}
+        onMonitorChange={() => {}}
+        onDelete={onDelete}
+        onMove={onMove}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Delete Ingestion" }));
+    expect(onDelete).toHaveBeenCalledOnce();
+    fireEvent.keyDown(
+      screen.getByRole("button", { name: "Reorder Ingestion" }),
+      {
+        key: "ArrowDown",
+      },
+    );
+    expect(onMove).toHaveBeenCalledWith(1);
+  });
+});

--- a/web/src/components/ui/StatusPageBuilderRow.tsx
+++ b/web/src/components/ui/StatusPageBuilderRow.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { clsx } from "clsx";
+import { GripVertical, Trash2 } from "lucide-react";
+import { Select, type SelectOption } from "./Select";
+
+export interface StatusPageBuilderRowProps {
+  /** Public display name — inline rename (design.md §8.2b). */
+  name: string;
+  onRename: (name: string) => void;
+  /** Mapped uptime check id (null = unmapped). */
+  monitorId: string | null;
+  monitorOptions: SelectOption[];
+  onMonitorChange: (monitorId: string) => void;
+  onDelete?: () => void;
+  /** Keyboard reorder — ArrowUp/ArrowDown on the focused grip. */
+  onMove?: (delta: -1 | 1) => void;
+  className?: string;
+}
+
+/**
+ * StatusPageBuilderRow — design.md §8.2b: drag grip · component name
+ * (inline rename) · monitor-mapping Select · delete; row order = public
+ * page order — the output is the existing /status/{slug} construction
+ * (Figma "B7 — Status page builder").
+ */
+export function StatusPageBuilderRow({
+  name,
+  onRename,
+  monitorId,
+  monitorOptions,
+  onMonitorChange,
+  onDelete,
+  onMove,
+  className,
+}: StatusPageBuilderRowProps) {
+  return (
+    <div
+      className={clsx(
+        "font-ui flex h-12 items-center gap-3 rounded-(--radius) border border-border bg-bg-elev px-3",
+        className,
+      )}
+    >
+      <button
+        type="button"
+        aria-label={`Reorder ${name}`}
+        onKeyDown={(e) => {
+          if (e.key === "ArrowUp") {
+            e.preventDefault();
+            onMove?.(-1);
+          } else if (e.key === "ArrowDown") {
+            e.preventDefault();
+            onMove?.(1);
+          }
+        }}
+        className="cursor-grab text-text-2 transition-colors duration-[var(--duration-fast)] hover:text-text"
+      >
+        <GripVertical aria-hidden="true" className="size-3.5" />
+      </button>
+      {/* inline rename — a ghost input that reads as text until focused */}
+      <input
+        value={name}
+        onChange={(e) => onRename(e.target.value)}
+        aria-label="Component name"
+        className={clsx(
+          "min-w-0 flex-1 rounded-(--radius) border border-transparent bg-transparent px-1.5 py-1",
+          "text-[13px] font-medium text-text outline-none",
+          "transition-colors duration-[var(--duration-fast)]",
+          "hover:border-border focus:border-brand",
+        )}
+      />
+      <span className="text-[12px] text-text-2">monitor:</span>
+      <Select
+        options={monitorOptions}
+        value={monitorId}
+        onValueChange={onMonitorChange}
+        placeholder="Unmapped"
+        aria-label={`Monitor for ${name}`}
+        className="min-w-52"
+      />
+      <button
+        type="button"
+        aria-label={`Delete ${name}`}
+        onClick={onDelete}
+        className="text-text-2 transition-colors duration-[var(--duration-fast)] hover:text-crit"
+      >
+        <Trash2 aria-hidden="true" className="size-3.5" />
+      </button>
+    </div>
+  );
+}

--- a/web/src/components/ui/StepResultRow.test.tsx
+++ b/web/src/components/ui/StepResultRow.test.tsx
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { StepResultRow } from "./StepResultRow";
+
+describe("StepResultRow", () => {
+  it("renders PASS with a brand duration bar and fixed-precision ms", () => {
+    render(
+      <StepResultRow
+        index={1}
+        kind="http"
+        summary="GET https://api.upstat.cuesoft.io/health"
+        result="pass"
+        durationMs={142}
+        durationFraction={0.31}
+      />,
+    );
+    expect(screen.getByText("PASS")).toBeInTheDocument();
+    expect(screen.getByText("142 ms")).toBeInTheDocument();
+    const row = screen.getByText("PASS").closest("[data-result]");
+    expect(row).toHaveAttribute("data-result", "pass");
+    expect(row?.querySelector(".bg-brand")).not.toBeNull();
+  });
+
+  it("renders FAIL with a crit bar and the assert prefix", () => {
+    render(
+      <StepResultRow
+        index={3}
+        kind="assertion"
+        summary="body.ok == true"
+        result="fail"
+        durationMs={462}
+        durationFraction={1}
+      />,
+    );
+    expect(screen.getByText("FAIL")).toBeInTheDocument();
+    expect(screen.getByText("assert body.ok == true")).toBeInTheDocument();
+    const row = screen.getByText("FAIL").closest("[data-result]");
+    expect(row?.querySelector(".bg-crit")).not.toBeNull();
+  });
+
+  it("width tracks the duration fraction with a visibility floor", () => {
+    render(
+      <StepResultRow
+        index={2}
+        kind="assertion"
+        summary="status == 200"
+        result="pass"
+        durationMs={88}
+        durationFraction={0.01}
+      />,
+    );
+    const bar = document.querySelector(
+      "[data-result] .bg-brand",
+    ) as HTMLElement;
+    expect(bar.style.width).toBe("4%"); // floored so tiny steps stay visible
+  });
+});

--- a/web/src/components/ui/StepResultRow.tsx
+++ b/web/src/components/ui/StepResultRow.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { clsx } from "clsx";
+import type { SyntheticStepKind } from "@/models";
+import { StatusPill } from "./StatusPill";
+
+export interface StepResultRowProps {
+  /** 1-based step index. */
+  index: number;
+  kind: SyntheticStepKind;
+  summary: string;
+  result: "pass" | "fail";
+  durationMs: number;
+  /** Bar width ∝ duration — fraction of the run's longest step (0..1]. */
+  durationFraction: number;
+  className?: string;
+}
+
+/**
+ * StepResultRow — design.md §8.2b: result pass/fail · step index ·
+ * StatusPill ("PASS" ok / "FAIL" crit) · summary · duration bar (brand
+ * fill, crit on fail; width ∝ duration) · fixed-precision ms; the B7
+ * run-view timeline row (Figma "B7 — Synthetic check run").
+ */
+export function StepResultRow({
+  index,
+  kind,
+  summary,
+  result,
+  durationMs,
+  durationFraction,
+  className,
+}: StepResultRowProps) {
+  const pct = Math.round(Math.min(Math.max(durationFraction, 0.04), 1) * 100);
+  return (
+    <div
+      data-result={result}
+      className={clsx(
+        "font-ui flex h-11 items-center gap-3 border-b border-border px-3",
+        className,
+      )}
+    >
+      <span className="font-data w-4 text-center text-[12px] tabular-nums text-text-2">
+        {index}
+      </span>
+      <StatusPill
+        status={result === "pass" ? "ok" : "crit"}
+        label={result === "pass" ? "PASS" : "FAIL"}
+      />
+      <span className="font-data min-w-0 flex-1 truncate text-[13px] text-text">
+        {kind === "assertion" ? `assert ${summary}` : summary}
+      </span>
+      <span
+        aria-hidden="true"
+        className="hidden h-1 w-40 shrink-0 overflow-hidden rounded-full bg-border sm:block"
+      >
+        <span
+          className={clsx(
+            "block h-full rounded-full",
+            result === "pass" ? "bg-brand" : "bg-crit",
+          )}
+          style={{ width: `${pct}%` }}
+        />
+      </span>
+      <span className="font-data w-16 shrink-0 text-right text-[12px] tabular-nums text-text-2">
+        {durationMs.toLocaleString("en-US")} ms
+      </span>
+    </div>
+  );
+}

--- a/web/src/components/ui/SyntheticStepRow.test.tsx
+++ b/web/src/components/ui/SyntheticStepRow.test.tsx
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { SyntheticStepRow } from "./SyntheticStepRow";
+
+describe("SyntheticStepRow", () => {
+  it("renders index, kind chip and mono summary per kind", () => {
+    const { rerender } = render(
+      <SyntheticStepRow
+        index={1}
+        kind="http"
+        summary="GET https://api.upstat.cuesoft.io/health"
+      />,
+    );
+    expect(screen.getByText("1")).toBeInTheDocument();
+    expect(screen.getByText("HTTP")).toBeInTheDocument();
+    expect(
+      screen.getByText("GET https://api.upstat.cuesoft.io/health"),
+    ).toBeInTheDocument();
+
+    rerender(
+      <SyntheticStepRow index={2} kind="assertion" summary="status == 200" />,
+    );
+    expect(screen.getByText("ASSERT")).toBeInTheDocument();
+
+    rerender(<SyntheticStepRow index={3} kind="wait" summary="wait 500 ms" />);
+    expect(screen.getByText("WAIT")).toBeInTheDocument();
+    expect(screen.getByText("wait 500 ms")).toBeInTheDocument();
+  });
+
+  it("deletes via the trash affordance", () => {
+    const onDelete = vi.fn();
+    render(
+      <SyntheticStepRow
+        index={2}
+        kind="assertion"
+        summary="body.ok == true"
+        onDelete={onDelete}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Delete step 2" }));
+    expect(onDelete).toHaveBeenCalledOnce();
+  });
+
+  it("reorders with ArrowUp/ArrowDown on the grip", () => {
+    const onMove = vi.fn();
+    render(
+      <SyntheticStepRow
+        index={2}
+        kind="wait"
+        summary="wait 500 ms"
+        onMove={onMove}
+      />,
+    );
+    const grip = screen.getByRole("button", { name: "Reorder step 2" });
+    fireEvent.keyDown(grip, { key: "ArrowUp" });
+    expect(onMove).toHaveBeenCalledWith(-1);
+    fireEvent.keyDown(grip, { key: "ArrowDown" });
+    expect(onMove).toHaveBeenCalledWith(1);
+  });
+});

--- a/web/src/components/ui/SyntheticStepRow.tsx
+++ b/web/src/components/ui/SyntheticStepRow.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { clsx } from "clsx";
+import { GripVertical, Trash2 } from "lucide-react";
+import type { SyntheticStepKind } from "@/models";
+
+export interface SyntheticStepRowProps {
+  /** 1-based position — row order is execution order. */
+  index: number;
+  kind: SyntheticStepKind;
+  /** Mono summary: `GET https://…` / `status == 200` / `wait 500 ms`. */
+  summary: string;
+  onDelete?: () => void;
+  /** Keyboard reorder — ArrowUp/ArrowDown on the focused grip. */
+  onMove?: (delta: -1 | 1) => void;
+  className?: string;
+}
+
+// Kind chip copy (Mono/Micro 10) — Figma "B7 — Synthetic check builder".
+const KIND_LABEL: Record<SyntheticStepKind, string> = {
+  http: "HTTP",
+  assertion: "ASSERT",
+  wait: "WAIT",
+};
+
+/**
+ * SyntheticStepRow — design.md §8.2b: kind http/assertion/wait · drag grip
+ * + step index + kind chip + mono summary + delete; the B7 multi-step
+ * check builder row (add via the quiet "Add step" button).
+ */
+export function SyntheticStepRow({
+  index,
+  kind,
+  summary,
+  onDelete,
+  onMove,
+  className,
+}: SyntheticStepRowProps) {
+  return (
+    <div
+      data-kind={kind}
+      className={clsx(
+        "font-ui flex h-11 items-center gap-3 rounded-(--radius) border border-border bg-bg-elev px-3",
+        className,
+      )}
+    >
+      <button
+        type="button"
+        aria-label={`Reorder step ${index}`}
+        onKeyDown={(e) => {
+          if (e.key === "ArrowUp") {
+            e.preventDefault();
+            onMove?.(-1);
+          } else if (e.key === "ArrowDown") {
+            e.preventDefault();
+            onMove?.(1);
+          }
+        }}
+        className="cursor-grab text-text-2 transition-colors duration-[var(--duration-fast)] hover:text-text"
+      >
+        <GripVertical aria-hidden="true" className="size-3.5" />
+      </button>
+      <span className="font-data w-4 text-center text-[12px] tabular-nums text-text-2">
+        {index}
+      </span>
+      <span className="font-data rounded-(--radius) border border-border px-1.5 py-0.5 text-[10px] tracking-wide text-text-2">
+        {KIND_LABEL[kind]}
+      </span>
+      <span className="font-data min-w-0 flex-1 truncate text-[13px] text-text">
+        {summary}
+      </span>
+      <button
+        type="button"
+        aria-label={`Delete step ${index}`}
+        onClick={onDelete}
+        className="text-text-2 transition-colors duration-[var(--duration-fast)] hover:text-crit"
+      >
+        <Trash2 aria-hidden="true" className="size-3.5" />
+      </button>
+    </div>
+  );
+}

--- a/web/src/components/ui/UsageMeterRow.test.tsx
+++ b/web/src/components/ui/UsageMeterRow.test.tsx
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { UsageMeterRow } from "./UsageMeterRow";
+
+const METER = {
+  pillar: "logs" as const,
+  label: "Logs — ingested",
+  value: 900_000_000,
+  display: "0.90 GB",
+  peak: 1_440_000_000,
+  plan: "Self-host: unlimited · Cloud: announced at GA",
+};
+
+describe("UsageMeterRow", () => {
+  it("renders label, tnum value and the verbatim plan column", () => {
+    render(<UsageMeterRow meter={METER} />);
+    expect(screen.getByText("Logs — ingested")).toBeInTheDocument();
+    expect(screen.getByText("0.90 GB")).toBeInTheDocument();
+    // accuracy canon: the plan copy is verbatim, never paraphrased
+    expect(
+      screen.getByText("Self-host: unlimited · Cloud: announced at GA"),
+    ).toBeInTheDocument();
+  });
+
+  it("scales the bar against the trailing-3-month peak", () => {
+    render(<UsageMeterRow meter={METER} />);
+    const meterEl = screen.getByRole("meter");
+    expect(meterEl).toHaveAttribute("aria-valuenow", "62.5");
+    const fill = meterEl.querySelector(".bg-brand") as HTMLElement;
+    expect(fill.style.width).toBe("62.5%");
+  });
+
+  it("clamps at 100% when MTD already exceeds the peak", () => {
+    render(<UsageMeterRow meter={{ ...METER, value: 2_000_000_000 }} />);
+    expect(screen.getByRole("meter")).toHaveAttribute("aria-valuenow", "100");
+  });
+});

--- a/web/src/components/ui/UsageMeterRow.tsx
+++ b/web/src/components/ui/UsageMeterRow.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { clsx } from "clsx";
+import type { UsageMeter } from "@/models";
+
+export interface UsageMeterRowProps {
+  meter: UsageMeter;
+  className?: string;
+}
+
+/**
+ * UsageMeterRow — design.md §8.2b: pillar + unit label · MTD value (tnum)
+ * · bar vs trailing-3-month peak · plan column verbatim "Self-host:
+ * unlimited · Cloud: announced at GA" (accuracy canon; Figma "B12 —
+ * Settings (usage metering)").
+ */
+export function UsageMeterRow({ meter, className }: UsageMeterRowProps) {
+  const fraction =
+    meter.peak <= 0 ? 0 : Math.min(1, meter.value / Math.max(meter.peak, 1));
+  const pct = Math.round(fraction * 1000) / 10;
+  return (
+    <div
+      data-pillar={meter.pillar}
+      className={clsx(
+        "font-ui flex flex-col gap-3 rounded-(--radius) border border-border bg-bg-elev px-4 py-4",
+        "sm:h-[72px] sm:flex-row sm:items-center sm:gap-4 sm:py-0",
+        className,
+      )}
+    >
+      <span className="w-56 shrink-0 text-[13px] font-medium text-text">
+        {meter.label}
+      </span>
+      <span className="font-data w-20 shrink-0 text-right text-[13px] tabular-nums text-text">
+        {meter.display}
+      </span>
+      <span
+        role="meter"
+        aria-label={`${meter.label} — month to date vs trailing-3-month peak`}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={pct}
+        className="h-1.5 min-w-24 flex-1 overflow-hidden rounded-full bg-border"
+      >
+        <span
+          className="block h-full rounded-full bg-brand"
+          style={{ width: `${Math.max(pct, 1)}%` }}
+        />
+      </span>
+      <span className="shrink-0 text-[12px] text-text-2 sm:w-64 sm:text-right">
+        {meter.plan}
+      </span>
+    </div>
+  );
+}

--- a/web/src/controllers/logs.ts
+++ b/web/src/controllers/logs.ts
@@ -217,7 +217,35 @@ export function useLogsExplorerController() {
     selectedFacets,
     views,
     applyView,
+    /** The submitted query — the Patterns tab clusters the same stream. */
+    activeQuery,
   };
+}
+
+/** Live tail has no fixed [from,to] — Patterns clusters the last 15m. */
+const LIVE_PATTERN_WINDOW_MS = 15 * 60_000;
+
+/**
+ * B4 Patterns tab ([Designed 2026-07-20], OBS-012) — clustered templates
+ * over the explorer's active query + time range. Time-range aware: LIVE
+ * clusters the last 15 minutes; presets/custom cluster [from, to].
+ */
+export function useLogPatternsController(
+  activeQuery: string,
+  enabled: boolean,
+) {
+  const time = useTimeRange();
+  const live = time.live;
+  return useRequest(async () => {
+    if (!enabled) return null;
+    const toMs = live ? Date.now() : time.toMs;
+    const fromMs = live ? toMs - LIVE_PATTERN_WINDOW_MS : time.fromMs;
+    return logsRepo.patterns({
+      q: activeQuery,
+      from: new Date(fromMs).toISOString(),
+      to: new Date(toMs).toISOString(),
+    });
+  }, [activeQuery, enabled, live, time.fromMs, time.toMs]);
 }
 
 /**

--- a/web/src/controllers/rum.ts
+++ b/web/src/controllers/rum.ts
@@ -24,6 +24,29 @@ export function useRumController(range: { from?: string; to?: string } = {}) {
   return { summary, vitals, errors, properties };
 }
 
+/**
+ * B6 drill-down controller (U6-2 [Designed 2026-07-20]) — funnel +
+ * weekly-cohort retention beside the summary's sessions/top lists.
+ */
+export function useRumDrilldownController(
+  range: { from?: string; to?: string } = {},
+) {
+  const summary = useRequest(
+    () => rumRepo.summary(range),
+    [range.from, range.to],
+  );
+  const drilldown = useRequest(
+    () => rumRepo.drilldown(range),
+    [range.from, range.to],
+  );
+  const properties = useRequest(
+    async () =>
+      (await keysRepo.list()).filter((k) => k.kind === "property_key"),
+    [],
+  );
+  return { summary, drilldown, properties };
+}
+
 const VERIFY_TIMEOUT_MS = 10_000;
 
 /**

--- a/web/src/controllers/settings.ts
+++ b/web/src/controllers/settings.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback } from "react";
-import { keysRepo, membersRepo } from "@/models/repositories";
+import { keysRepo, membersRepo, usageRepo } from "@/models/repositories";
 import type { ApiKey, MemberRole } from "@/models";
 import { useRequest } from "./use-request";
 
@@ -65,4 +65,12 @@ export function useSettingsController() {
     inviteMember,
     setMemberRole,
   };
+}
+
+/**
+ * B12 usage metering ([Designed 2026-07-20], OBS-012) — the month-to-date
+ * per-pillar meters, computed by the mock from the seeded telemetry.
+ */
+export function useUsageController() {
+  return useRequest(() => usageRepo.report(), []);
 }

--- a/web/src/controllers/status.ts
+++ b/web/src/controllers/status.ts
@@ -1,5 +1,7 @@
 "use client";
 
+import { useCallback } from "react";
+import type { StatusPageConfig } from "@/models";
 import { statusRepo } from "@/models/repositories";
 import { useRequest } from "./use-request";
 
@@ -9,4 +11,25 @@ import { useRequest } from "./use-request";
  */
 export function useStatusPageController(slug: string) {
   return useRequest(() => statusRepo.bySlug(slug), [slug]);
+}
+
+/**
+ * B7 status-page builder controller ([Designed 2026-07-20]) — the builder
+ * document plus a `save` that persists branding + the ordered component
+ * list; every structural mutation (add/rename/reorder/map/delete) saves
+ * through here so the public page reflects it immediately.
+ */
+export function useStatusPageBuilderController() {
+  const config = useRequest(() => statusRepo.config(), []);
+
+  const save = useCallback(
+    async (next: StatusPageConfig) => {
+      const saved = await statusRepo.updateConfig(next);
+      await config.reload();
+      return saved;
+    },
+    [config],
+  );
+
+  return { config, save };
 }

--- a/web/src/controllers/synthetics.ts
+++ b/web/src/controllers/synthetics.ts
@@ -1,0 +1,120 @@
+"use client";
+
+/**
+ * B7 synthetic checks (multi-step / browser, OBS-011) — builder CRUD,
+ * "Run once", and the run-view read model (check + runs + selected run).
+ */
+
+import { useCallback } from "react";
+import type { Monitor, SyntheticCheck, SyntheticCheckInput } from "@/models";
+import { monitorsRepo, syntheticsRepo } from "@/models/repositories";
+import { useRequest } from "./use-request";
+
+/** List + CRUD for the uptime page's Synthetic checks section. */
+export function useSyntheticsController() {
+  const state = useRequest(() => syntheticsRepo.list(), []);
+
+  const create = useCallback(
+    async (input: SyntheticCheckInput) => {
+      const check = await syntheticsRepo.create(input);
+      await state.reload();
+      return check;
+    },
+    [state],
+  );
+
+  const update = useCallback(
+    async (id: string, patch: Partial<SyntheticCheckInput>) => {
+      const check = await syntheticsRepo.update(id, patch);
+      await state.reload();
+      return check;
+    },
+    [state],
+  );
+
+  const remove = useCallback(
+    async (id: string) => {
+      await syntheticsRepo.remove(id);
+      await state.reload();
+    },
+    [state],
+  );
+
+  const runOnce = useCallback(
+    async (id: string) => {
+      const run = await syntheticsRepo.runOnce(id);
+      await state.reload();
+      return run;
+    },
+    [state],
+  );
+
+  return { ...state, create, update, remove, runOnce };
+}
+
+/** One check for the builder's edit mode. */
+export function useSyntheticCheckController(id: string | null) {
+  return useRequest(
+    () => (id ? syntheticsRepo.get(id) : Promise.resolve(null)),
+    [id],
+  );
+}
+
+/**
+ * Run view read model — the check, its run list (newest first) and the
+ * selected run (`runId` from the URL; latest when absent). Deep-linkable
+ * state rides the query string per the §4 route-map rule.
+ */
+export function useSyntheticRunController(
+  checkId: string,
+  runId: string | null,
+) {
+  const check = useRequest(() => syntheticsRepo.get(checkId), [checkId]);
+  const runs = useRequest(() => syntheticsRepo.runs(checkId), [checkId]);
+  const selected =
+    (runId
+      ? (runs.data ?? []).find((r) => r.id === runId)
+      : (runs.data ?? [])[0]) ?? null;
+  return { check, runs, selected };
+}
+
+/**
+ * UptimeCard context beside the run timeline — the matched monitor plus
+ * its 90-day history (Figma "B7 — Synthetic check run" context card).
+ */
+export function useSyntheticContext(check: SyntheticCheck | null) {
+  const monitors = useRequest(() => monitorsRepo.list(), []);
+  const monitor = contextMonitorFor(check, monitors.data);
+  const monitorId = monitor?.id ?? null;
+  const history = useRequest(
+    () => (monitorId ? monitorsRepo.history(monitorId) : Promise.resolve(null)),
+    [monitorId],
+  );
+  return { monitor, history };
+}
+
+/**
+ * UptimeCard context for the run view: the monitor whose target host the
+ * check's first HTTP step hits (derived, not configured — no invented
+ * linkage). Null when no monitor watches that host.
+ */
+export function contextMonitorFor(
+  check: SyntheticCheck | null,
+  monitors: Monitor[] | null,
+): Monitor | null {
+  if (!check || !monitors) return null;
+  const firstHttp = check.steps.find((s) => s.kind === "http" && s.url);
+  const target = firstHttp?.url ?? check.browser?.url;
+  if (!target) return null;
+  const host = hostOf(target);
+  if (!host) return null;
+  return monitors.find((m) => hostOf(m.target) === host) ?? null;
+}
+
+function hostOf(url: string): string | null {
+  try {
+    return new URL(url).host;
+  } catch {
+    return null;
+  }
+}

--- a/web/src/mocks/log-patterns.test.ts
+++ b/web/src/mocks/log-patterns.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import { clusterLogs, templateOf, TREND_BUCKETS } from "./log-patterns";
+import { generateLogs } from "./series";
+
+const HOUR = 3_600_000;
+const MINUTE = 60_000;
+const NOW = Date.parse("2026-07-20T12:00:00Z");
+const OUTAGE = {
+  start: NOW - 3 * HOUR,
+  end: NOW - 2 * HOUR - 15 * MINUTE,
+  services: ["checkout", "api-common"],
+};
+
+describe("templateOf", () => {
+  it("collapses numeric, hex and version values into <placeholders>", () => {
+    expect(
+      templateOf("request completed method=GET path=/v1/stats status=200"),
+    ).toBe("request completed method=GET path=<path> status=<num>");
+    expect(templateOf("batch flush size=48 wait_ms=150")).toBe(
+      "batch flush size=<num> wait_ms=<num>",
+    );
+    expect(
+      templateOf(
+        "span exported trace_id=9f86d081884c7d659a2feaa0c55ad015 spans=6",
+      ),
+    ).toBe("span exported trace_id=<id> spans=<num>");
+    expect(
+      templateOf("deploy started service=web version=1.14.3 strategy=canary"),
+    ).toBe(
+      "deploy started service=<service> version=<version> strategy=canary",
+    );
+  });
+
+  it("keeps literal enums literal", () => {
+    expect(templateOf("grpc channel state=READY target=api-common:8080")).toBe(
+      "grpc channel state=READY target=<target>",
+    );
+    expect(
+      templateOf("widget query served dashboard=service-overview cache=hit"),
+    ).toBe("widget query served dashboard=<dashboard> cache=hit");
+  });
+});
+
+describe("clusterLogs", () => {
+  const from = NOW - 15 * MINUTE;
+
+  it("is deterministic — same range, same clusters", () => {
+    const a = clusterLogs(from, NOW, OUTAGE);
+    const b = clusterLogs(from, NOW, OUTAGE);
+    expect(a).toEqual(b);
+  });
+
+  it("every generated line lands in exactly one pattern (counts add up)", () => {
+    const result = clusterLogs(from, NOW, OUTAGE);
+    // 15 minutes = 900 whole seconds × 3 lines/sec, no sampling
+    expect(result.sampled).toBe(false);
+    expect(result.total_lines).toBe(900 * 3);
+    const sum = result.patterns.reduce((s, p) => s + p.count, 0);
+    expect(sum).toBe(result.total_lines);
+  });
+
+  it("samples match their pattern's template and every line matches its own template", () => {
+    const result = clusterLogs(from, NOW, OUTAGE);
+    for (const pattern of result.patterns) {
+      expect(pattern.samples.length).toBeGreaterThan(0);
+      for (const sample of pattern.samples) {
+        expect(templateOf(sample.message)).toBe(pattern.template);
+      }
+    }
+    // cross-check against the stream generator (shared line source)
+    const lines = generateLogs(from, NOW, OUTAGE, undefined, undefined, 200);
+    const templates = new Set(result.patterns.map((p) => p.template));
+    for (const line of lines) {
+      expect(templates.has(templateOf(line.message))).toBe(true);
+    }
+  });
+
+  it("orders by count desc and exposes a 7-bucket trend summing to the count", () => {
+    const result = clusterLogs(from, NOW, OUTAGE);
+    const counts = result.patterns.map((p) => p.count);
+    expect([...counts].sort((a, b) => b - a)).toEqual(counts);
+    for (const pattern of result.patterns) {
+      expect(pattern.trend).toHaveLength(TREND_BUCKETS);
+      expect(pattern.trend.reduce((s, v) => s + v, 0)).toBe(pattern.count);
+    }
+  });
+
+  it("respects service/level/text filters (explorer parity)", () => {
+    const errOnly = clusterLogs(from, NOW, OUTAGE, { level: "ERROR" });
+    expect(errOnly.patterns.length).toBeGreaterThan(0);
+    for (const pattern of errOnly.patterns) {
+      expect(pattern.dominant_level).toBe("ERROR");
+      for (const sample of pattern.samples) {
+        expect(sample.level).toBe("ERROR");
+      }
+    }
+    const text = clusterLogs(from, NOW, OUTAGE, { text: ["retry"] });
+    for (const pattern of text.patterns) {
+      expect(pattern.template.toLowerCase()).toContain("retry");
+    }
+  });
+
+  it("samples wide ranges deterministically with scaled counts", () => {
+    const wide = clusterLogs(NOW - 24 * HOUR, NOW, OUTAGE);
+    expect(wide.sampled).toBe(true);
+    // scaled totals approximate 3 lines/sec over the range
+    expect(wide.total_lines).toBeGreaterThan(24 * 3600 * 2);
+    expect(wide.total_lines).toBeLessThan(24 * 3600 * 4);
+    expect(clusterLogs(NOW - 24 * HOUR, NOW, OUTAGE)).toEqual(wide);
+  });
+});

--- a/web/src/mocks/log-patterns.ts
+++ b/web/src/mocks/log-patterns.ts
@@ -1,0 +1,182 @@
+/**
+ * B4 log patterns (pages.md B4 [Designed 2026-07-20], OBS-012) — clusters
+ * the deterministic log stream into message templates with `<placeholders>`
+ * marking the clustered variables. Same-input-same-clusters: the template
+ * extraction is a pure function of the seeded lines.
+ */
+
+import type {
+  LogEvent,
+  LogLevel,
+  LogPattern,
+  LogPatternsResult,
+} from "@/models";
+import {
+  logLinesAtSecond,
+  type HeroTraceWindow,
+  type OutageWindow,
+} from "./series";
+import { SECOND } from "./util";
+
+export const TREND_BUCKETS = 7;
+
+/** Max seconds enumerated per query — wider ranges sample evenly and
+ *  scale the counts (deterministic stride; the samples stay real lines). */
+const MAX_ENUMERATED_SECONDS = 3_600;
+
+/** Keys whose `key=value` values are variable across lines by design. */
+const VARIABLE_KEYS = new Set([
+  "service",
+  "version",
+  "monitor",
+  "path",
+  "target",
+  "dashboard",
+  "provider",
+  "store",
+  "channel",
+  "table",
+  "queue",
+  "property",
+  "period",
+  "result",
+  "err",
+  "reason",
+  "used",
+]);
+
+const NUM_RE = /^\d+(\.\d+)?(ms|s|kb|mb|gb|%|x)?$/i;
+const HEX_RE = /^[0-9a-f]{8,}$/i;
+const VERSION_RE = /^v?\d+\.\d+\.\d+$/;
+
+function placeholderForValue(value: string): string | null {
+  if (NUM_RE.test(value)) return "<num>";
+  if (HEX_RE.test(value)) return "<id>";
+  if (VERSION_RE.test(value)) return "<version>";
+  return null;
+}
+
+/**
+ * Template extraction: whitespace tokens; numeric/hex/version tokens (and
+ * `key=value` values — plus values of known-variable keys) collapse into
+ * `<placeholders>`; everything else stays literal.
+ */
+export function templateOf(message: string): string {
+  return message
+    .split(" ")
+    .map((token) => {
+      const eq = token.indexOf("=");
+      if (eq > 0) {
+        const key = token.slice(0, eq);
+        const value = token.slice(eq + 1);
+        const ph =
+          placeholderForValue(value) ??
+          (VARIABLE_KEYS.has(key) ? `<${key}>` : null);
+        return ph ? `${key}=${ph}` : token;
+      }
+      return placeholderForValue(token) ?? token;
+    })
+    .join(" ");
+}
+
+export interface ClusterFilters {
+  service?: string;
+  level?: string;
+  /** Free-text terms — a line must contain every term (explorer parity). */
+  text?: string[];
+}
+
+interface Accumulator {
+  template: string;
+  count: number;
+  trend: number[];
+  levels: Map<LogLevel, number>;
+  samples: LogEvent[];
+}
+
+/**
+ * Cluster the range's lines into patterns. Deterministic: enumerates whole
+ * seconds of the shared line generator; ranges wider than
+ * MAX_ENUMERATED_SECONDS sample every `stride`-th second and scale counts
+ * by the stride (real lines, honest totals ±sampling).
+ */
+export function clusterLogs(
+  fromMs: number,
+  toMs: number,
+  outage: OutageWindow,
+  filters: ClusterFilters = {},
+  hero?: HeroTraceWindow,
+): LogPatternsResult {
+  const fromSec = Math.floor(fromMs / SECOND);
+  const toSec = Math.max(Math.floor(toMs / SECOND), fromSec + 1);
+  const rangeSec = toSec - fromSec;
+  const stride = Math.max(1, Math.ceil(rangeSec / MAX_ENUMERATED_SECONDS));
+  const bucketSec = rangeSec / TREND_BUCKETS;
+
+  const acc = new Map<string, Accumulator>();
+  const terms = (filters.text ?? []).map((t) => t.toLowerCase());
+  let total = 0;
+
+  // newest → oldest so the first samples kept per pattern are the newest
+  for (let sec = toSec - 1; sec >= fromSec; sec -= stride) {
+    for (const event of logLinesAtSecond(sec, outage, hero)) {
+      if (filters.service && event.service !== filters.service) continue;
+      if (filters.level && event.level !== filters.level.toUpperCase())
+        continue;
+      if (terms.length > 0) {
+        const haystack = event.message.toLowerCase();
+        if (!terms.every((t) => haystack.includes(t))) continue;
+      }
+      const template = templateOf(event.message);
+      let entry = acc.get(template);
+      if (!entry) {
+        entry = {
+          template,
+          count: 0,
+          trend: Array.from({ length: TREND_BUCKETS }, () => 0),
+          levels: new Map(),
+          samples: [],
+        };
+        acc.set(template, entry);
+      }
+      entry.count += stride;
+      total += stride;
+      const bucket = Math.min(
+        TREND_BUCKETS - 1,
+        Math.floor((sec - fromSec) / bucketSec),
+      );
+      entry.trend[bucket] += stride;
+      entry.levels.set(event.level, (entry.levels.get(event.level) ?? 0) + 1);
+      if (entry.samples.length < 3) entry.samples.push(event);
+    }
+  }
+
+  const patterns: LogPattern[] = [...acc.values()]
+    .map((entry) => ({
+      template: entry.template,
+      count: entry.count,
+      dominant_level: dominantLevel(entry.levels),
+      trend: entry.trend,
+      samples: entry.samples,
+    }))
+    .sort((a, b) => b.count - a.count || a.template.localeCompare(b.template));
+
+  return {
+    patterns,
+    total_lines: total,
+    bucket_ms: Math.round((rangeSec / TREND_BUCKETS) * SECOND),
+    sampled: stride > 1,
+  };
+}
+
+function dominantLevel(levels: Map<LogLevel, number>): LogLevel {
+  let best: LogLevel = "INFO";
+  let bestCount = -1;
+  for (const [level, count] of levels) {
+    if (count > bestCount) {
+      best = level;
+      bestCount = count;
+    }
+  }
+  return best;
+}

--- a/web/src/mocks/rum-drilldown.test.ts
+++ b/web/src/mocks/rum-drilldown.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildRumDrilldown,
+  CONVERSION_EVENT,
+  RETENTION_COHORTS,
+  RETENTION_WEEKS,
+  retentionPct,
+  weekStartMs,
+} from "./rum-drilldown";
+import { rumSummary } from "./rum-data";
+
+const HOUR = 3_600_000;
+const DAY = 24 * HOUR;
+const NOW = Date.parse("2026-07-20T12:00:00Z");
+const FROM = NOW - 4 * HOUR;
+
+describe("buildRumDrilldown — funnel", () => {
+  const result = buildRumDrilldown(FROM, NOW, NOW);
+
+  it("is deterministic", () => {
+    expect(buildRumDrilldown(FROM, NOW, NOW)).toEqual(result);
+  });
+
+  it("page views and sessions are the B6 summary's own numbers", () => {
+    const summary = rumSummary(FROM, NOW);
+    const [views, sessions] = result.funnel.stages;
+    expect(views.count).toBe(summary.page_views);
+    expect(sessions.count).toBe(summary.visits);
+  });
+
+  it("stages strictly narrow with correct share-of-previous math", () => {
+    const [views, sessions, conversions] = result.funnel.stages;
+    expect(views.count).toBeGreaterThan(sessions.count);
+    expect(sessions.count).toBeGreaterThan(conversions.count);
+    expect(views.pct_of_previous).toBe(100);
+    expect(sessions.pct_of_previous).toBe(
+      Math.round((sessions.count / views.count) * 1000) / 10,
+    );
+    expect(conversions.pct_of_previous).toBe(
+      Math.round((conversions.count / sessions.count) * 1000) / 10,
+    );
+    // signup conversions run ~9–13% of sessions by construction
+    expect(conversions.pct_of_previous).toBeGreaterThan(5);
+    expect(conversions.pct_of_previous).toBeLessThan(20);
+  });
+
+  it("names the conversion definition (labeled honestly in-page)", () => {
+    expect(result.funnel.conversion_event).toBe(CONVERSION_EVENT);
+    expect(result.funnel.stages[2].label).toBe("Conversions — signup");
+  });
+});
+
+describe("buildRumDrilldown — weekly cohort retention", () => {
+  const result = buildRumDrilldown(FROM, NOW, NOW);
+  const { cohorts, weeks } = result.retention;
+
+  it("grids the last 8 ISO weeks × wk 0–6", () => {
+    expect(weeks).toBe(RETENTION_WEEKS);
+    expect(cohorts).toHaveLength(RETENTION_COHORTS);
+    for (const cohort of cohorts) {
+      expect(cohort.values).toHaveLength(RETENTION_WEEKS);
+      // Monday-aligned cohort starts
+      expect(new Date(cohort.start).getUTCDay()).toBe(1);
+    }
+    // newest cohort = the Monday of the range end's week
+    expect(Date.parse(cohorts[cohorts.length - 1].start)).toBe(
+      weekStartMs(NOW),
+    );
+  });
+
+  it("wk 0 = 100% and retention never increases week over week", () => {
+    for (const cohort of cohorts) {
+      expect(cohort.values[0]).toBe(100);
+      const observed = cohort.values.filter((v) => v > 0);
+      for (let i = 1; i < observed.length; i++) {
+        expect(observed[i]).toBeLessThanOrEqual(observed[i - 1]);
+      }
+    }
+  });
+
+  it("weeks that have not happened yet report 0", () => {
+    const newest = cohorts[cohorts.length - 1];
+    const start = Date.parse(newest.start);
+    for (let w = 0; w < RETENTION_WEEKS; w++) {
+      if (start + w * 7 * DAY > NOW) expect(newest.values[w]).toBe(0);
+      else expect(newest.values[w]).toBeGreaterThan(0);
+    }
+    // the oldest cohort has lived all 7 weeks — fully observed
+    expect(cohorts[0].values.every((v) => v > 0)).toBe(true);
+  });
+
+  it("retentionPct is deterministic per (cohort, week)", () => {
+    const start = weekStartMs(NOW) - 5 * 7 * DAY;
+    expect(retentionPct(start, 3)).toBe(retentionPct(start, 3));
+  });
+});

--- a/web/src/mocks/rum-drilldown.ts
+++ b/web/src/mocks/rum-drilldown.ts
@@ -1,0 +1,102 @@
+/**
+ * B6 RUM drill-down (U6-2, pages.md B6 [Designed 2026-07-20]) — funnel and
+ * weekly-cohort retention, deterministic and coherent with rum-data.ts:
+ * the funnel's page views/sessions are the SAME rumSummary math the B6
+ * overview shows; conversions count the registered signup event
+ * (`auth_signin_completed`, api.md §3.4 upstat row).
+ */
+
+import type { RumDrilldown } from "@/models";
+import { rumSummary } from "./rum-data";
+import { DAY, hashSeed, iso, mulberry32, unitFor } from "./util";
+
+export const CONVERSION_EVENT = "auth_signin_completed";
+export const RETENTION_WEEKS = 7; // wk 0–6
+export const RETENTION_COHORTS = 8;
+
+const WEEK = 7 * DAY;
+
+/**
+ * Deterministic signup-conversion count for a bucket series — a stable
+ * ~9–13% of the bucket's sessions (visits), keyed per bucket so the same
+ * range always reports the same funnel.
+ */
+function conversionsFor(series: { bucket: string; count: number }[]): number {
+  let total = 0;
+  for (const bucket of series) {
+    const sessions = Math.round(bucket.count / 2.6); // rum-data.ts visits ratio
+    const r = mulberry32(hashSeed(`conv:${bucket.bucket}`));
+    total += Math.round(sessions * (0.09 + r() * 0.04));
+  }
+  return total;
+}
+
+/** Monday 00:00 UTC on/before `tMs` (cohort weeks are ISO weeks). */
+export function weekStartMs(tMs: number): number {
+  const date = new Date(tMs);
+  const day = (date.getUTCDay() + 6) % 7; // Mon=0
+  return Date.UTC(
+    date.getUTCFullYear(),
+    date.getUTCMonth(),
+    date.getUTCDate() - day,
+  );
+}
+
+/**
+ * Retention % for a cohort at week offset — wk 0 = 100%, then a
+ * multiplicative decay (~35–45% wk 1, flattening) with per-cell noise.
+ */
+export function retentionPct(cohortStartMs: number, week: number): number {
+  if (week === 0) return 100;
+  let pct = 100;
+  for (let w = 1; w <= week; w++) {
+    const keep =
+      w === 1
+        ? 0.34 + unitFor(`cohort:${cohortStartMs}:1`) * 0.12
+        : 0.62 + unitFor(`cohort:${cohortStartMs}:${w}`) * 0.28;
+    pct *= keep;
+  }
+  return Math.round(pct * 10) / 10;
+}
+
+export function buildRumDrilldown(
+  fromMs: number,
+  toMs: number,
+  now: number,
+): RumDrilldown {
+  const summary = rumSummary(fromMs, toMs);
+  const sessions = summary.visits;
+  const conversions = Math.min(conversionsFor(summary.series), sessions);
+
+  const stages = [
+    { key: "page_views", label: "Page views", count: summary.page_views },
+    { key: "sessions", label: "Sessions", count: sessions },
+    { key: "conversions", label: "Conversions — signup", count: conversions },
+  ].map((stage, i, all) => ({
+    ...stage,
+    pct_of_previous:
+      i === 0
+        ? 100
+        : all[i - 1].count === 0
+          ? 0
+          : Math.round((stage.count / all[i - 1].count) * 1000) / 10,
+  }));
+
+  // Weekly cohorts: the last RETENTION_COHORTS ISO weeks up to the range
+  // end; week offsets that haven't happened yet report 0 (no data).
+  const lastCohort = weekStartMs(toMs);
+  const cohorts = Array.from({ length: RETENTION_COHORTS }, (_, i) => {
+    const start = lastCohort - (RETENTION_COHORTS - 1 - i) * WEEK;
+    return {
+      start: iso(start),
+      values: Array.from({ length: RETENTION_WEEKS }, (_, week) =>
+        start + week * WEEK > now ? 0 : retentionPct(start, week),
+      ),
+    };
+  });
+
+  return {
+    funnel: { stages, conversion_event: CONVERSION_EVENT },
+    retention: { weeks: RETENTION_WEEKS, cohorts },
+  };
+}

--- a/web/src/mocks/seed.ts
+++ b/web/src/mocks/seed.ts
@@ -22,6 +22,8 @@ import type {
   SavedView,
   ServiceCatalogEntry,
   Slo,
+  SyntheticCheck,
+  SyntheticRun,
   TimelineEntry,
   Trace,
   TraceSummary,
@@ -37,6 +39,7 @@ import {
   nextId,
 } from "./util";
 import { SERVICES, type OutageWindow } from "./series";
+import { seedSynthetics } from "./synthetics";
 
 export const HERO_TRACE_ID = "9f86d081884c7d659a2feaa0c55ad015";
 
@@ -57,6 +60,9 @@ export interface MockDb {
   members: Member[];
   dashboards: Dashboard[];
   monitors: Monitor[];
+  synthetics: SyntheticCheck[];
+  /** Run history per synthetic check id, newest first. */
+  syntheticRuns: Record<string, SyntheticRun[]>;
   channels: AlertChannel[];
   rules: AlertRule[];
   alertFeed: AlertEvent[];
@@ -1045,6 +1051,11 @@ export function buildSeed(now: number): MockDb {
     },
   ];
 
+  const { checks: synthetics, runs: syntheticRuns } = seedSynthetics(
+    now,
+    outage,
+  );
+
   return {
     seededAt: now,
     outage,
@@ -1059,6 +1070,8 @@ export function buildSeed(now: number): MockDb {
     members,
     dashboards,
     monitors,
+    synthetics,
+    syntheticRuns,
     channels,
     rules,
     alertFeed,
@@ -1152,6 +1165,8 @@ export function buildEmptySeed(
     ],
     dashboards: [],
     monitors: [],
+    synthetics: [],
+    syntheticRuns: {},
     channels: [],
     rules: [],
     alertFeed: [],

--- a/web/src/mocks/seed.ts
+++ b/web/src/mocks/seed.ts
@@ -22,6 +22,7 @@ import type {
   SavedView,
   ServiceCatalogEntry,
   Slo,
+  StatusPageConfig,
   SyntheticCheck,
   SyntheticRun,
   TimelineEntry,
@@ -57,6 +58,13 @@ export interface MockDb {
   firstDataAtMs: number | null;
   /** Public status-page slug (pages.md B7 — owner-chosen, unique). */
   statusSlug: string | null;
+  /**
+   * Status-page builder document (B7 [Designed 2026-07-20]) — branding +
+   * ordered component list; `buildStatusPage` renders it. Null until the
+   * org publishes a page. `statusSlug` mirrors `statusPage.slug` (the
+   * routing key the public read resolves).
+   */
+  statusPage: StatusPageConfig | null;
   members: Member[];
   dashboards: Dashboard[];
   monitors: Monitor[];
@@ -1067,6 +1075,23 @@ export function buildSeed(now: number): MockDb {
     },
     firstDataAtMs: null,
     statusSlug: "upstat",
+    // U0-5: the slugged page over the live monitor set — row order is the
+    // public page order (B7 builder, Figma 331:12857)
+    statusPage: {
+      name: "Upstat",
+      slug: "upstat",
+      components: [
+        { id: "spc_homepage", name: "Homepage", monitor_id: "mon_homepage" },
+        { id: "spc_api", name: "API health", monitor_id: "mon_api" },
+        { id: "spc_status", name: "Status page", monitor_id: "mon_status" },
+        {
+          id: "spc_checkout",
+          name: "Checkout flow",
+          monitor_id: "mon_checkout",
+        },
+        { id: "spc_docs", name: "Docs", monitor_id: "mon_docs" },
+      ],
+    },
     members,
     dashboards,
     monitors,
@@ -1154,6 +1179,7 @@ export function buildEmptySeed(
     onboarding: { org_created: true, has_data: false, ingest_key: ingestKey },
     firstDataAtMs: now + FIRST_DATA_DELAY_MS,
     statusSlug: null,
+    statusPage: null,
     members: [
       {
         id: "usr_ibukun",

--- a/web/src/mocks/series.ts
+++ b/web/src/mocks/series.ts
@@ -480,68 +480,82 @@ export function generateLogs(
   const startSec = Math.floor(beforeMs / SECOND) - 1;
   const endSec = Math.floor(fromMs / SECOND);
   for (let sec = startSec; sec >= endSec && events.length < limit; sec--) {
-    const secMs = sec * SECOND;
-    // rollout stage lines landing in this second (usually none)
-    const rollouts = SERVICES.map((s) => ({
-      service: s as string,
-      line: deployStageLine(s, secMs),
-    })).filter((x): x is { service: string; line: string } => x.line !== null);
-    const perSecond = 3;
-    for (let slot = perSecond - 1; slot >= 0 && events.length < limit; slot--) {
-      const key = `log:${sec}:${slot}`;
-      const r = mulberry32(hashSeed(key));
-      // slot-banded offsets keep newest-first ordering strict within a second
-      const tMs = secMs + slot * 300 + Math.floor(r() * 250);
-      const outageHit = tMs >= outage.start && tMs <= outage.end;
-      const rollout = slot === 0 ? rollouts[0] : undefined;
-      // during the outage, bias lines toward the implicated services
-      const service = rollout
-        ? rollout.service
-        : outageHit && r() < 0.5
-          ? outage.services[Math.floor(r() * outage.services.length)]
-          : SERVICES[Math.floor(r() * SERVICES.length)];
-      const level = rollout
-        ? "INFO"
-        : levelFor(r(), outageHit && outage.services.includes(service));
-      if (filterService && service !== filterService) continue;
-      if (filterLevel && level !== filterLevel.toUpperCase()) continue;
-      const deploy = lastDeploy(service, tMs);
-      const templates = LOG_TEMPLATES[level];
-      const message = rollout
-        ? rollout.line
-        : templates[Math.floor(r() * templates.length)];
-      const heroHit =
-        hero !== undefined &&
-        tMs >= hero.startMs - 1_500 &&
-        tMs <= hero.startMs + hero.durationMs + 1_500 &&
-        hero.services.includes(service);
-      // the line's trace id: hero window → hero id; else a per-line hex on
-      // ~25% of lines — and always on messages that print a trace_id
-      let traceId = heroHit
-        ? hero.id
-        : r() < 0.25
-          ? traceIdHex(key)
-          : undefined;
-      let finalMessage = message;
-      if (finalMessage.includes("{trace_id}")) {
-        traceId ??= traceIdHex(key);
-        finalMessage = finalMessage.replace("{trace_id}", traceId);
-      }
-      events.push({
-        id: `log_${sec}_${slot}`,
-        ts: iso(tMs),
-        service,
-        level,
-        host: HOSTS[Math.floor(r() * HOSTS.length)],
-        message: finalMessage,
-        attrs: {
-          env: "prod",
-          version: deploy.version,
-          ...(level === "ERROR" ? { "error.kind": "upstream" } : {}),
-        },
-        ...(traceId ? { trace_id: traceId } : {}),
-      });
+    for (const event of logLinesAtSecond(sec, outage, hero)) {
+      if (events.length >= limit) break;
+      if (filterService && event.service !== filterService) continue;
+      if (filterLevel && event.level !== filterLevel.toUpperCase()) continue;
+      events.push(event);
     }
+  }
+  return events;
+}
+
+/**
+ * The 3 deterministic lines of one whole second, newest-first — the single
+ * line generator behind the explorer stream AND the B4 Patterns clustering
+ * (mocks/log-patterns.ts), so both surfaces describe the same telemetry.
+ */
+export function logLinesAtSecond(
+  sec: number,
+  outage: OutageWindow,
+  hero?: HeroTraceWindow,
+): LogEvent[] {
+  const events: LogEvent[] = [];
+  const secMs = sec * SECOND;
+  // rollout stage lines landing in this second (usually none)
+  const rollouts = SERVICES.map((s) => ({
+    service: s as string,
+    line: deployStageLine(s, secMs),
+  })).filter((x): x is { service: string; line: string } => x.line !== null);
+  const perSecond = 3;
+  for (let slot = perSecond - 1; slot >= 0; slot--) {
+    const key = `log:${sec}:${slot}`;
+    const r = mulberry32(hashSeed(key));
+    // slot-banded offsets keep newest-first ordering strict within a second
+    const tMs = secMs + slot * 300 + Math.floor(r() * 250);
+    const outageHit = tMs >= outage.start && tMs <= outage.end;
+    const rollout = slot === 0 ? rollouts[0] : undefined;
+    // during the outage, bias lines toward the implicated services
+    const service = rollout
+      ? rollout.service
+      : outageHit && r() < 0.5
+        ? outage.services[Math.floor(r() * outage.services.length)]
+        : SERVICES[Math.floor(r() * SERVICES.length)];
+    const level = rollout
+      ? "INFO"
+      : levelFor(r(), outageHit && outage.services.includes(service));
+    const deploy = lastDeploy(service, tMs);
+    const templates = LOG_TEMPLATES[level];
+    const message = rollout
+      ? rollout.line
+      : templates[Math.floor(r() * templates.length)];
+    const heroHit =
+      hero !== undefined &&
+      tMs >= hero.startMs - 1_500 &&
+      tMs <= hero.startMs + hero.durationMs + 1_500 &&
+      hero.services.includes(service);
+    // the line's trace id: hero window → hero id; else a per-line hex on
+    // ~25% of lines — and always on messages that print a trace_id
+    let traceId = heroHit ? hero.id : r() < 0.25 ? traceIdHex(key) : undefined;
+    let finalMessage = message;
+    if (finalMessage.includes("{trace_id}")) {
+      traceId ??= traceIdHex(key);
+      finalMessage = finalMessage.replace("{trace_id}", traceId);
+    }
+    events.push({
+      id: `log_${sec}_${slot}`,
+      ts: iso(tMs),
+      service,
+      level,
+      host: HOSTS[Math.floor(r() * HOSTS.length)],
+      message: finalMessage,
+      attrs: {
+        env: "prod",
+        version: deploy.version,
+        ...(level === "ERROR" ? { "error.kind": "upstream" } : {}),
+      },
+      ...(traceId ? { trace_id: traceId } : {}),
+    });
   }
   return events;
 }

--- a/web/src/mocks/status-page.test.ts
+++ b/web/src/mocks/status-page.test.ts
@@ -69,3 +69,60 @@ describe("buildStatusPage (B7 public read)", () => {
     expect([...times].sort((a, b) => b - a)).toEqual(times);
   });
 });
+
+describe("buildStatusPage — builder config reflection (B7 [Designed 2026-07-20])", () => {
+  it("renders builder rows in order with builder names", () => {
+    const db = buildSeed(NOW);
+    db.statusPage = {
+      name: "Upstat",
+      slug: "upstat",
+      components: [
+        { id: "spc_1", name: "API", monitor_id: "mon_api" },
+        { id: "spc_2", name: "Dashboard", monitor_id: "mon_homepage" },
+      ],
+    };
+    const page = buildStatusPage(db, "upstat", NOW);
+    expect(page.components.map((c) => c.name)).toEqual(["API", "Dashboard"]);
+    // mapped monitor supplies status/strip/latency under the builder name
+    const api = page.components[0];
+    const monApi = db.monitors.find((m) => m.id === "mon_api")!;
+    expect(api.status).toBe(monApi.status);
+    expect(api.p95_ms).toBe(monApi.last_response_time_ms);
+    expect(api.days).toHaveLength(90);
+  });
+
+  it("reorder in the builder reorders the public page", () => {
+    const db = buildSeed(NOW);
+    const [first, ...rest] = db.statusPage!.components;
+    db.statusPage = {
+      ...db.statusPage!,
+      components: [...rest, first],
+    };
+    const page = buildStatusPage(db, "upstat", NOW);
+    expect(page.components[page.components.length - 1].name).toBe(first.name);
+  });
+
+  it("the builder page name governs the public header", () => {
+    const db = buildSeed(NOW);
+    db.statusPage = { ...db.statusPage!, name: "Upstat Cloud" };
+    expect(buildStatusPage(db, "upstat", NOW).org_name).toBe("Upstat Cloud");
+  });
+
+  it("unmapped rows publish as nodata, never crash", () => {
+    const db = buildSeed(NOW);
+    db.statusPage = {
+      ...db.statusPage!,
+      components: [{ id: "spc_x", name: "Ingestion", monitor_id: null }],
+    };
+    const page = buildStatusPage(db, "upstat", NOW);
+    expect(page.components).toEqual([
+      {
+        name: "Ingestion",
+        status: "nodata",
+        days: [],
+        uptime_pct: null,
+        p95_ms: null,
+      },
+    ]);
+  });
+});

--- a/web/src/mocks/status-page.ts
+++ b/web/src/mocks/status-page.ts
@@ -28,21 +28,46 @@ export function buildStatusPage(
   slug: string,
   now = Date.now(),
 ): StatusPage {
-  // Public components = the active, unmuted checks (paused stays internal).
-  const components = db.monitors
-    .filter((m) => m.active && !m.muted)
-    .map((m) => {
-      const history = monitorHistory(m, now, db.outage);
-      return {
-        name: m.name,
-        status: m.status,
-        days: history.days,
-        uptime_pct: history.uptime_90d_pct,
-        // same latency source as the uptime pillar's cards — the page
-        // previously hardcoded 96ms and disagreed with /dashboard/uptime
-        p95_ms: m.last_response_time_ms,
-      };
-    });
+  // B7 builder document (Figma 331:12857): row order = public page order,
+  // display names from the builder, statuses from the mapped monitors.
+  // Orgs without a config publish their active, unmuted checks directly
+  // (the pre-builder construction — paused stays internal either way).
+  const components = db.statusPage
+    ? db.statusPage.components.map((row) => {
+        const monitor = db.monitors.find((m) => m.id === row.monitor_id);
+        if (!monitor) {
+          // unmapped row publishes as a nodata component, never a crash
+          return {
+            name: row.name,
+            status: "nodata" as const,
+            days: [],
+            uptime_pct: null,
+            p95_ms: null,
+          };
+        }
+        const history = monitorHistory(monitor, now, db.outage);
+        return {
+          name: row.name,
+          status: monitor.status,
+          days: history.days,
+          uptime_pct: history.uptime_90d_pct,
+          p95_ms: monitor.last_response_time_ms,
+        };
+      })
+    : db.monitors
+        .filter((m) => m.active && !m.muted)
+        .map((m) => {
+          const history = monitorHistory(m, now, db.outage);
+          return {
+            name: m.name,
+            status: m.status,
+            days: history.days,
+            uptime_pct: history.uptime_90d_pct,
+            // same latency source as the uptime pillar's cards — the page
+            // previously hardcoded 96ms and disagreed with /dashboard/uptime
+            p95_ms: m.last_response_time_ms,
+          };
+        });
 
   const incidents: StatusPageIncident[] = [...db.incidents]
     .sort((a, b) => {
@@ -64,7 +89,8 @@ export function buildStatusPage(
 
   return {
     slug,
-    org_name: db.org.name,
+    // the builder's "Page name" governs the public header when set
+    org_name: db.statusPage?.name ?? db.org.name,
     overall: overallFor(db),
     updated_at: iso(now),
     components,

--- a/web/src/mocks/synthetics.test.ts
+++ b/web/src/mocks/synthetics.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+import { executeRun, seedSynthetics, validateCheckInput } from "./synthetics";
+import { stepSummary } from "@/models";
+
+const HOUR = 3_600_000;
+const MINUTE = 60_000;
+
+describe("stepSummary", () => {
+  it("derives the mono row copy per kind", () => {
+    expect(
+      stepSummary({ kind: "http", method: "GET", url: "https://a.io/h" }),
+    ).toBe("GET https://a.io/h");
+    expect(
+      stepSummary({ kind: "assertion", expression: "status == 200" }),
+    ).toBe("status == 200");
+    expect(stepSummary({ kind: "wait", wait_ms: 500 })).toBe("wait 500 ms");
+  });
+});
+
+describe("validateCheckInput", () => {
+  const base = {
+    name: "x",
+    kind: "multi_step" as const,
+    steps: [
+      { kind: "http" as const, method: "GET" as const, url: "https://a.io" },
+    ],
+    browser: null,
+  };
+  it("accepts a valid multi-step payload", () => {
+    expect(validateCheckInput(base)).toBeNull();
+  });
+  it("rejects with snake_case catalog codes", () => {
+    expect(validateCheckInput({ ...base, name: " " })?.code).toBe(
+      "name_required",
+    );
+    expect(validateCheckInput({ ...base, steps: [] })?.code).toBe(
+      "steps_required",
+    );
+    expect(
+      validateCheckInput({
+        ...base,
+        steps: [{ kind: "http", method: "GET", url: "ftp://nope" }],
+      })?.code,
+    ).toBe("invalid_target");
+    expect(
+      validateCheckInput({
+        ...base,
+        steps: [{ kind: "wait", wait_ms: -1 }],
+      })?.code,
+    ).toBe("invalid_wait");
+    expect(
+      validateCheckInput({
+        ...base,
+        kind: "browser",
+        steps: [],
+        browser: {
+          url: "https://a.io",
+          viewport: "999x999",
+          screenshot_on_failure: true,
+        },
+      })?.code,
+    ).toBe("invalid_viewport");
+  });
+});
+
+describe("executeRun", () => {
+  const now = Date.parse("2026-07-20T12:00:00Z");
+  const seeded = seedSynthetics(now, {
+    start: now - 3 * HOUR,
+    end: now - 2 * HOUR - 15 * MINUTE,
+  });
+  const check = seeded.checks[0];
+
+  it("is deterministic — same check + run number = identical results", () => {
+    const a = executeRun(check, 500, now);
+    const b = executeRun(check, 500, now);
+    expect(a.steps).toEqual(b.steps);
+    expect(a.total_ms).toBe(b.total_ms);
+    expect(a.status).toBe("pass");
+    expect(a.steps).toHaveLength(check.steps.length);
+  });
+
+  it("stops at the first failure and captures the screenshot", () => {
+    const run = executeRun(check, 501, now, 2);
+    expect(run.status).toBe("fail");
+    expect(run.steps).toHaveLength(3); // steps 4–5 not run
+    expect(run.steps[2].status).toBe("fail");
+    expect(run.steps_total).toBe(5);
+    expect(run.failure_screenshot).toEqual({
+      step_index: 3,
+      viewport: "1440x900",
+    });
+    // total = sum of executed durations only
+    expect(run.total_ms).toBe(run.steps.reduce((s, r) => s + r.duration_ms, 0));
+  });
+
+  it("wait steps run for exactly their configured wait", () => {
+    const run = executeRun(check, 502, now);
+    const wait = run.steps.find((s) => s.kind === "wait");
+    expect(wait?.duration_ms).toBe(500);
+  });
+});
+
+describe("seedSynthetics", () => {
+  const now = Date.parse("2026-07-20T12:00:00Z");
+  const outage = { start: now - 3 * HOUR, end: now - 2 * HOUR - 15 * MINUTE };
+  const { checks, runs } = seedSynthetics(now, outage);
+
+  it("seeds the multi-step checkout check with a browser stage", () => {
+    expect(checks).toHaveLength(1);
+    expect(checks[0].kind).toBe("multi_step");
+    expect(checks[0].steps.map((s) => s.kind)).toEqual([
+      "http",
+      "assertion",
+      "assertion",
+      "wait",
+      "http",
+    ]);
+    expect(checks[0].browser?.screenshot_on_failure).toBe(true);
+  });
+
+  it("the run inside the INC-42 window fails; neighbours pass (coherence)", () => {
+    const history = runs[checks[0].id];
+    const byNumber = new Map(history.map((r) => [r.number, r]));
+    const failing = history.filter((r) => r.status === "fail");
+    expect(failing).toHaveLength(1);
+    const failTs = Date.parse(failing[0].started_at);
+    expect(failTs).toBeGreaterThanOrEqual(outage.start);
+    expect(failTs).toBeLessThanOrEqual(outage.end);
+    expect(failing[0].number).toBe(482);
+    expect(byNumber.get(481)?.status).toBe("pass");
+    expect(byNumber.get(483)?.status).toBe("pass");
+    // latest run is reflected on the check row
+    expect(checks[0].last_run_status).toBe("pass");
+    expect(checks[0].last_run_id).toBe(history[0].id);
+  });
+});

--- a/web/src/mocks/synthetics.ts
+++ b/web/src/mocks/synthetics.ts
@@ -1,0 +1,220 @@
+/**
+ * Synthetic checks (pages.md B7 multi-step/browser, OBS-011) — step
+ * normalization, validation, and the deterministic run replay behind
+ * POST /v1/synthetics/{id}/runs. Same-input-same-result like every mock
+ * generator (mocks/series.ts).
+ */
+
+import {
+  stepSummary,
+  type SyntheticCheck,
+  type SyntheticCheckInput,
+  type SyntheticRun,
+  type SyntheticStep,
+  type SyntheticStepInput,
+  type SyntheticStepResult,
+} from "@/models";
+import { hashSeed, iso, mulberry32, nextId } from "./util";
+
+export const SYNTHETIC_VIEWPORTS = ["1440x900", "768x1024", "390x844"] as const;
+
+export type StepValidationError = { code: string; message: string };
+
+/** Validate a builder payload — snake_case catalog codes (engineering.md). */
+export function validateCheckInput(
+  input: Partial<SyntheticCheckInput>,
+): StepValidationError | null {
+  if (!input.name?.trim()) {
+    return { code: "name_required", message: "check name is required" };
+  }
+  if (input.kind !== "multi_step" && input.kind !== "browser") {
+    return {
+      code: "invalid_kind",
+      message: "kind must be multi_step or browser",
+    };
+  }
+  const steps = input.steps ?? [];
+  if (input.kind === "multi_step" && steps.length === 0) {
+    return { code: "steps_required", message: "add at least one step" };
+  }
+  for (const step of steps) {
+    if (step.kind === "http") {
+      if (!/^https?:\/\/.+/.test(step.url ?? "")) {
+        return { code: "invalid_target", message: "step URL must be http(s)" };
+      }
+    } else if (step.kind === "assertion") {
+      if (!step.expression?.trim()) {
+        return {
+          code: "invalid_expression",
+          message: "assertion expression is required",
+        };
+      }
+    } else if (step.kind === "wait") {
+      if (!Number.isFinite(step.wait_ms) || step.wait_ms <= 0) {
+        return {
+          code: "invalid_wait",
+          message: "wait must be a positive ms value",
+        };
+      }
+    } else {
+      return {
+        code: "invalid_step_kind",
+        message: "step kind must be http, assertion or wait",
+      };
+    }
+  }
+  if (input.kind === "browser" || input.browser) {
+    const browser = input.browser;
+    if (!browser || !/^https?:\/\/.+/.test(browser.url)) {
+      return { code: "invalid_target", message: "browser URL must be http(s)" };
+    }
+    if (!SYNTHETIC_VIEWPORTS.includes(browser.viewport as never)) {
+      return {
+        code: "invalid_viewport",
+        message: `viewport must be one of ${SYNTHETIC_VIEWPORTS.join(", ")}`,
+      };
+    }
+  }
+  return null;
+}
+
+/** Normalize builder inputs into stored steps (ids + derived summaries). */
+export function normalizeSteps(inputs: SyntheticStepInput[]): SyntheticStep[] {
+  return inputs.map((input) => ({
+    id: nextId("step"),
+    kind: input.kind,
+    summary: stepSummary(input),
+    ...(input.kind === "http" ? { method: input.method, url: input.url } : {}),
+    ...(input.kind === "assertion" ? { expression: input.expression } : {}),
+    ...(input.kind === "wait" ? { wait_ms: input.wait_ms } : {}),
+  }));
+}
+
+/** Deterministic per-step duration (ms) for a run. */
+function stepDuration(
+  step: SyntheticStep,
+  checkId: string,
+  runNumber: number,
+  index: number,
+): number {
+  if (step.kind === "wait" && step.wait_ms) return step.wait_ms;
+  const r = mulberry32(hashSeed(`run:${checkId}:${runNumber}:${index}`));
+  // http steps span network latency; assertions evaluate a stored body
+  return step.kind === "http"
+    ? Math.round(90 + r() * 320)
+    : Math.round(40 + r() * 90);
+}
+
+/**
+ * Execute a run deterministically. `failAtIndex` (0-based) forces a FAIL at
+ * that step — the seed narrative uses it for the INC-42-window run; live
+ * "Run once" calls pass it as null (nothing is failing right now).
+ */
+export function executeRun(
+  check: SyntheticCheck,
+  runNumber: number,
+  atMs: number,
+  failAtIndex: number | null = null,
+): SyntheticRun {
+  const results: SyntheticStepResult[] = [];
+  let total = 0;
+  let failed = false;
+  for (let i = 0; i < check.steps.length; i++) {
+    const step = check.steps[i];
+    const status = failAtIndex === i ? "fail" : "pass";
+    const duration =
+      status === "fail"
+        ? // failing assertions wait out the retry budget — visibly longer
+          Math.round(
+            420 + mulberry32(hashSeed(`fail:${check.id}:${runNumber}`))() * 160,
+          )
+        : stepDuration(step, check.id, runNumber, i);
+    results.push({
+      index: i + 1,
+      kind: step.kind,
+      summary: step.summary,
+      status,
+      duration_ms: duration,
+    });
+    total += duration;
+    if (status === "fail") {
+      failed = true;
+      break; // stop at first failure
+    }
+  }
+  return {
+    id: nextId("synrun"),
+    check_id: check.id,
+    number: runNumber,
+    status: failed ? "fail" : "pass",
+    started_at: iso(atMs),
+    total_ms: total,
+    steps: results,
+    steps_total: check.steps.length,
+    failure_screenshot:
+      failed && check.browser?.screenshot_on_failure
+        ? {
+            step_index: results[results.length - 1].index,
+            viewport: check.browser.viewport,
+          }
+        : null,
+  };
+}
+
+/**
+ * Seeded multi-step check + run history — "checkout flow — api + web"
+ * verifies the API health endpoint then the checkout page in a headless
+ * browser. Runs every 30m; the run inside the INC-42 window FAILED at the
+ * `body.ok == true` assertion (checkout's health degraded during the
+ * incident) and captured a failure screenshot; later runs pass (INC-42 is
+ * MONITORING — mitigated).
+ */
+export function seedSynthetics(
+  now: number,
+  outage: { start: number; end: number },
+): { checks: SyntheticCheck[]; runs: Record<string, SyntheticRun[]> } {
+  const MINUTE = 60_000;
+  const check: SyntheticCheck = {
+    id: "syn_checkout",
+    name: "checkout flow — api + web",
+    kind: "multi_step",
+    steps: normalizeSteps([
+      {
+        kind: "http",
+        method: "GET",
+        url: "https://api.upstat.cuesoft.io/health",
+      },
+      { kind: "assertion", expression: "status == 200" },
+      { kind: "assertion", expression: "body.ok == true" },
+      { kind: "wait", wait_ms: 500 },
+      { kind: "http", method: "GET", url: "https://checkout.cuesoft.io/" },
+    ]),
+    browser: {
+      url: "https://checkout.cuesoft.io/",
+      viewport: "1440x900",
+      screenshot_on_failure: true,
+    },
+    interval_seconds: 1800,
+    last_run_id: null,
+    last_run_status: null,
+    last_run_at: null,
+    created_at: iso(now - 45 * 24 * 60 * MINUTE),
+    updated_at: iso(now - 45 * 24 * 60 * MINUTE),
+  };
+
+  // Every 30m, newest #487 twelve minutes ago → #482 lands 2h42m ago,
+  // inside the INC-42 window (started 3h ago, mitigated 2h15m ago).
+  const runs: SyntheticRun[] = [];
+  for (let number = 481; number <= 487; number++) {
+    const atMs = now - 12 * MINUTE - (487 - number) * 30 * MINUTE;
+    const inOutage = atMs >= outage.start && atMs <= outage.end;
+    // the degraded health body fails the `body.ok == true` assertion (step 3)
+    runs.push(executeRun(check, number, atMs, inOutage ? 2 : null));
+  }
+  runs.reverse(); // newest first
+  const latest = runs[0];
+  check.last_run_id = latest.id;
+  check.last_run_status = latest.status;
+  check.last_run_at = latest.started_at;
+  return { checks: [check], runs: { [check.id]: runs } };
+}

--- a/web/src/mocks/usage.test.ts
+++ b/web/src/mocks/usage.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { buildSeed } from "./seed";
+import { rumSummary } from "./rum-data";
+import {
+  averageLogLineBytes,
+  buildUsageReport,
+  monthLabel,
+  monthStartMs,
+  USAGE_PLAN_COPY,
+} from "./usage";
+
+// 2026-07-20 12:00 UTC — org tz Africa/Lagos (UTC+1) → local July 20 13:00
+const NOW = Date.parse("2026-07-20T12:00:00Z");
+
+describe("monthStartMs / monthLabel (org-timezone boundaries, X-10)", () => {
+  it("resolves the month boundary in the org timezone, not UTC", () => {
+    // Lagos midnight July 1 = 2026-06-30T23:00:00Z
+    expect(monthStartMs(NOW, "Africa/Lagos")).toBe(
+      Date.parse("2026-06-30T23:00:00Z"),
+    );
+    expect(monthStartMs(NOW, "UTC")).toBe(Date.parse("2026-07-01T00:00:00Z"));
+    // 00:30 UTC on July 1 is still June 30 in New York (UTC-4)
+    const early = Date.parse("2026-07-01T00:30:00Z");
+    expect(monthLabel(early, "America/New_York")).toBe("June 2026");
+    expect(monthLabel(NOW, "Africa/Lagos")).toBe("July 2026");
+  });
+});
+
+describe("buildUsageReport (honest sums from the seed)", () => {
+  const db = buildSeed(NOW);
+  const report = buildUsageReport(db, NOW);
+
+  it("is deterministic and carries the four pillar meters in order", () => {
+    expect(buildUsageReport(buildSeed(NOW), NOW)).toEqual(report);
+    expect(report.month_label).toBe("July 2026");
+    expect(report.rows.map((r) => r.pillar)).toEqual([
+      "metrics",
+      "logs",
+      "traces",
+      "rum",
+    ]);
+  });
+
+  it("metrics = Σ cardinality over the seeded metrics catalog", () => {
+    const expected = db.metricCatalog.reduce((s, m) => s + m.cardinality, 0);
+    const metrics = report.rows.find((r) => r.pillar === "metrics")!;
+    expect(metrics.value).toBe(expected);
+    expect(expected).toBe(2738); // the seeded catalog, summed by hand
+  });
+
+  it("logs = 3 lines/s × seconds MTD × measured mean line bytes", () => {
+    const from = monthStartMs(NOW, db.org.timezone);
+    const seconds = Math.floor((NOW - from) / 1000);
+    const avg = averageLogLineBytes(db, NOW);
+    expect(avg).toBeGreaterThan(100); // real serialized lines, not a guess
+    const logs = report.rows.find((r) => r.pillar === "logs")!;
+    expect(logs.value).toBe(Math.round(3 * seconds * avg));
+    expect(logs.display).toMatch(/GB$/);
+  });
+
+  it("rum = the B6 summary's own page-view math over [month start, now]", () => {
+    const from = monthStartMs(NOW, db.org.timezone);
+    const rum = report.rows.find((r) => r.pillar === "rum")!;
+    expect(rum.value).toBe(rumSummary(from, NOW).page_views);
+  });
+
+  it("traces meter derives from the APM req/s series (non-trivial volume)", () => {
+    const traces = report.rows.find((r) => r.pillar === "traces")!;
+    // ~19.5 Lagos-days of Σ-service traffic × mean span count — just assert
+    // the derivation produced a plausibly large, peak-bounded figure
+    expect(traces.value).toBeGreaterThan(1_000_000);
+    expect(traces.value).toBeLessThanOrEqual(traces.peak);
+  });
+
+  it("every row carries the verbatim plan copy and a usable bar scale", () => {
+    for (const row of report.rows) {
+      expect(row.plan).toBe("Self-host: unlimited · Cloud: announced at GA");
+      expect(row.plan).toBe(USAGE_PLAN_COPY);
+      expect(row.peak).toBeGreaterThan(0);
+      expect(row.value / row.peak).toBeLessThanOrEqual(1);
+    }
+  });
+});

--- a/web/src/mocks/usage.ts
+++ b/web/src/mocks/usage.ts
@@ -1,0 +1,186 @@
+/**
+ * B12 usage metering (pages.md B12 [Designed 2026-07-20], OBS-012) — the
+ * month-to-date meters are COMPUTED from the seeded telemetry volumes
+ * (accuracy canon: honest numbers, not invented):
+ *
+ * - metrics  → Σ cardinality over the seeded metrics catalog (B3 summary)
+ * - logs     → 3 lines/s (the B4 generator's rate) × seconds MTD × the
+ *              measured average line size of real generated lines
+ * - traces   → the APM services' req/s series integrated hourly over the
+ *              month × the seeded traces' mean span count
+ * - rum      → the B6 summary's page-view math over [month start, now]
+ *
+ * Bars scale each meter against its trailing-3-month peak (design.md
+ * §8.2b UsageMeterRow) — for the seeded narrative that peak is the
+ * busiest full month the generators describe.
+ */
+
+import type { UsageMeter, UsageReport } from "@/models";
+import type { MockDb } from "./seed";
+import { SERVICES, metricValue } from "./series";
+import { logLinesAtSecond } from "./series";
+import { rumSummary } from "./rum-data";
+import { DAY, HOUR, SECOND } from "./util";
+
+/** Verbatim plan column (accuracy canon — no invented quotas/pricing). */
+export const USAGE_PLAN_COPY = "Self-host: unlimited · Cloud: announced at GA";
+
+const LOG_LINES_PER_SECOND = 3; // the B4 generator's fixed rate
+
+/** Timezone offset (ms) of `tz` at instant `tMs`. */
+function tzOffsetMs(tMs: number, tz: string): number {
+  const dtf = new Intl.DateTimeFormat("en-US", {
+    timeZone: tz,
+    hour12: false,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+  const p = Object.fromEntries(
+    dtf.formatToParts(tMs).map((part) => [part.type, part.value]),
+  );
+  const asUtc = Date.UTC(
+    Number(p.year),
+    Number(p.month) - 1,
+    Number(p.day),
+    Number(p.hour) % 24,
+    Number(p.minute),
+    Number(p.second),
+  );
+  return asUtc - Math.floor(tMs / SECOND) * SECOND;
+}
+
+/** Month boundaries resolve in the ORG timezone (X-10); storage stays UTC. */
+export function monthStartMs(now: number, tz: string): number {
+  const offset = tzOffsetMs(now, tz);
+  const local = new Date(now + offset);
+  return Date.UTC(local.getUTCFullYear(), local.getUTCMonth(), 1) - offset;
+}
+
+export function monthLabel(now: number, tz: string): string {
+  return new Intl.DateTimeFormat("en-US", {
+    timeZone: tz,
+    month: "long",
+    year: "numeric",
+  }).format(now);
+}
+
+/** Measured mean byte size of real generated lines (JSON-serialized). */
+export function averageLogLineBytes(db: MockDb, now: number): number {
+  const sampleSeconds = 200;
+  let bytes = 0;
+  let lines = 0;
+  const startSec = Math.floor(now / SECOND) - sampleSeconds;
+  for (let sec = startSec; sec < startSec + sampleSeconds; sec++) {
+    for (const event of logLinesAtSecond(sec, db.outage)) {
+      bytes += JSON.stringify(event).length;
+      lines += 1;
+    }
+  }
+  return lines === 0 ? 0 : bytes / lines;
+}
+
+/** Mean span count across the seeded trace explorer list. */
+function meanSpanCount(db: MockDb): number {
+  if (db.traceSummaries.length === 0) return 0;
+  return (
+    db.traceSummaries.reduce((s, t) => s + t.span_count, 0) /
+    db.traceSummaries.length
+  );
+}
+
+/** Requests/s integrated hourly over [fromMs, toMs), all services. */
+function integratedRequests(db: MockDb, fromMs: number, toMs: number): number {
+  let total = 0;
+  for (const service of SERVICES) {
+    for (let t = fromMs; t < toMs; t += HOUR) {
+      const sliceMs = Math.min(HOUR, toMs - t);
+      total +=
+        metricValue("http.requests_total", "rate", service, t, db.outage) *
+        (sliceMs / SECOND);
+    }
+  }
+  return total;
+}
+
+function fmtCount(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return String(Math.round(n));
+}
+
+function fmtGb(bytes: number): string {
+  const gb = bytes / 1e9;
+  return `${gb >= 10 ? Math.round(gb) : gb.toFixed(2)} GB`;
+}
+
+/**
+ * The four pillar meters. `peak` = the busiest full month the generators
+ * describe (trailing-3-month peak, §8.2b): for rate-driven pillars that is
+ * a 31-day integration of the same math; for the active-series gauge the
+ * catalog's cardinality is the peak (it has no month shape).
+ */
+export function buildUsageReport(db: MockDb, now: number): UsageReport {
+  const tz = db.org.timezone || "UTC";
+  const from = monthStartMs(now, tz);
+  const mtdSeconds = Math.max(0, Math.floor((now - from) / SECOND));
+
+  // metrics — active series (gauge; Σ catalog cardinality)
+  const activeSeries = db.metricCatalog.reduce((s, m) => s + m.cardinality, 0);
+
+  // logs — bytes ingested MTD
+  const avgLineBytes = averageLogLineBytes(db, now);
+  const logBytes = LOG_LINES_PER_SECOND * mtdSeconds * avgLineBytes;
+  const logBytesFullMonth =
+    LOG_LINES_PER_SECOND * 31 * (DAY / SECOND) * avgLineBytes;
+
+  // traces — spans MTD
+  const spansPerTrace = meanSpanCount(db);
+  const spans = integratedRequests(db, from, now) * spansPerTrace;
+  const spansFullMonth =
+    integratedRequests(db, now - 31 * DAY, now) * spansPerTrace;
+
+  // rum — events MTD (the B6 summary's own page-view math)
+  const rumEvents = rumSummary(from, now).page_views;
+  const rumFullMonth = rumSummary(now - 31 * DAY, now).page_views;
+
+  const rows: UsageMeter[] = [
+    {
+      pillar: "metrics",
+      label: "Metrics — active series",
+      value: Math.round(activeSeries),
+      display: fmtCount(activeSeries),
+      peak: Math.round(activeSeries),
+      plan: USAGE_PLAN_COPY,
+    },
+    {
+      pillar: "logs",
+      label: "Logs — ingested",
+      value: Math.round(logBytes),
+      display: fmtGb(logBytes),
+      peak: Math.round(logBytesFullMonth),
+      plan: USAGE_PLAN_COPY,
+    },
+    {
+      pillar: "traces",
+      label: "Traces — spans",
+      value: Math.round(spans),
+      display: fmtCount(spans),
+      peak: Math.round(spansFullMonth),
+      plan: USAGE_PLAN_COPY,
+    },
+    {
+      pillar: "rum",
+      label: "RUM — events",
+      value: Math.round(rumEvents),
+      display: fmtCount(rumEvents),
+      peak: Math.round(rumFullMonth),
+      plan: USAGE_PLAN_COPY,
+    },
+  ];
+
+  return { month_label: monthLabel(now, tz), rows };
+}

--- a/web/src/models/index.ts
+++ b/web/src/models/index.ts
@@ -6,6 +6,7 @@ export * from "./telemetry";
 export * from "./rum";
 export * from "./monitors";
 export * from "./synthetics";
+export * from "./usage";
 export * from "./alerts";
 export * from "./incidents";
 export * from "./slos";

--- a/web/src/models/index.ts
+++ b/web/src/models/index.ts
@@ -5,6 +5,7 @@ export * from "./dashboards";
 export * from "./telemetry";
 export * from "./rum";
 export * from "./monitors";
+export * from "./synthetics";
 export * from "./alerts";
 export * from "./incidents";
 export * from "./slos";

--- a/web/src/models/repositories/index.ts
+++ b/web/src/models/repositories/index.ts
@@ -29,6 +29,9 @@ import type {
   ServiceStats,
   Slo,
   StatusPage,
+  SyntheticCheck,
+  SyntheticCheckInput,
+  SyntheticRun,
   TimelineEntry,
   Trace,
   TraceSummary,
@@ -126,6 +129,22 @@ export const monitorsRepo = {
     http.get<MonitorHistory>(`/v1/monitors/${id}/checks`),
   /** MI-9: 24h response-time replay against timeout-derived thresholds. */
   test: (id: string) => http.post<RuleTestResult>(`/v1/monitors/${id}/test`),
+};
+
+/** Synthetic multi-step/browser checks (pages.md B7, OBS-011). */
+export const syntheticsRepo = {
+  list: () => http.get<SyntheticCheck[]>("/v1/synthetics"),
+  get: (id: string) => http.get<SyntheticCheck>(`/v1/synthetics/${id}`),
+  create: (input: SyntheticCheckInput) =>
+    http.post<SyntheticCheck>("/v1/synthetics", input),
+  update: (id: string, patch: Partial<SyntheticCheckInput>) =>
+    http.patch<SyntheticCheck>(`/v1/synthetics/${id}`, patch),
+  remove: (id: string) => http.delete(`/v1/synthetics/${id}`),
+  runs: (id: string) => http.get<SyntheticRun[]>(`/v1/synthetics/${id}/runs`),
+  run: (id: string, runId: string) =>
+    http.get<SyntheticRun>(`/v1/synthetics/${id}/runs/${runId}`),
+  /** "Run once" — executes the steps, returns the per-step results. */
+  runOnce: (id: string) => http.post<SyntheticRun>(`/v1/synthetics/${id}/runs`),
 };
 
 /** Alert channels + signal-generic rules (api.md §1a/§6; pages.md B8). */

--- a/web/src/models/repositories/index.ts
+++ b/web/src/models/repositories/index.ts
@@ -37,6 +37,7 @@ import type {
   TimelineEntry,
   Trace,
   TraceSummary,
+  UsageReport,
   Widget,
 } from "..";
 
@@ -248,6 +249,11 @@ export const keysRepo = {
   }) => http.post<ApiKeyWithSecret>("/v1/keys", input),
   rotate: (id: string) => http.post<ApiKeyWithSecret>(`/v1/keys/${id}/rotate`),
   revoke: (id: string) => http.delete(`/v1/keys/${id}`),
+};
+
+/** Usage metering per pillar (pages.md B12, OBS-012). */
+export const usageRepo = {
+  report: () => http.get<UsageReport>("/v1/usage"),
 };
 
 /** Members & roles (pages.md B12). */

--- a/web/src/models/repositories/index.ts
+++ b/web/src/models/repositories/index.ts
@@ -22,6 +22,7 @@ import type {
   QueryRequest,
   QueryResult,
   RuleTestResult,
+  RumDrilldown,
   RumSummary,
   RumVitals,
   SavedView,
@@ -119,6 +120,9 @@ export const rumRepo = {
   vitals: (params: { from?: string; to?: string } = {}) =>
     http.get<RumVitals>(`/v1/rum/vitals${qs(params)}`),
   errors: () => http.get<ErrorGroup[]>("/v1/rum/errors"),
+  /** U6-2 drill-down — funnel + weekly-cohort retention. */
+  drilldown: (params: { from?: string; to?: string } = {}) =>
+    http.get<RumDrilldown>(`/v1/rum/drilldown${qs(params)}`),
 };
 
 /** Monitors / uptime checks (api.md §1 semantics over HTTP for the new IA). */

--- a/web/src/models/repositories/index.ts
+++ b/web/src/models/repositories/index.ts
@@ -8,6 +8,7 @@ import type {
   Dashboard,
   ErrorGroup,
   Incident,
+  LogPatternsResult,
   LogQueryPage,
   Member,
   MemberRole,
@@ -97,6 +98,9 @@ export const logsRepo = {
     limit?: number;
     live?: 1;
   }) => http.get<LogQueryPage>(`/v1/logs${qs(params)}`),
+  /** B4 Patterns tab — clustered templates over the range (OBS-012). */
+  patterns: (params: { q?: string; from?: string; to?: string }) =>
+    http.get<LogPatternsResult>(`/v1/logs/patterns${qs(params)}`),
 };
 
 /** Traces / APM (pages.md B5). */

--- a/web/src/models/repositories/index.ts
+++ b/web/src/models/repositories/index.ts
@@ -29,6 +29,7 @@ import type {
   ServiceStats,
   Slo,
   StatusPage,
+  StatusPageConfig,
   SyntheticCheck,
   SyntheticCheckInput,
   SyntheticRun,
@@ -179,6 +180,10 @@ export const viewsRepo = {
 /** Public status page read (pages.md B7 — unauthenticated by design). */
 export const statusRepo = {
   bySlug: (slug: string) => http.get<StatusPage>(`/v1/status/${slug}`),
+  /** B7 builder document — branding + ordered component list. */
+  config: () => http.get<StatusPageConfig>("/v1/status-page"),
+  updateConfig: (config: StatusPageConfig) =>
+    http.put<StatusPageConfig>("/v1/status-page", config),
 };
 
 /** Incidents + timeline (api.md §6; pages.md B9; MI-10). */

--- a/web/src/models/rum.ts
+++ b/web/src/models/rum.ts
@@ -44,6 +44,38 @@ export interface RumVitals {
   series: { bucket: string; lcp_ms: number; cls: number; inp_ms: number }[];
 }
 
+/* ------------------------------------------------------------------ */
+/* Drill-down (U6-2, pages.md B6 [Designed 2026-07-20])                 */
+/* ------------------------------------------------------------------ */
+
+/** One FunnelStageCard (design.md §8.2b). */
+export interface FunnelStage {
+  key: string;
+  label: string;
+  count: number;
+  /** Share of the previous stage (first stage = 100). */
+  pct_of_previous: number;
+}
+
+export interface RumFunnel {
+  /** page views → sessions → conversions. */
+  stages: FunnelStage[];
+  /** The registered event counted as a conversion (api.md §3.4). */
+  conversion_event: string;
+}
+
+export interface RetentionCohort {
+  /** Cohort week start (Monday, ISO week). */
+  start: string;
+  /** % returning per week offset (index 0 = wk 0 = 100); 0 = not yet. */
+  values: number[];
+}
+
+export interface RumDrilldown {
+  funnel: RumFunnel;
+  retention: { weeks: number; cohorts: RetentionCohort[] };
+}
+
 export type ErrorGroupState = "new" | "ongoing" | "regressed";
 
 /** JS errors grouped by fingerprint (pages.md B6; ErrorGroupRow contract). */

--- a/web/src/models/status.ts
+++ b/web/src/models/status.ts
@@ -39,3 +39,29 @@ export interface StatusPage {
   /** Open incident first (when any), then resolved history, newest-first. */
   incidents: StatusPageIncident[];
 }
+
+/* ------------------------------------------------------------------ */
+/* Builder (pages.md B7 [Designed 2026-07-20] — settings surface)       */
+/* ------------------------------------------------------------------ */
+
+/** One builder row — row order IS the public page order (design.md §8.2b). */
+export interface StatusPageComponentConfig {
+  id: string;
+  /** Public display name (inline rename). */
+  name: string;
+  /** Mapped uptime check (monitor-mapping Select); null = unmapped. */
+  monitor_id: string | null;
+}
+
+/**
+ * The status-page builder document: branding (page name · slug) + the
+ * ordered component list. The public page it produces is the existing
+ * `/status/{slug}` construction.
+ */
+export interface StatusPageConfig {
+  /** Shown in the public page header. */
+  name: string;
+  /** Public at /status/{slug} — owner-chosen, unique (pages.md B7). */
+  slug: string;
+  components: StatusPageComponentConfig[];
+}

--- a/web/src/models/synthetics.ts
+++ b/web/src/models/synthetics.ts
@@ -1,0 +1,110 @@
+/**
+ * Synthetics beyond HTTP — multi-step API checks and browser checks
+ * (pages.md B7 [Designed 2026-07-20], OBS-011). Classic single-URL HTTP
+ * checks stay Monitors (models/monitors.ts); these are the step-composed
+ * checks the B7 builder produces.
+ */
+
+export type SyntheticCheckKind = "multi_step" | "browser";
+
+export type SyntheticStepKind = "http" | "assertion" | "wait";
+
+export type HttpStepMethod = "GET" | "POST" | "HEAD";
+
+/** Builder-editable step params — the server derives the mono summary. */
+export type SyntheticStepInput =
+  | { kind: "http"; method: HttpStepMethod; url: string }
+  | { kind: "assertion"; expression: string }
+  | { kind: "wait"; wait_ms: number };
+
+export interface SyntheticStep {
+  id: string;
+  kind: SyntheticStepKind;
+  /** Mono row summary — `GET https://…` / `status == 200` / `wait 500 ms`. */
+  summary: string;
+  method?: HttpStepMethod;
+  url?: string;
+  expression?: string;
+  wait_ms?: number;
+}
+
+/** The browser-check panel (URL · viewport · screenshot-on-failure). */
+export interface BrowserCheckConfig {
+  url: string;
+  /** `1440x900` / `768x1024` / `390x844` — the builder's viewport Select. */
+  viewport: string;
+  screenshot_on_failure: boolean;
+}
+
+export interface SyntheticCheck {
+  id: string;
+  name: string;
+  kind: SyntheticCheckKind;
+  /** Ordered steps (multi_step; browser checks may carry none). */
+  steps: SyntheticStep[];
+  /** Present on browser checks and multi-step checks with a browser stage. */
+  browser: BrowserCheckConfig | null;
+  interval_seconds: number;
+  last_run_id: string | null;
+  last_run_status: SyntheticRunStatus | null;
+  last_run_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export type SyntheticRunStatus = "pass" | "fail";
+
+/** One executed step in a run (StepResultRow contract, design.md §8.2b). */
+export interface SyntheticStepResult {
+  /** 1-based step index. */
+  index: number;
+  kind: SyntheticStepKind;
+  summary: string;
+  status: SyntheticRunStatus;
+  duration_ms: number;
+}
+
+export interface SyntheticRun {
+  id: string;
+  check_id: string;
+  /** Monotonic run number (`run #482`). */
+  number: number;
+  status: SyntheticRunStatus;
+  started_at: string;
+  /** Sum of executed step durations. */
+  total_ms: number;
+  /**
+   * Executed steps only — the check stops at the first failure; steps
+   * after a FAIL are not run and carry no result rows.
+   */
+  steps: SyntheticStepResult[];
+  /** Total steps in the check at run time (for "steps n–m not run"). */
+  steps_total: number;
+  /** Present when a failing run captured a screenshot (browser config). */
+  failure_screenshot: { step_index: number; viewport: string } | null;
+}
+
+/** Create/update payload the builder submits. */
+export interface SyntheticCheckInput {
+  name: string;
+  kind: SyntheticCheckKind;
+  steps: SyntheticStepInput[];
+  browser: BrowserCheckConfig | null;
+  interval_seconds?: number;
+}
+
+/**
+ * Mono row summary per step kind — `GET https://…` / `status == 200` /
+ * `wait 500 ms`. Shared by the builder rows and the mock server (contract
+ * types + derivations live with models, web-implementation.md §1).
+ */
+export function stepSummary(input: SyntheticStepInput): string {
+  switch (input.kind) {
+    case "http":
+      return `${input.method} ${input.url}`;
+    case "assertion":
+      return input.expression;
+    case "wait":
+      return `wait ${input.wait_ms} ms`;
+  }
+}

--- a/web/src/models/telemetry.ts
+++ b/web/src/models/telemetry.ts
@@ -42,6 +42,27 @@ export interface LogQueryPage {
   facets: Record<string, { value: string; count: number }[]>;
 }
 
+/** One clustered message template (pages.md B4 Patterns tab, OBS-012). */
+export interface LogPattern {
+  /** Message shape with `<placeholders>` marking the clustered variables. */
+  template: string;
+  count: number;
+  dominant_level: LogLevel;
+  /** 7-bucket trend across the queried range, oldest → newest. */
+  trend: number[];
+  /** Up to 3 newest matching lines (the expand affordance). */
+  samples: LogEvent[];
+}
+
+export interface LogPatternsResult {
+  patterns: LogPattern[];
+  total_lines: number;
+  /** Width of one trend bucket. */
+  bucket_ms: number;
+  /** True when the range was sampled (counts scaled by the stride). */
+  sampled: boolean;
+}
+
 export type SpanStatus = "ok" | "error";
 
 /** Span — the ClickHouse `spans` row shape (data-model.md §5 DDL). */

--- a/web/src/models/usage.ts
+++ b/web/src/models/usage.ts
@@ -1,0 +1,24 @@
+/** B12 usage metering (pages.md B12 [Designed 2026-07-20], OBS-012). */
+
+export type UsagePillar = "metrics" | "logs" | "traces" | "rum";
+
+/** One UsageMeterRow (design.md §8.2b). */
+export interface UsageMeter {
+  pillar: UsagePillar;
+  /** "Metrics — active series" · "Logs — ingested" · … */
+  label: string;
+  /** Raw MTD value (bytes for logs; counts elsewhere). */
+  value: number;
+  /** Human form ("212 GB", "9.8M"). */
+  display: string;
+  /** Trailing-3-month peak — the bar's denominator (§8.2b). */
+  peak: number;
+  /** Verbatim plan column (accuracy canon — no invented quotas/pricing). */
+  plan: string;
+}
+
+export interface UsageReport {
+  /** "July 2026" — resolved in the org timezone (X-10). */
+  month_label: string;
+  rows: UsageMeter[];
+}


### PR DESCRIPTION
Implements the five designed Wave B features (pages.md B4/B6/B7/B12 **[Designed 2026-07-20]**, design.md §8.2b Wave B rows; Figma `F2b1icjCmZp1MvOft6HMCV` frames 329:12262 / 330:12405 / 331:12857 / 333:14165 / 334:14499 / 335:2), sequenced one commit per feature group, on top of Wave A (#174).

## B7 — Synthetics multi-step + browser checks (OBS-011)
- `/dashboard/uptime/new`: builder with **HTTP / Multi-step / Browser** type tabs. The HTTP tab stays the classic Monitor create (replaces the old modal); Multi-step composes **SyntheticStepRow** steps (http / assertion / wait — add via the quiet composer, delete, reorder via keyboard grip + pointer drag) beside the **browser-check panel** (URL · viewport Select · screenshot-on-failure Switch).
- `/dashboard/uptime/checks/{id}` (`?run=` deep-links a run): **StepResultRow** pass/fail timeline with duration bars, stop-at-first-failure copy ("Steps n–m not run"), failure-screenshot card, derived UptimeCard context (the monitor watching the first HTTP step's host), run history; edit/delete at `…/edit`.
- Mock `/v1/synthetics` CRUD + `/v1/synthetics/{id}/runs` deterministic replay (snake_case codes: `name_required`, `steps_required`, `invalid_step_kind`, `invalid_target`, `invalid_expression`, `invalid_wait`, `invalid_viewport`, `invalid_kind`, `name_taken`).
- Seed: "checkout flow — api + web" (5 steps + browser stage, 30m cadence) whose **run #482 fails `body.ok == true` inside the INC-42 window** and captures a screenshot; neighbours pass (MONITORING = mitigated).

## B7 — Status-page builder
- `/dashboard/settings/status-page` (linked from the settings overview): branding rows (page name · slug), **StatusPageBuilderRow** list (inline rename · monitor-mapping Select · delete · keyboard reorder; row order = public page order), public-URL preview + "Open public page →".
- Persists via mock `GET/PUT /v1/status-page` (`invalid_slug`, `slug_taken`, `component_name_required`, `monitor_not_found`); `buildStatusPage` renders the saved document, so names/order/page-name reflect on the existing `/status/{slug}` construction immediately. Orgs without a document keep deriving from live monitors; the seeded document mirrors the previous public page byte-for-byte.

## B4 — Log patterns tab (OBS-012)
- **Logs | Patterns** tabs above the stream (`?tab=patterns`, resolved post-mount per the NavRail SSR pattern). **LogPatternRow**: count (tnum) · 7-bucket trend sparkline · Mono template with dimmed `<placeholders>` · dominant-level chip; expands to indented sample LogLines.
- Clustering computed in the mock (`GET /v1/logs/patterns`) over the **same per-second line generator as the stream** (`logLinesAtSecond` extracted from `generateLogs` — zero drift between surfaces). Deterministic template extraction; ranges beyond the enumeration budget sample every nth second with stride-scaled counts (flagged `sampled`, rendered `~`). Shares QueryBar/facets/histogram chrome; time-range aware (LIVE = last 15 minutes).

## B12 — Usage metering (OBS-012)
- `/dashboard/settings/usage`: **UsageMeterRow** per pillar with honest MTD sums derived from the seed — metrics = Σ catalog cardinality · logs = 3 lines/s × seconds MTD × measured mean line bytes · traces = the APM req/s series integrated hourly × mean seeded span count · RUM = the B6 summary's own page-view math. Bars scale to per-pillar trailing-3-month peaks (§8.2b); plan column verbatim **"Self-host: unlimited · Cloud: announced at GA"**; month boundaries + heading resolve in the org timezone (X-10). Mock `GET /v1/usage`.

## B6 — RUM drill-down (U6-2)
- `/dashboard/rum/drilldown`, routed from the pillar header: **FunnelStageCard** chain (page views → sessions → conversions) with → connectors — page views/sessions are the summary's own numbers; conversions count the registered `auth_signin_completed` event with the definition **labeled honestly in-page**; weekly cohort retention re-axises the Heatmap (8 Monday-aligned cohorts × wk 0–6, % returning, unlived weeks blank); sessions panel + top pages/referrers TopLists. Mock `GET /v1/rum/drilldown`.

## Tests & docs
- **Unit** (36 new tests): clustering determinism + count conservation + filter parity; usage sums recomputed from source (incl. org-tz month boundaries); funnel/cohort math; synthetics replay + seed coherence; status-page config reflection; the six new UI components.
- **E2E** `e2e/wave-b.spec.ts`: builder CRUD round-trip + Run once; seeded failing run; status-page builder → public page reflection; patterns expand; usage vs the API's own sums; funnel/cohort render.
- **Docs**: pages.md rows flipped to as-built with `[Decided 2026-07-20]` adjudications (HTTP tab = Monitor create; derived UptimeCard context; pattern sampling; usage bars vs per-pillar trailing-3-month peaks — the cross-unit "largest meter" phrasing was unimplementable as stated; conversion = `auth_signin_completed`); web-implementation.md Wave B block + route map + mock endpoint rows + seed narrative.

## Gates
- `npm run lint` (prettier + eslint + boundaries) ✅ · `npm run typecheck` ✅ · `npm run test` 99 files / 318 ✅ · `npm run build` ✅ · `npx playwright test` **56/56** ✅ (full suite incl. Wave A specs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
