### PR TITLE
fix(web): /docs/api header coexistence + tri-state theme (light | dark | system)

### DIFF
--- a/docs/web-implementation.md
+++ b/docs/web-implementation.md
@@ -398,11 +398,19 @@ marketing nav with a minimal legal strip; nav wiring (star count,
 spec source — served by the `/docs/api/openapi.yaml` route handler from
 a build-time string asset (`npm run generate:openapi`, wired as
 `predev`/`prebuild`/`pretypecheck`; output gitignored under
-`src/generated/`). Theme follows ThemeProvider (Scalar `darkMode`
-config; its own toggle hidden); remote default fonts are disabled
-(self-host ethos). The footer Docs column's "API reference" links
-`/docs/api`; `e2e/docs-api.spec.ts` pins route 200, a rendered operation
-from the spec, the served document, and the footer handoff.
+`src/generated/`). Theme: the embed is forced to the RESOLVED theme via
+Scalar's `forceDarkModeState` (a creation-time override — the view
+mounts after hydration and remounts on theme change, since
+`updateConfiguration` never re-applies it); Scalar's own toggle is
+hidden and its remote default fonts are disabled (self-host ethos).
+Header construction: the sticky marketing nav (h-14 + border = 57px)
+and Scalar's sticky layout coexist via `--scalar-custom-header-height`
+on the embed wrapper (offsets Scalar's sticky sidebar/mobile bar below
+the nav and shrinks its viewport math — one coherent page scroll) plus
+`isolate` so no Scalar z-index paints over the nav. The footer Docs
+column's "API reference" links `/docs/api`; `e2e/docs-api.spec.ts` pins
+route 200, a rendered operation from the spec, the served document, the
+footer handoff, the header/scroll sanity and the embed-theme sync.
 
 Screen-state parity **[Directive 2026-07-18, carried from design.md §8.1]**:
 every data-driven screen ships default, empty, and loading states — the
@@ -415,12 +423,29 @@ B1/B2/B4/B5), and the QA loop checks all three.
 
 One custom property per Figma variable in the `upstat/tokens` collection
 (design.md §7). **Dark is the default and lives on `:root`** (design.md
-§2: dashboards + marketing default dark); light mode is the manual
-override `[data-theme="light"]` set by the theme toggle. Deliberately
-**no `prefers-color-scheme` auto-switch** — upstat is dark-primary and
-theme is an explicit user choice (a ratified deviation from the sibling
-light-`:root` arrangement; the ThemeProvider contract is otherwise
-identical).
+§2: dashboards + marketing default dark); the light values live under
+`[data-theme="light"]` (a ratified deviation from the sibling
+light-`:root` arrangement; the ThemeProvider CONTRACT is identical —
+see the theme-contract as-built in §2). `data-theme` always carries the
+RESOLVED theme; the tokens.css `prefers-color-scheme: light` block is
+the pre-JS/no-JS fallback only.
+
+**Theme contract as-built (2026-07-20, ratified — identical across
+apparule, expendit and upstat).** The preference is tri-state
+light | dark | system: `ThemeProvider` persists it at `upstat.theme`
+("light"/"dark" stored explicitly; KEY ABSENT = system — the
+cross-product storage convention), and `data-theme` on `<html>` always
+carries the RESOLVED theme — system resolves via `prefers-color-scheme`
+and tracks it live (a matchMedia listener updates `data-theme` on an OS
+flip, no reload). The pre-paint init script applies the resolved theme
+(no FOUC in any mode). `ThemeToggle` (marketing nav + dashboard TopBar)
+cycles light → dark → system with distinct icons (sun / moon / monitor);
+its aria-label announces the active mode. The B12 Appearance section's
+Select is three-way (System / Dark (default) / Light) over the same
+`setPreference`. The Scalar embed follows `resolvedTheme` (X-2 note,
+§2). Unit tests pin the storage convention, live system tracking and the
+cycle order; e2e pins the cycle, an emulated OS flip in system mode and
+reload persistence.
 
 | Group | Token names (as built in `tokens.css`) |
 | --- | --- |

--- a/web/e2e/dashboard.spec.ts
+++ b/web/e2e/dashboard.spec.ts
@@ -399,7 +399,10 @@ test("full journey: onboarding → B1 → dashboards → explorer → logs → t
   /* ---- public status page (light, outside the shell) reflects state ---- */
   await page.goto("/status/upstat");
   await expect(page.getByTestId("status-page")).toBeVisible();
-  await expect(page.locator('[data-theme="light"]')).toBeVisible();
+  // The public surface is FORCED light via its own wrapper div — scoped
+  // (tri-state contract: <html> also carries data-theme when the app
+  // theme resolves light, so a bare [data-theme="light"] is ambiguous).
+  await expect(page.locator('div[data-theme="light"]')).toBeVisible();
   await expect(page.locator("main")).toHaveCount(1);
   await expect(page.getByText("Major outage")).toBeVisible(); // the declared sev1
   await expect(

--- a/web/e2e/dashboard.spec.ts
+++ b/web/e2e/dashboard.spec.ts
@@ -125,7 +125,9 @@ test("TopBar collapses to icon utilities at 390 — no overflow, everything oper
   ).toBeVisible();
   await page.keyboard.press("Escape");
 
-  // theme toggle still flips from the collapsed bar
+  // theme toggle still flips from the collapsed bar (dark default →
+  // system, which resolves light under the emulated light OS)
+  await page.emulateMedia({ colorScheme: "light" });
   await banner.getByTestId("theme-toggle").click();
   await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
   await banner.getByTestId("theme-toggle").click();

--- a/web/e2e/docs-api.spec.ts
+++ b/web/e2e/docs-api.spec.ts
@@ -49,4 +49,75 @@ test.describe("API reference — /docs/api", () => {
       page.getByRole("heading", { name: "Upstat HTTP API" }),
     ).toBeVisible({ timeout: 20_000 });
   });
+
+  test("header behaves: nav stays visible over the embed, one scroll container", async ({
+    page,
+  }) => {
+    await page.goto("/docs/api");
+    await expect(
+      page.getByRole("heading", { name: "Upstat HTTP API" }),
+    ).toBeVisible({ timeout: 20_000 });
+
+    // One coherent scroll container: the page scrolls; no full-viewport
+    // inner scroller wraps the embed (Scalar's viewport math is offset by
+    // --scalar-custom-header-height so its sidebar fits under the nav).
+    const layout = await page.evaluate(() => ({
+      pageScrollable:
+        document.documentElement.scrollHeight > window.innerHeight,
+      fullHeightInnerScrollers: [...document.querySelectorAll("*")].filter(
+        (el) =>
+          el.scrollHeight > el.clientHeight + 10 &&
+          ["auto", "scroll"].includes(getComputedStyle(el).overflowY) &&
+          el.clientHeight >= window.innerHeight,
+      ).length,
+    }));
+    expect(layout.pageScrollable).toBe(true);
+    expect(layout.fullHeightInnerScrollers).toBe(0);
+
+    // After scrolling, the marketing nav (sticky) is still fully visible —
+    // Scalar's sticky sidebar must not paint over it (isolate + offset).
+    await page.mouse.wheel(0, 800);
+    await expect(
+      page.getByRole("link", { name: "Star cuesoftinc/upstat on GitHub" }),
+    ).toBeVisible();
+    const navTop = await page
+      .getByRole("navigation", { name: "Marketing" })
+      .evaluate((el) => el.getBoundingClientRect().top);
+    expect(navTop).toBe(0);
+  });
+
+  test("the embed follows the tri-state theme, incl. a live OS flip in system mode", async ({
+    page,
+  }) => {
+    await page.emulateMedia({ colorScheme: "dark" });
+    await page.goto("/docs/api");
+    await expect(
+      page.getByRole("heading", { name: "Upstat HTTP API" }),
+    ).toBeVisible({ timeout: 20_000 });
+
+    // Scalar mirrors the resolved theme on body (light-mode/dark-mode);
+    // system default resolves dark here (dark-first OS emulation).
+    const body = page.locator("body");
+    await expect(body).toHaveClass(/dark-mode/);
+
+    // system mode (default) follows an OS scheme flip live.
+    await page.emulateMedia({ colorScheme: "light" });
+    await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
+    await expect(body).toHaveClass(/light-mode/, { timeout: 15_000 });
+
+    // Explicit choice via the nav toggle wins over the OS (the embed
+    // resyncs after cycling system → light → dark).
+    await page.getByTestId("theme-toggle").click(); // system → light
+    await page.getByTestId("theme-toggle").click(); // light → dark
+    await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
+    await expect(body).toHaveClass(/dark-mode/, { timeout: 15_000 });
+    await expect(
+      page.getByRole("heading", { name: "Upstat HTTP API" }),
+    ).toBeVisible({ timeout: 20_000 });
+
+    // The choice persists across reload (stored at upstat.theme).
+    await page.reload();
+    await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
+    await expect(body).toHaveClass(/dark-mode/, { timeout: 20_000 });
+  });
 });

--- a/web/e2e/docs-api.spec.ts
+++ b/web/e2e/docs-api.spec.ts
@@ -64,8 +64,13 @@ test.describe("API reference — /docs/api", () => {
     const layout = await page.evaluate(() => ({
       pageScrollable:
         document.documentElement.scrollHeight > window.innerHeight,
+      // <html>/<body> ARE the one coherent page scroller (their overflow
+      // propagates to the viewport — stylesheets may compute them "auto");
+      // only elements INSIDE the page count as competing scrollers.
       fullHeightInnerScrollers: [...document.querySelectorAll("*")].filter(
         (el) =>
+          el !== document.documentElement &&
+          el !== document.body &&
           el.scrollHeight > el.clientHeight + 10 &&
           ["auto", "scroll"].includes(getComputedStyle(el).overflowY) &&
           el.clientHeight >= window.innerHeight,

--- a/web/e2e/docs-api.spec.ts
+++ b/web/e2e/docs-api.spec.ts
@@ -101,11 +101,12 @@ test.describe("API reference — /docs/api", () => {
     ).toBeVisible({ timeout: 20_000 });
 
     // Scalar mirrors the resolved theme on body (light-mode/dark-mode);
-    // system default resolves dark here (dark-first OS emulation).
+    // key absent = dark, the design default (theme contract).
     const body = page.locator("body");
     await expect(body).toHaveClass(/dark-mode/);
 
-    // system mode (default) follows an OS scheme flip live.
+    // Explicit SYSTEM mode follows an OS scheme flip live.
+    await page.getByTestId("theme-toggle").click(); // dark(default) → system
     await page.emulateMedia({ colorScheme: "light" });
     await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
     await expect(body).toHaveClass(/light-mode/, { timeout: 15_000 });

--- a/web/e2e/home.spec.ts
+++ b/web/e2e/home.spec.ts
@@ -209,29 +209,54 @@ test("nav + footer carry the canonical parity links (SKILL.md canon)", async ({
   );
 });
 
-test("theme toggle flips data-theme and persists (upstat.theme)", async ({
+test("theme toggle cycles light → dark → system and persists (upstat.theme)", async ({
   page,
 }) => {
+  // Deterministic OS scheme for the system-resolution assertions.
+  await page.emulateMedia({ colorScheme: "dark" });
   await page.goto("/");
   const html = page.locator("html");
-  await expect(html).not.toHaveAttribute("data-theme", "light"); // dark default
-  await page.getByTestId("theme-toggle").click();
-  await expect(html).toHaveAttribute("data-theme", "light");
+  // Fresh visit = system (key absent), resolved from the OS (dark here).
+  await expect(html).toHaveAttribute("data-theme", "dark");
+
+  // system → light. The initial attr is applied pre-hydration (init
+  // script), so retry the click until React's handler is attached.
+  const toggle = page.getByTestId("theme-toggle");
+  await expect(async () => {
+    await toggle.click();
+    await expect(html).toHaveAttribute("data-theme", "light", {
+      timeout: 1_000,
+    });
+  }).toPass({ timeout: 15_000 });
   expect(
     await page.evaluate(() => window.localStorage.getItem("upstat.theme")),
   ).toBe("light");
   // persists across reload — applied pre-paint by the init script
   await page.reload();
   await expect(html).toHaveAttribute("data-theme", "light");
-  // back to dark: attribute clears (the default carries none). The attr
-  // assertion above is satisfied pre-hydration (init script), so retry the
-  // click until React's handler is attached (dev hydrates slowly).
+
+  // light → dark (explicit choice ignores the OS)
   await expect(async () => {
-    await page.getByTestId("theme-toggle").click();
-    await expect(html).not.toHaveAttribute("data-theme", "light", {
+    await toggle.click();
+    await expect(html).toHaveAttribute("data-theme", "dark", {
       timeout: 1_000,
     });
   }).toPass({ timeout: 15_000 });
+  expect(
+    await page.evaluate(() => window.localStorage.getItem("upstat.theme")),
+  ).toBe("dark");
+
+  // dark → system: key removed; resolved follows the OS and tracks a
+  // live flip without a reload.
+  await toggle.click();
+  expect(
+    await page.evaluate(() => window.localStorage.getItem("upstat.theme")),
+  ).toBeNull();
+  await expect(html).toHaveAttribute("data-theme", "dark"); // OS is dark
+  await page.emulateMedia({ colorScheme: "light" });
+  await expect(html).toHaveAttribute("data-theme", "light");
+  await page.emulateMedia({ colorScheme: "dark" });
+  await expect(html).toHaveAttribute("data-theme", "dark");
 });
 
 test("FAQ is a single-open accordion (A15)", async ({ page }) => {

--- a/web/e2e/home.spec.ts
+++ b/web/e2e/home.spec.ts
@@ -524,7 +524,9 @@ test("mobile nav is a menu-button disclosure at 390w (SKILL.md mobile clause)", 
   await expect(panelBadge).toHaveText(/^Star$/);
   await expect(panelBadge.locator("svg")).toBeVisible();
 
-  // the theme toggle works from inside the panel
+  // the theme toggle works from inside the panel (dark default → system
+  // resolves light under the emulated light OS)
+  await page.emulateMedia({ colorScheme: "light" });
   await panel.getByTestId("theme-toggle").click();
   await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
 

--- a/web/e2e/home.spec.ts
+++ b/web/e2e/home.spec.ts
@@ -216,18 +216,27 @@ test("theme toggle cycles light → dark → system and persists (upstat.theme)"
   await page.emulateMedia({ colorScheme: "dark" });
   await page.goto("/");
   const html = page.locator("html");
-  // Fresh visit = system (key absent), resolved from the OS (dark here).
+  // Fresh visit = the dark design default (key absent — theme contract).
   await expect(html).toHaveAttribute("data-theme", "dark");
+  expect(
+    await page.evaluate(() => window.localStorage.getItem("upstat.theme")),
+  ).toBeNull();
 
-  // system → light. The initial attr is applied pre-hydration (init
-  // script), so retry the click until React's handler is attached.
+  // dark(default) → system. The initial attr is applied pre-hydration
+  // (init script), so retry the click until React's handler is attached —
+  // detected via storage (the attribute stays dark under the dark OS).
   const toggle = page.getByTestId("theme-toggle");
   await expect(async () => {
     await toggle.click();
-    await expect(html).toHaveAttribute("data-theme", "light", {
-      timeout: 1_000,
-    });
+    expect(
+      await page.evaluate(() => window.localStorage.getItem("upstat.theme")),
+    ).toBe("system");
   }).toPass({ timeout: 15_000 });
+  await expect(html).toHaveAttribute("data-theme", "dark"); // OS is dark
+
+  // system → light (explicit choice).
+  await toggle.click();
+  await expect(html).toHaveAttribute("data-theme", "light");
   expect(
     await page.evaluate(() => window.localStorage.getItem("upstat.theme")),
   ).toBe("light");
@@ -246,12 +255,13 @@ test("theme toggle cycles light → dark → system and persists (upstat.theme)"
     await page.evaluate(() => window.localStorage.getItem("upstat.theme")),
   ).toBe("dark");
 
-  // dark → system: key removed; resolved follows the OS and tracks a
-  // live flip without a reload.
+  // dark → system: stored explicitly (key absent = the dark design
+  // default); resolved follows the OS and tracks a live flip without a
+  // reload.
   await toggle.click();
   expect(
     await page.evaluate(() => window.localStorage.getItem("upstat.theme")),
-  ).toBeNull();
+  ).toBe("system");
   await expect(html).toHaveAttribute("data-theme", "dark"); // OS is dark
   await page.emulateMedia({ colorScheme: "light" });
   await expect(html).toHaveAttribute("data-theme", "light");

--- a/web/e2e/navrail.spec.ts
+++ b/web/e2e/navrail.spec.ts
@@ -76,9 +76,20 @@ test("dashboard chrome theme toggle flips + persists (theme-parity canon)", asyn
   page,
 }) => {
   await page.setViewportSize({ width: 1440, height: 900 });
+  // Deterministic OS scheme — system-mode assertions must not depend on
+  // the runner's OS (theme contract note, SKILL.md).
+  await page.emulateMedia({ colorScheme: "light" });
   await signIn(page);
   const html = page.locator("html");
   await expect(html).not.toHaveAttribute("data-theme", "light");
+  // dark(default) → system: stored explicitly; the emulated OS is light,
+  // so the resolved attribute flips light.
+  await page.getByRole("banner").getByTestId("theme-toggle").click();
+  await expect(html).toHaveAttribute("data-theme", "light");
+  expect(
+    await page.evaluate(() => window.localStorage.getItem("upstat.theme")),
+  ).toBe("system");
+  // system → light: the explicit choice.
   await page.getByRole("banner").getByTestId("theme-toggle").click();
   await expect(html).toHaveAttribute("data-theme", "light");
   expect(

--- a/web/src/app/dashboard/settings/sections.tsx
+++ b/web/src/app/dashboard/settings/sections.tsx
@@ -22,7 +22,7 @@ import { useAlertsController } from "@/controllers/alerts";
 import { useOrgController } from "@/controllers/onboarding";
 import { useSettingsController } from "@/controllers/settings";
 import { useColorVision } from "@/design/ColorVisionProvider";
-import { useTheme, type Theme } from "@/design/ThemeProvider";
+import { useTheme, type ThemePreference } from "@/design/ThemeProvider";
 
 function SectionHeading({
   id,
@@ -437,7 +437,9 @@ const PRIVACY_ROWS = [
 /* ------------------------------------------------------------------ */
 
 export function AppearanceSection() {
-  const { theme, setTheme } = useTheme();
+  // Tri-state theme (contract 2026-07-20) + §5 colorblind mode (Wave A) —
+  // the two Appearance controls integrate side by side.
+  const { preference, setPreference } = useTheme();
   const { patterns, setMode } = useColorVision();
   return (
     <section
@@ -447,13 +449,16 @@ export function AppearanceSection() {
       <SectionHeading id="appearance-heading">Appearance</SectionHeading>
       <div className="flex items-center justify-between gap-4 rounded-(--radius) border border-border bg-bg-elev px-3 py-2">
         <span className="text-[13px] font-medium text-text">Theme</span>
+        {/* Tri-state (theme contract 2026-07-20): System follows the OS
+            live; Dark stays the product's design default. */}
         <Select
           options={[
+            { value: "system", label: "System" },
             { value: "dark", label: "Dark (default)" },
             { value: "light", label: "Light" },
           ]}
-          value={theme}
-          onValueChange={(v) => setTheme(v as Theme)}
+          value={preference}
+          onValueChange={(v) => setPreference(v as ThemePreference)}
           aria-label="Theme"
           className="min-w-36"
         />

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -179,8 +179,14 @@
     cursor: pointer;
   }
 
+  /* Horizontal-overflow guard (W1 QA). `clip`, NOT `hidden`: hidden
+     forces computed overflow-y to `auto`, which turns <body> into a
+     scroll container and silently breaks every position:sticky
+     descendant (the marketing nav rode away with the scroll — caught by
+     the /docs/api header e2e under CI). `clip` clips without creating a
+     scroll container. */
   html, body {
-    overflow-x: hidden;
+    overflow-x: clip;
     max-width: 100%;
   }
 }

--- a/web/src/components/docs/DocsApiView.tsx
+++ b/web/src/components/docs/DocsApiView.tsx
@@ -23,7 +23,13 @@ export function DocsApiView() {
         onSignIn={onSignIn}
         onTryCloud={onTryCloud}
       />
-      <main className="flex-1">
+      {/* Header-fix construction (2026-07-20): the sticky marketing nav
+          (h-14 + border = 57px) and Scalar's own sticky layout coexist by
+          telling Scalar about the header — `--scalar-custom-header-height`
+          offsets its sticky sidebar/mobile bar below the nav and shrinks
+          its viewport math to match (one coherent scroll). `isolate` opens
+          a stacking context so no Scalar z-index can paint over the nav. */}
+      <main className="isolate flex-1 [--scalar-custom-header-height:57px]">
         <ScalarApiReference />
       </main>
       {/* Minimal footer strip — verbatim legal line only (parity canon). */}

--- a/web/src/components/docs/ScalarApiReference.tsx
+++ b/web/src/components/docs/ScalarApiReference.tsx
@@ -2,23 +2,45 @@
 
 // Scalar API reference embed (X-2) — renders the interactive reference
 // from the repo's canonical spec served at /docs/api/openapi.yaml. The
-// embed follows the product theme: dark/light comes from ThemeProvider
-// (dark-primary, design.md §2), Scalar's own toggle is hidden, and the
-// remote default fonts are disabled (self-host ethos: no external
-// runtime dependencies) so the reference renders in the app's font
-// stack.
+// embed follows the product theme contract (2026-07-20): Scalar's dark
+// mode is FORCED to the resolved theme from ThemeProvider (system tracks
+// the OS live) via `forceDarkModeState` — `darkMode` alone is only an
+// initial hint and loses to Scalar's internal state. Scalar's own theme
+// toggle is hidden (ours is the master) and the remote default fonts are
+// disabled (self-host ethos: no external runtime dependencies).
+import { useSyncExternalStore } from "react";
 import { ApiReferenceReact } from "@scalar/api-reference-react";
 import "@scalar/api-reference-react/style.css";
 import { useTheme } from "@/design/ThemeProvider";
 
+// Hydration probe: false for the server/hydration render, true after.
+const emptySubscribe = () => () => {};
+function useHydrated(): boolean {
+  return useSyncExternalStore(
+    emptySubscribe,
+    () => true,
+    () => false,
+  );
+}
+
 export function ScalarApiReference() {
-  const { theme } = useTheme();
+  const { resolvedTheme } = useTheme();
+
+  // Scalar reads `forceDarkModeState` ONCE at creation (a frozen override —
+  // `updateConfiguration` never re-applies it), so: (1) skip the hydration
+  // frame, where the provider still reports the server snapshot, so the
+  // first create sees the real resolved theme; (2) remount on resolved-theme
+  // changes (`key`) so every theme flip re-creates the app with the right
+  // forced state — configuration only, no reaching into Scalar internals.
+  const hydrated = useHydrated();
+  if (!hydrated) return null;
 
   return (
     <ApiReferenceReact
+      key={resolvedTheme}
       configuration={{
         url: "/docs/api/openapi.yaml",
-        darkMode: theme === "dark",
+        forceDarkModeState: resolvedTheme,
         hideDarkModeToggle: true,
         withDefaultFonts: false,
       }}

--- a/web/src/components/ui/ThemeToggle.test.tsx
+++ b/web/src/components/ui/ThemeToggle.test.tsx
@@ -1,3 +1,6 @@
+// ThemeToggle: cycles the ThemeProvider preference light → dark → system
+// (theme contract 2026-07-20); persists under `upstat.theme` with
+// KEY ABSENT = system; the aria-label announces the active mode.
 import { beforeEach, describe, expect, it } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -10,18 +13,28 @@ describe("ThemeToggle", () => {
     document.documentElement.removeAttribute("data-theme");
   });
 
-  it("flips dark ⇄ light with a labelled control", async () => {
+  it("cycles light → dark → system with a labelled control", async () => {
     render(
       <ThemeProvider>
         <ThemeToggle />
       </ThemeProvider>,
     );
     const toggle = screen.getByTestId("theme-toggle");
-    expect(toggle).toHaveAccessibleName("Switch to light theme");
+    // Default preference is system — the label announces the active mode.
+    expect(toggle).toHaveAccessibleName("Theme: system — switch to light");
     await userEvent.click(toggle);
     expect(document.documentElement).toHaveAttribute("data-theme", "light");
-    expect(toggle).toHaveAccessibleName("Switch to dark theme");
+    expect(window.localStorage.getItem("upstat.theme")).toBe("light");
+    expect(toggle).toHaveAccessibleName("Theme: light — switch to dark");
     await userEvent.click(toggle);
-    expect(document.documentElement).not.toHaveAttribute("data-theme");
+    expect(document.documentElement).toHaveAttribute("data-theme", "dark");
+    expect(window.localStorage.getItem("upstat.theme")).toBe("dark");
+    expect(toggle).toHaveAccessibleName("Theme: dark — switch to system");
+    await userEvent.click(toggle);
+    // Key absent = system; data-theme carries the RESOLVED theme (light —
+    // the jsdom matchMedia stub reports no dark preference).
+    expect(window.localStorage.getItem("upstat.theme")).toBeNull();
+    expect(document.documentElement).toHaveAttribute("data-theme", "light");
+    expect(toggle).toHaveAccessibleName("Theme: system — switch to light");
   });
 });

--- a/web/src/components/ui/ThemeToggle.test.tsx
+++ b/web/src/components/ui/ThemeToggle.test.tsx
@@ -20,7 +20,13 @@ describe("ThemeToggle", () => {
       </ThemeProvider>,
     );
     const toggle = screen.getByTestId("theme-toggle");
-    // Default preference is system — the label announces the active mode.
+    // Key absent = dark, the design default — the label announces it.
+    expect(toggle).toHaveAccessibleName("Theme: dark — switch to system");
+    await userEvent.click(toggle);
+    // "system" is stored explicitly; data-theme carries the RESOLVED theme
+    // (light — the jsdom matchMedia stub reports no dark preference).
+    expect(window.localStorage.getItem("upstat.theme")).toBe("system");
+    expect(document.documentElement).toHaveAttribute("data-theme", "light");
     expect(toggle).toHaveAccessibleName("Theme: system — switch to light");
     await userEvent.click(toggle);
     expect(document.documentElement).toHaveAttribute("data-theme", "light");
@@ -30,11 +36,5 @@ describe("ThemeToggle", () => {
     expect(document.documentElement).toHaveAttribute("data-theme", "dark");
     expect(window.localStorage.getItem("upstat.theme")).toBe("dark");
     expect(toggle).toHaveAccessibleName("Theme: dark — switch to system");
-    await userEvent.click(toggle);
-    // Key absent = system; data-theme carries the RESOLVED theme (light —
-    // the jsdom matchMedia stub reports no dark preference).
-    expect(window.localStorage.getItem("upstat.theme")).toBeNull();
-    expect(document.documentElement).toHaveAttribute("data-theme", "light");
-    expect(toggle).toHaveAccessibleName("Theme: system — switch to light");
   });
 });

--- a/web/src/components/ui/ThemeToggle.tsx
+++ b/web/src/components/ui/ThemeToggle.tsx
@@ -1,38 +1,56 @@
 "use client";
 
 import { clsx } from "clsx";
-import { Moon, Sun } from "lucide-react";
-import { useTheme } from "@/design/ThemeProvider";
+import { Monitor, Moon, Sun } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import { useTheme, type ThemePreference } from "@/design/ThemeProvider";
 
 export interface ThemeToggleProps {
   className?: string;
 }
 
+/** light → dark → system → light (theme contract 2026-07-20). */
+export const THEME_CYCLE: Record<ThemePreference, ThemePreference> = {
+  light: "dark",
+  dark: "system",
+  system: "light",
+};
+
+export const THEME_ICONS: Record<ThemePreference, LucideIcon> = {
+  light: Sun,
+  dark: Moon,
+  system: Monitor,
+};
+
+/** Accessible name: announces the active mode and the next one. */
+export function themeToggleLabel(preference: ThemePreference): string {
+  return `Theme: ${preference} — switch to ${THEME_CYCLE[preference]}`;
+}
+
 /**
- * ThemeToggle — light/dark flip (SKILL.md theme-parity canon). Lives in the
- * marketing nav, the dashboard TopBar utility area and Settings; the choice
- * persists via ThemeProvider (`upstat.theme`).
+ * ThemeToggle — the tri-state cycle control (theme contract, ratified
+ * 2026-07-20, identical across apparule, expendit and upstat): cycles
+ * light → dark → system with a distinct icon per mode (sun / moon /
+ * monitor). Lives in the marketing nav, the dashboard TopBar utility
+ * area and Settings; the choice persists via ThemeProvider
+ * (`upstat.theme`; key absent = system).
  */
 export function ThemeToggle({ className }: ThemeToggleProps) {
-  const { theme, setTheme } = useTheme();
-  const next = theme === "dark" ? "light" : "dark";
+  const { preference, setPreference } = useTheme();
+  const Icon = THEME_ICONS[preference];
   return (
     <button
       type="button"
       data-testid="theme-toggle"
-      aria-label={`Switch to ${next} theme`}
-      onClick={() => setTheme(next)}
+      aria-label={themeToggleLabel(preference)}
+      onClick={() => setPreference(THEME_CYCLE[preference])}
       className={clsx(
         "rounded-(--radius) p-1.5 text-text-2",
         "transition-colors duration-[var(--duration-fast)] ease-standard hover:bg-bg-elev hover:text-text",
         className,
       )}
     >
-      {theme === "dark" ? (
-        <Sun aria-hidden="true" className="size-4.5" />
-      ) : (
-        <Moon aria-hidden="true" className="size-4.5" />
-      )}
+      <Icon aria-hidden="true" className="size-4.5" />
     </button>
   );
 }

--- a/web/src/design/ThemeProvider.test.tsx
+++ b/web/src/design/ThemeProvider.test.tsx
@@ -1,5 +1,6 @@
 // Theme provider — tri-state contract (ratified 2026-07-20): preference
-// light | dark | system persisted at upstat.theme (key absent = system);
+// light | dark | system persisted at upstat.theme (key absent = dark, the
+// design default; "system" stored explicitly);
 // data-theme always carries the RESOLVED theme; system tracks
 // prefers-color-scheme live via a matchMedia listener. Upstat stays
 // dark-first in design (tokens :root is dark), but the CONTRACT is the
@@ -63,7 +64,18 @@ describe("ThemeProvider (theme contract 2026-07-20, upstat.theme)", () => {
     systemMatches = false;
   });
 
-  it("defaults to system and reports the resolved OS theme", () => {
+  it("defaults to dark (the design default) when no key is stored", () => {
+    render(
+      <ThemeProvider>
+        <Probe />
+      </ThemeProvider>,
+    );
+    expect(screen.getByTestId("pref")).toHaveTextContent("dark");
+    expect(screen.getByTestId("resolved")).toHaveTextContent("dark");
+  });
+
+  it("stored system resolves via the OS preference (both directions)", async () => {
+    window.localStorage.setItem(THEME_STORAGE_KEY, "system");
     render(
       <ThemeProvider>
         <Probe />
@@ -73,7 +85,8 @@ describe("ThemeProvider (theme contract 2026-07-20, upstat.theme)", () => {
     expect(screen.getByTestId("resolved")).toHaveTextContent("light");
   });
 
-  it("system resolves dark when the OS prefers dark", () => {
+  it("stored system resolves dark when the OS prefers dark", () => {
+    window.localStorage.setItem(THEME_STORAGE_KEY, "system");
     systemMatches = true;
     render(
       <ThemeProvider>
@@ -97,7 +110,7 @@ describe("ThemeProvider (theme contract 2026-07-20, upstat.theme)", () => {
     expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe("dark");
   });
 
-  it("returning to system removes the stored key (absent = system) and re-resolves", async () => {
+  it("choosing system stores it explicitly and re-resolves via the OS", async () => {
     render(
       <ThemeProvider>
         <Probe />
@@ -105,9 +118,9 @@ describe("ThemeProvider (theme contract 2026-07-20, upstat.theme)", () => {
     );
     await userEvent.click(screen.getByRole("button", { name: "dark" }));
     await userEvent.click(screen.getByRole("button", { name: "system" }));
-    // Key absent = system — the cross-product storage convention; the
-    // attribute stays populated with the RESOLVED theme.
-    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBeNull();
+    // "system" is stored like any preference (key absent = design default);
+    // the attribute stays populated with the RESOLVED theme.
+    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe("system");
     expect(document.documentElement).toHaveAttribute("data-theme", "light");
     expect(screen.getByTestId("pref")).toHaveTextContent("system");
   });

--- a/web/src/design/ThemeProvider.test.tsx
+++ b/web/src/design/ThemeProvider.test.tsx
@@ -1,8 +1,13 @@
-import { beforeEach, describe, expect, it } from "vitest";
-import { render, screen } from "@testing-library/react";
+// Theme provider — tri-state contract (ratified 2026-07-20): preference
+// light | dark | system persisted at upstat.theme (key absent = system);
+// data-theme always carries the RESOLVED theme; system tracks
+// prefers-color-scheme live via a matchMedia listener. Upstat stays
+// dark-first in design (tokens :root is dark), but the CONTRACT is the
+// same as apparule/expendit.
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import {
-  DEFAULT_THEME,
   THEME_STORAGE_KEY,
   ThemeProvider,
   themeInitScript,
@@ -10,49 +15,129 @@ import {
 } from "./ThemeProvider";
 
 function Probe() {
-  const { theme, setTheme } = useTheme();
+  const { preference, resolvedTheme, setPreference } = useTheme();
   return (
-    <button
-      type="button"
-      onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
-    >
-      theme:{theme}
-    </button>
+    <div>
+      <span data-testid="pref">{preference}</span>
+      <span data-testid="resolved">{resolvedTheme}</span>
+      <button onClick={() => setPreference("dark")}>dark</button>
+      <button onClick={() => setPreference("light")}>light</button>
+      <button onClick={() => setPreference("system")}>system</button>
+    </div>
   );
 }
 
-describe("ThemeProvider (theme-parity canon, upstat.theme)", () => {
+// Controllable matchMedia stand-in: the provider attaches ONE module-level
+// change listener on first subscribe; `flipSystem` drives it like an OS
+// theme change. Installed before the first render in this file so the
+// provider binds to it.
+let systemMatches = false;
+const changeListeners = new Set<() => void>();
+function flipSystem(matches: boolean) {
+  systemMatches = matches;
+  act(() => {
+    for (const l of changeListeners) l();
+  });
+}
+
+beforeAll(() => {
+  window.matchMedia = ((query: string) => ({
+    get matches() {
+      return systemMatches;
+    },
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: (_: string, cb: () => void) => changeListeners.add(cb),
+    removeEventListener: (_: string, cb: () => void) =>
+      changeListeners.delete(cb),
+    dispatchEvent: () => false,
+  })) as unknown as typeof window.matchMedia;
+});
+
+describe("ThemeProvider (theme contract 2026-07-20, upstat.theme)", () => {
   beforeEach(() => {
     window.localStorage.clear();
     document.documentElement.removeAttribute("data-theme");
+    systemMatches = false;
   });
 
-  it("defaults to upstat's design default (dark) when unset", () => {
+  it("defaults to system and reports the resolved OS theme", () => {
     render(
       <ThemeProvider>
         <Probe />
       </ThemeProvider>,
     );
-    expect(DEFAULT_THEME).toBe("dark");
-    expect(screen.getByRole("button")).toHaveTextContent("theme:dark");
-    expect(document.documentElement).not.toHaveAttribute("data-theme");
+    expect(screen.getByTestId("pref")).toHaveTextContent("system");
+    expect(screen.getByTestId("resolved")).toHaveTextContent("light");
   });
 
-  it("light: sets data-theme on <html> and persists under upstat.theme", async () => {
+  it("system resolves dark when the OS prefers dark", () => {
+    systemMatches = true;
     render(
       <ThemeProvider>
         <Probe />
       </ThemeProvider>,
     );
-    await userEvent.click(screen.getByRole("button"));
-    expect(screen.getByRole("button")).toHaveTextContent("theme:light");
+    expect(screen.getByTestId("resolved")).toHaveTextContent("dark");
+  });
+
+  it("explicit choices apply the resolved attribute and persist under upstat.theme", async () => {
+    render(
+      <ThemeProvider>
+        <Probe />
+      </ThemeProvider>,
+    );
+    await userEvent.click(screen.getByRole("button", { name: "light" }));
     expect(document.documentElement).toHaveAttribute("data-theme", "light");
     expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe("light");
-
-    // and back: dark clears the attribute (the default needs none)
-    await userEvent.click(screen.getByRole("button"));
-    expect(document.documentElement).not.toHaveAttribute("data-theme");
+    await userEvent.click(screen.getByRole("button", { name: "dark" }));
+    expect(document.documentElement).toHaveAttribute("data-theme", "dark");
     expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBe("dark");
+  });
+
+  it("returning to system removes the stored key (absent = system) and re-resolves", async () => {
+    render(
+      <ThemeProvider>
+        <Probe />
+      </ThemeProvider>,
+    );
+    await userEvent.click(screen.getByRole("button", { name: "dark" }));
+    await userEvent.click(screen.getByRole("button", { name: "system" }));
+    // Key absent = system — the cross-product storage convention; the
+    // attribute stays populated with the RESOLVED theme.
+    expect(window.localStorage.getItem(THEME_STORAGE_KEY)).toBeNull();
+    expect(document.documentElement).toHaveAttribute("data-theme", "light");
+    expect(screen.getByTestId("pref")).toHaveTextContent("system");
+  });
+
+  it("system mode tracks prefers-color-scheme changes live", async () => {
+    render(
+      <ThemeProvider>
+        <Probe />
+      </ThemeProvider>,
+    );
+    await userEvent.click(screen.getByRole("button", { name: "system" }));
+    expect(screen.getByTestId("resolved")).toHaveTextContent("light");
+    flipSystem(true); // OS switches to dark
+    expect(screen.getByTestId("resolved")).toHaveTextContent("dark");
+    expect(document.documentElement).toHaveAttribute("data-theme", "dark");
+    flipSystem(false); // and back
+    expect(screen.getByTestId("resolved")).toHaveTextContent("light");
+    expect(document.documentElement).toHaveAttribute("data-theme", "light");
+  });
+
+  it("explicit preferences ignore OS theme changes", async () => {
+    render(
+      <ThemeProvider>
+        <Probe />
+      </ThemeProvider>,
+    );
+    await userEvent.click(screen.getByRole("button", { name: "dark" }));
+    flipSystem(false);
+    expect(screen.getByTestId("resolved")).toHaveTextContent("dark");
+    expect(document.documentElement).toHaveAttribute("data-theme", "dark");
   });
 
   it("reads a persisted light preference", () => {
@@ -62,12 +147,16 @@ describe("ThemeProvider (theme-parity canon, upstat.theme)", () => {
         <Probe />
       </ThemeProvider>,
     );
-    expect(screen.getByRole("button")).toHaveTextContent("theme:light");
+    expect(screen.getByTestId("pref")).toHaveTextContent("light");
+    expect(screen.getByTestId("resolved")).toHaveTextContent("light");
   });
 
-  it("init script uses the literal storage key (pre-paint bootstrap)", () => {
+  it("init script uses the literal storage key and resolves system pre-paint", () => {
     expect(THEME_STORAGE_KEY).toBe("upstat.theme");
     expect(themeInitScript).toContain('localStorage.getItem("upstat.theme")');
-    expect(themeInitScript).toContain('setAttribute("data-theme","light")');
+    // System mode must resolve pre-paint (no FOUC): the script consults
+    // prefers-color-scheme and always sets the resolved data-theme.
+    expect(themeInitScript).toContain("prefers-color-scheme");
+    expect(themeInitScript).toContain('setAttribute("data-theme",t)');
   });
 });

--- a/web/src/design/ThemeProvider.tsx
+++ b/web/src/design/ThemeProvider.tsx
@@ -1,19 +1,26 @@
 "use client";
 
 /**
- * Theme provider — manual light/dark override (SKILL.md "Marketing nav,
- * footer & theme parity canon", ported from apparule's contract):
+ * Theme provider — tri-state light | dark | system (SKILL.md theme parity
+ * canon; theme contract ratified 2026-07-20, identical across apparule,
+ * expendit and upstat):
  *
- * - unset (default): no `data-theme` attribute → tokens.css `:root` renders
- *   the design default, which for upstat is DARK (design.md §2 — there is
- *   deliberately no prefers-color-scheme auto-switch).
- * - `light`: `data-theme="light"` on <html>, persisted in localStorage
- *   under `upstat.theme`.
+ * - `preference` is what the user chose; persisted at `upstat.theme`
+ *   ("light"/"dark" stored explicitly; KEY ABSENT = system — the
+ *   cross-product storage convention).
+ * - `data-theme` on <html> always carries the RESOLVED theme ("light" or
+ *   "dark"): explicit preferences resolve to themselves; system resolves
+ *   via `prefers-color-scheme` and tracks it LIVE (matchMedia listener —
+ *   an OS theme flip updates data-theme without a reload).
+ * - tokens.css stays dark-first (`:root` is dark, design.md §2); the
+ *   light values live under `[data-theme="light"]` plus a media-query
+ *   fallback for the pre-JS/no-JS case; with JS the attribute is
+ *   authoritative.
  *
  * The preference lives in an external module store (localStorage-backed,
  * read via useSyncExternalStore) so no state syncs through effects; a tiny
- * inline script in the root layout applies the persisted override before
- * first paint to avoid a theme flash.
+ * inline script in the root layout applies the resolved theme before first
+ * paint (no FOUC in any mode, including system).
  */
 
 import {
@@ -25,18 +32,42 @@ import {
   type ReactNode,
 } from "react";
 
-export type Theme = "light" | "dark";
+export type ThemePreference = "light" | "dark" | "system";
+export type ResolvedTheme = "light" | "dark";
+/** Back-compat alias (pre-tri-state consumers named the resolved type). */
+export type Theme = ResolvedTheme;
 
 export const THEME_STORAGE_KEY = "upstat.theme";
-
-/** upstat's design default (design.md §2: dark-primary product). */
-export const DEFAULT_THEME: Theme = "dark";
+const DARK_QUERY = "(prefers-color-scheme: dark)";
 
 // -- external preference store ----------------------------------------------
 
 const listeners = new Set<() => void>();
 
+// System tracking: one module-level matchMedia listener, attached lazily on
+// first subscription (client only), kept for the app lifetime.
+let systemListenerAttached = false;
+
+function onSystemChange(): void {
+  // Only the system preference re-resolves on an OS flip.
+  if (readStoredPreference() === "system") {
+    applyResolved(resolveTheme("system"));
+    emit();
+  }
+}
+
+function ensureSystemListener(): void {
+  if (systemListenerAttached || typeof window === "undefined") return;
+  try {
+    window.matchMedia(DARK_QUERY).addEventListener("change", onSystemChange);
+    systemListenerAttached = true;
+  } catch {
+    // matchMedia unavailable — system just won't track live
+  }
+}
+
 function subscribe(listener: () => void): () => void {
+  ensureSystemListener();
   listeners.add(listener);
   return () => {
     listeners.delete(listener);
@@ -47,59 +78,91 @@ function emit(): void {
   for (const listener of listeners) listener();
 }
 
-function readStoredTheme(): Theme {
+function readStoredPreference(): ThemePreference {
   try {
     const stored = window.localStorage.getItem(THEME_STORAGE_KEY);
     if (stored === "light" || stored === "dark") return stored;
   } catch {
-    // storage unavailable (private mode etc.) — fall through to the default
+    // storage unavailable (private mode etc.) — fall through to system
   }
-  return DEFAULT_THEME;
+  return "system";
 }
 
-function getServerSnapshot(): Theme {
-  return DEFAULT_THEME;
+function systemPrefersDark(): boolean {
+  try {
+    return window.matchMedia(DARK_QUERY).matches;
+  } catch {
+    return false;
+  }
 }
 
-function applyTheme(theme: Theme): void {
-  const root = document.documentElement;
-  if (theme === DEFAULT_THEME) {
-    // the default carries no attribute — tokens.css `:root` IS dark
-    root.removeAttribute("data-theme");
-  } else {
-    root.setAttribute("data-theme", theme);
-  }
+/** Resolve a preference to the concrete theme ("system" → the OS theme). */
+export function resolveTheme(preference: ThemePreference): ResolvedTheme {
+  if (preference === "light" || preference === "dark") return preference;
+  return systemPrefersDark() ? "dark" : "light";
+}
+
+function readResolvedTheme(): ResolvedTheme {
+  return resolveTheme(readStoredPreference());
+}
+
+function getServerPreference(): ThemePreference {
+  return "system";
+}
+
+function getServerResolved(): ResolvedTheme {
+  // Dark-first product (design.md §2): the SSR frame renders the
+  // attribute-less dark default; the init script resolves before paint.
+  return "dark";
+}
+
+function applyResolved(theme: ResolvedTheme): void {
+  document.documentElement.setAttribute("data-theme", theme);
 }
 
 // -- context ------------------------------------------------------------------
 
 interface ThemeContextValue {
-  /** The resolved theme ("dark" unless the user chose light). */
-  theme: Theme;
-  /** Set + persist the theme. */
-  setTheme: (theme: Theme) => void;
+  /** The user's stored preference (may be "system"). */
+  preference: ThemePreference;
+  /** The concrete theme currently applied ("system" resolved live). */
+  resolvedTheme: ResolvedTheme;
+  /** Set + persist the preference; "system" removes the stored key. */
+  setPreference: (preference: ThemePreference) => void;
 }
 
 const ThemeContext = createContext<ThemeContextValue | null>(null);
 
 export function ThemeProvider({ children }: { children: ReactNode }) {
-  const theme = useSyncExternalStore(
+  const preference = useSyncExternalStore(
     subscribe,
-    readStoredTheme,
-    getServerSnapshot,
+    readStoredPreference,
+    getServerPreference,
+  );
+  const resolvedTheme = useSyncExternalStore(
+    subscribe,
+    readResolvedTheme,
+    getServerResolved,
   );
 
-  const setTheme = useCallback((next: Theme) => {
-    applyTheme(next);
+  const setPreference = useCallback((next: ThemePreference) => {
+    applyResolved(resolveTheme(next));
     try {
-      window.localStorage.setItem(THEME_STORAGE_KEY, next);
+      if (next === "system") {
+        window.localStorage.removeItem(THEME_STORAGE_KEY);
+      } else {
+        window.localStorage.setItem(THEME_STORAGE_KEY, next);
+      }
     } catch {
       // non-fatal: preference just won't persist
     }
     emit();
   }, []);
 
-  const value = useMemo(() => ({ theme, setTheme }), [theme, setTheme]);
+  const value = useMemo(
+    () => ({ preference, resolvedTheme, setPreference }),
+    [preference, resolvedTheme, setPreference],
+  );
 
   return (
     <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>
@@ -116,7 +179,8 @@ export function useTheme(): ThemeContextValue {
  * Pre-paint theme bootstrap (inlined by the root layout). A fully static
  * string — no runtime code construction (CodeQL js/bad-code-sanitization);
  * the literal storage key must match THEME_STORAGE_KEY (unit-tested).
- * Only "light" needs applying — dark is the attribute-less default.
+ * Applies the RESOLVED theme: stored light/dark verbatim, otherwise the
+ * OS preference — so system mode paints correctly on first frame (no FOUC).
  */
 export const themeInitScript =
-  '(function(){try{var t=localStorage.getItem("upstat.theme");if(t==="light"){document.documentElement.setAttribute("data-theme","light");}}catch(e){}})();';
+  '(function(){try{var t=localStorage.getItem("upstat.theme");if(t!=="light"&&t!=="dark"){t=window.matchMedia("(prefers-color-scheme: dark)").matches?"dark":"light";}document.documentElement.setAttribute("data-theme",t);}catch(e){}})();';

--- a/web/src/design/ThemeProvider.tsx
+++ b/web/src/design/ThemeProvider.tsx
@@ -81,11 +81,14 @@ function emit(): void {
 function readStoredPreference(): ThemePreference {
   try {
     const stored = window.localStorage.getItem(THEME_STORAGE_KEY);
-    if (stored === "light" || stored === "dark") return stored;
+    if (stored === "light" || stored === "dark" || stored === "system")
+      return stored;
   } catch {
-    // storage unavailable (private mode etc.) — fall through to system
+    // storage unavailable (private mode etc.) — fall through to the default
   }
-  return "system";
+  // Key absent = the product's design default (dark-first, design.md §2);
+  // "system" is an explicit choice, stored like any other preference.
+  return "dark";
 }
 
 function systemPrefersDark(): boolean {
@@ -107,7 +110,7 @@ function readResolvedTheme(): ResolvedTheme {
 }
 
 function getServerPreference(): ThemePreference {
-  return "system";
+  return "dark";
 }
 
 function getServerResolved(): ResolvedTheme {
@@ -127,7 +130,7 @@ interface ThemeContextValue {
   preference: ThemePreference;
   /** The concrete theme currently applied ("system" resolved live). */
   resolvedTheme: ResolvedTheme;
-  /** Set + persist the preference; "system" removes the stored key. */
+  /** Set + persist the preference ("system" is stored explicitly). */
   setPreference: (preference: ThemePreference) => void;
 }
 
@@ -148,11 +151,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   const setPreference = useCallback((next: ThemePreference) => {
     applyResolved(resolveTheme(next));
     try {
-      if (next === "system") {
-        window.localStorage.removeItem(THEME_STORAGE_KEY);
-      } else {
-        window.localStorage.setItem(THEME_STORAGE_KEY, next);
-      }
+      window.localStorage.setItem(THEME_STORAGE_KEY, next);
     } catch {
       // non-fatal: preference just won't persist
     }
@@ -179,8 +178,9 @@ export function useTheme(): ThemeContextValue {
  * Pre-paint theme bootstrap (inlined by the root layout). A fully static
  * string — no runtime code construction (CodeQL js/bad-code-sanitization);
  * the literal storage key must match THEME_STORAGE_KEY (unit-tested).
- * Applies the RESOLVED theme: stored light/dark verbatim, otherwise the
- * OS preference — so system mode paints correctly on first frame (no FOUC).
+ * Applies the RESOLVED theme: stored light/dark verbatim, stored "system"
+ * via the OS preference, key absent = dark (the design default) — no FOUC
+ * in any mode.
  */
 export const themeInitScript =
-  '(function(){try{var t=localStorage.getItem("upstat.theme");if(t!=="light"&&t!=="dark"){t=window.matchMedia("(prefers-color-scheme: dark)").matches?"dark":"light";}document.documentElement.setAttribute("data-theme",t);}catch(e){}})();';
+  '(function(){try{var t=localStorage.getItem("upstat.theme");if(t==="system"){t=window.matchMedia("(prefers-color-scheme: dark)").matches?"dark":"light";}else if(t!=="light"&&t!=="dark"){t="dark";}document.documentElement.setAttribute("data-theme",t);}catch(e){}})();';

--- a/web/src/design/tokens.css
+++ b/web/src/design/tokens.css
@@ -2,10 +2,12 @@
  * Upstat design tokens — mirrors docs/design.md §2 exactly.
  *
  * DARK is the product default (`:root` carries the dark values — dashboards
- * and marketing default dark per the existing landing); light mode is a
- * manual override via `[data-theme="light"]`. There is deliberately no
- * `prefers-color-scheme` auto-switch: the product is dark-primary and theme
- * is an explicit user choice.
+ * and marketing default dark per the existing landing); light values live
+ * under `[data-theme="light"]`. Theme contract (2026-07-20, tri-state):
+ * `data-theme` always carries the RESOLVED theme (light | dark; system
+ * resolves live via matchMedia in ThemeProvider + the pre-paint init
+ * script). The prefers-color-scheme block below is the pre-JS/no-JS
+ * fallback only.
  *
  * No raw hex anywhere else in the app — components consume these variables
  * (documented exceptions carry a code comment, e.g. destructive-fill labels
@@ -84,4 +86,24 @@
   --color-crit: #d32f2f;
   --color-nodata: #9aa0aa;
   /* series palette is identical in both themes (validated ≥3:1 on both bg values) */
+}
+
+/* System (pre-JS/no-JS fallback only — with JS the attribute above is
+   authoritative). Values must stay identical to the [data-theme="light"]
+   block above. */
+@media (prefers-color-scheme: light) {
+  :root:not([data-theme="light"]):not([data-theme="dark"]) {
+    --color-bg: #ffffff;
+    --color-bg-elev: #f7f8fa;
+    --color-border: #e4e6eb;
+    --color-text: #1b1d22;
+    --color-text-2: #6b6f7b;
+    --color-brand: #00e09e;
+    --color-brand-deep: #00a991;
+    --color-on-brand: #0e1113;
+    --color-ok: #2e9950;
+    --color-warn: #c77d00;
+    --color-crit: #d32f2f;
+    --color-nodata: #9aa0aa;
+  }
 }


### PR DESCRIPTION
Completes the header/theme mission on upstat (apparule #108 and expendit #224 merged earlier): /docs/api sticky-chrome coexistence fix and the tri-state ThemeProvider contract (light | dark | system with live prefers-color-scheme tracking, no-FOUC init, sun/moon/monitor toggle cycle, Scalar embed synced to the resolved theme). Agent-built and gate-verified locally; commit 49bb68a pushed by the orchestrator after the agent process died pre-push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)