### PR TITLE
fix(web): adjudicated Figma↔code audit items — home content, charts, pills sweep, NavRail, brand mark, banner, assorted

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -308,7 +308,17 @@ links); `trending-up` / `trending-down` (QueryValue delta chips); `calendar`
 optional). **Added 2026-07-18** — the WidgetTypePicker tiles (§8.2b) add
 four glyphs, named per the naming standard below: `icon/table` (table
 widget), `icon/grid-3x3` (heatmap), `icon/share-2` (service map),
-`icon/type` (markdown). **Brand glyphs** — the Google 'G' for the X-1 auth CTA, the GitHub
+`icon/type` (markdown). **NavRail item icons [Adjudicated 2026-07-20]** —
+the twelve rail items carry ONE reconciled glyph list (master 284:2 vs
+code; the master's glyph wins where it is in this ratified set, code's
+stays where it isn't): `house` (Home) · `layout-dashboard` (Dashboards) ·
+`bar-chart-3` (Metrics) · `file-text` (Logs) · `route` (Traces — the
+APM/Traces pillar glyph; the rail master's git-branch is unratified and
+code's activity is vacated to Synthetics) · `globe` (RUM / Analytics) ·
+`activity` (Synthetics / Uptime) · `bell` (Monitors) · `flame` (Incidents —
+code-side keep; alert-triangle is unratified) · `target` (SLOs) ·
+`book-open` (Service Catalog — code-side keep; layers is unratified) ·
+`settings` (Settings). **Brand glyphs** — the Google 'G' for the X-1 auth CTA, the GitHub
 mark, Discord, Slack — are approved additions per the shared-foundations
 iconography rule (§2), **not Lucide**. All four stay on the approved list:
 Google 'G' and GitHub are built; Discord and Slack are in build now
@@ -349,12 +359,12 @@ never on screens. A screen frame must read as the shipped product would.
 | TimeseriesPanel | line / area / bars · with/without legend · loading (axis-first) / empty (radar sweep MI-16) / crosshair active — built ×9; the full mode × legend × state matrix is covered via instance overrides **[Decided 2026-07-16]** — **as built (2026-07-18 QA loop):** the bar variants inset their plots clear of the axis labels (bars no longer overlap the axis text) |
 | UptimeCard | all-up / with-outage-bars / nodata-gaps · % footer |
 | LogLine | collapsed / expanded (JSON tree) / level ×5 tints — level chip mapping **[Decided 2026-07-16]**: INFO → `brand` · DEBUG → `text-2` · TRACE → `nodata` (ERROR/WARN keep `crit`/`warn`) |
-| MonitorRow | status ×6 · muted toggle on/off |
-| IncidentBanner | sev1 / sev2 (persistent) · resolved (transient) |
-| SLOCard | healthy / burning (flame) / exhausted |
+| MonitorRow | status ×6 · muted toggle on/off — rows lead with the FULL labeled StatusPill; dot-only is reserved for the §5 colorblind rendering **[Adjudicated 2026-07-20]** |
+| IncidentBanner | sev1 / sev2 (persistent) · resolved (transient) — **[Adjudicated 2026-07-20, hybrid]** placement stays the GLOBAL chrome strip under the TopBar (§3); the strip carries the master's (48:141) explicit affordances: "open 12m"-style age and the "View incident →" / resolved "Postmortem →" link text |
+| SLOCard | healthy / burning (flame — §8.1 ratifies `flame` for burn-rate; the master's zap glyph is the design-side fix) / exhausted · per-state captions **[Adjudicated 2026-07-20]**: healthy "error budget N% left · burn X.X×" · burning "burn rate X.X× — page on-call" · exhausted "budget exhausted Nd ago" |
 | WidgetShell | view / edit (drag handle) / fullscreen — **as built (2026-07-18):** the edit-state body is the real "Choose a visualization" picker strip (WidgetTypePicker `layout=row`, §8.2b), not placeholder art — **as built (2026-07-18 QA loop):** the view-mode master carries a real chart body too (no placeholder in either state) |
 | ServiceMapNode | healthy / erroring (ring %) / selected |
-| Alert forms | channel: webhook / email · unverified / verified / degraded |
+| Alert forms | channel: webhook / email · unverified / verified / degraded — **[Adjudicated 2026-07-20]** the channel card leads with a friendly name over the masked target (webhook URLs keep origin + first path segment, the rest truncates); health is a labeled StatusPill (VERIFIED / UNVERIFIED / DEGRADED) with the degraded failure caption beneath |
 | AlertRuleCard | type: metric-threshold / log-pattern / trace-latency / slo-burn · mono query summary + threshold line (pages.md B "alert rules") |
 | TraceWaterfall | span row: depth indent ×3 · service color (series/n) · status ok/error · default / hover (mini-summary) / selected · chrome: time-axis header + SpanDrawer (tabs: tags / logs-in-span / process) — MI-7, pages.md B5 — **as built (2026-07-17):** SpanRow set + SpanDrawer set + a TraceWaterfall exemplar single (chrome assembled once, not a variant set) |
 | QueryValue | big tabular value + delta chip · threshold tint: none / ok / warn / crit · with/without sparkline (dashboard "query value" widget) |
@@ -400,8 +410,9 @@ project license, the copy reads **MIT**.
 | Component | Variants × states |
 | --- | --- |
 | **App chrome** | |
-| NavRail / NavRailItem | pillar icon ×12 · item: default / hover (flyout label) / active (brand accent) · rail chrome 56px: flyout-open / collapsed — **as built (2026-07-17):** NavRailItem is the variant set; NavRail ships as a single chrome component with rail states documented in its description — **[Directive 2026-07-19]:** rail is expandable; NavRail is now a variant set `state=collapsed` (56px) / `state=expanded` (240px icon+label rows, pillar section groups, foot chevron toggle, `upstat` wordmark); NavRailItem gains a `layout=rail/expanded` axis (expanded row 228px: default / hover raised bg / active accent bar); toggle persists per user, default expanded ≥1280px; exemplar `B1 — Home (rail expanded)` |
-| TopBar | org/env switcher closed/open · global TimePicker slot · search (`/`) field · bell: idle / unread-badge / flash (MI-14) — **as built (2026-07-17):** single chrome component, switcher/bell states documented in its description; bell badge states are CountBadge instances — **[Directive 2026-07-19]:** utility cluster now search · ThemeToggle · bell (theme parity canon); the master's flex spacer right-pins the cluster at any instance width |
+| BrandMark | glyph-only / glyph + lowercase `upstat` wordmark — the ONE product mark (filled bolt, brand green) **[Adjudicated 2026-07-20, systemic]**: it renders at every brand site — NavRail head, /signin (124:6), the public status page header (132:3530), marketing nav and footer brand block; the green "U" tile is retired everywhere |
+| NavRail / NavRailItem | pillar icon ×12 · item: default / hover (flyout label) / active (brand accent) · rail chrome 56px: flyout-open / collapsed — **as built (2026-07-17):** NavRailItem is the variant set; NavRail ships as a single chrome component with rail states documented in its description — **[Directive 2026-07-19]:** rail is expandable; NavRail is now a variant set `state=collapsed` (56px) / `state=expanded` (240px icon+label rows, pillar section groups, foot chevron toggle, `upstat` wordmark); NavRailItem gains a `layout=rail/expanded` axis (expanded row 228px: default / hover raised bg / active accent bar); toggle persists per user, default expanded ≥1280px; exemplar `B1 — Home (rail expanded)` — **[Adjudicated 2026-07-20]:** Home AND Dashboards sit ungrouped above the TELEMETRY group; the foot is a bordered chevron-square toggle + the signed-in user's avatar (no text button); the head is the bolt brand mark + `upstat` wordmark; item labels keep the fuller product names (RUM / Analytics · Synthetics / Uptime · Service Catalog); item icons per the §8.1 rail-icon list |
+| TopBar | org/env switcher closed/open · global TimePicker slot · search (`/`) field · bell: idle / unread-badge / flash (MI-14) — **as built (2026-07-17):** single chrome component, switcher/bell states documented in its description; bell badge states are CountBadge instances — **[Directive 2026-07-19]:** utility cluster now search · ThemeToggle · bell (theme parity canon); the master's flex spacer right-pins the cluster at any instance width — **[Adjudicated 2026-07-20]:** code matches the master's 43px bar height, lowercase `prod` env chip, "Search" placeholder (no ellipsis) and the TimePicker's "Custom" / "● LIVE" casing (the calendar glyph survives only as the <md collapse affordance) |
 | ThemeToggle | theme: dark (moon) / light (sun) / system (lucide `icon/monitor`) — 26px hairline button, the variant shows the state you are ON, token-bound · cycle order light → dark → system; system follows live `prefers-color-scheme` · lives on the marketing nav AND the TopBar utility cluster (parity canon) · persists at localStorage `upstat.theme`, default dark when unset — **[Revised 2026-07-20]** |
 | Modal / Sheet | modal sm/lg · right sheet · header + body slot + footer actions · z `sheet/modal 40` (§2 layers) |
 | CommandPalette / SearchOverlay | empty / results / no-results · result row: icon + label + kbd hint (`/` search, MI-17) |
@@ -417,11 +428,11 @@ project license, the copy reads **MIT**.
 | GoogleAuthButton | default / hover / loading · Google 'G' glyph + "Continue with Google" — the product's single auth CTA (X-1); renamed from `GoogleSignInCTA` 2026-07-17 per the §8.1 naming standard (same name in every product) |
 | Skeleton | kind: line / value / panel-axis · shimmer sweep — static (no sweep) under `prefers-reduced-motion` per §5 — the Stage-4 loading-frame primitive (§8.1 three-frame rule); iteration-1 addition **[built 2026-07-18]** |
 | **Product rows & overlays** | |
-| APIKeyRow / PropertyKeyRow | kind: ingestion-token (per-pillar scope chips) / property-key (RUM) · active / rotation-grace (24h) / revoked · mono key + copy + rejection-counter cell |
+| APIKeyRow / PropertyKeyRow | kind: ingestion-token (per-pillar scope chips) / property-key (RUM) · active / rotation-grace (24h) / revoked · mono key + copy + rejection-counter cell — **[Adjudicated 2026-07-20]** entity status is a labeled StatusPill (ACTIVE ok / ROTATING warn / REVOKED nodata), never lowercase text; the anatomy is key icon · name · masked-key chip · per-signal scope chips (otlp → logs/metrics/traces · rum · statsd → metrics · all) · "grace ends in 24h" / "N rejects (24h)" meta · pill |
 | MemberRow | avatar + name + email · role select: owner / admin / member · active / invited / disabled |
 | DashboardListRow | favorite star on/off · org-shared indicator · default / hover · name + updated ts |
 | SavedViewChip | personal / org-shared (avatar stack) · default / active (MI-18) |
-| AlertFeedRow + NotificationPopover | sev tint: sev1 / sev2 / resolved — **[Decided 2026-07-17]** the third tint is `resolved`, not sev3 (as built; standalone SevChip keeps sev1–3) · unread / read · ts + monitor name + 300ms slide-in (MI-14) · popover: empty / list |
+| AlertFeedRow + NotificationPopover | sev tint: sev1 / sev2 / resolved — **[Decided 2026-07-17]** the third tint is `resolved`, not sev3 (as built; standalone SevChip keeps sev1–3) · unread / read · 300ms slide-in (MI-14) · popover: empty / list — **[Adjudicated 2026-07-20]** the row is the master's single line (94:1513): unread brand dot · tinted mono sev chip (SEV-1 / SEV-2 / OK) · monitor name · relative age; the message detail rides the row tooltip |
 | IncidentComposer | idle / typing / slash-command autocomplete open (`/status`, `/sev`) / posting (optimistic prepend, MI-10) |
 | ThresholdOverlay | warn band / crit band / would-have-fired marker — composes over TimeseriesPanel (MI-9 test replay) — **as built (2026-07-17):** exemplar single, not a variant set |
 | ServiceCatalogRow | telemetry presence dots per pillar (present/absent ×4) · owner + repo/runbook links · default / hover |

--- a/docs/web-implementation.md
+++ b/docs/web-implementation.md
@@ -476,6 +476,36 @@ column's "API reference" links `/docs/api`; `e2e/docs-api.spec.ts` pins
 route 200, a rendered operation from the spec, the served document, the
 footer handoff, the header/scroll sanity and the embed-theme sync.
 
+**Audit convergence as-built (2026-07-20, adjudicated code-side items).**
+The Figma↔code audit's code-side items landed as one sequenced pass:
+(1) A8/A9 home content per the ratified canvas — the Community card is the
+public-status dogfooding moment ("View live →" → `/status/upstat`), the A9
+docs deep-link rows read "Self-host guide — step-by-step deploy docs →"
+(file-text) + "Query grammar — one grammar across all eight pillars →"
+(search), and the A14 twin renders the same label copy (no raw URLs) at the
+GitBook deployment guide. (2) TimeseriesPanel matches the master: four
+zero-baseline y ticks with unit-suffixed labels (new `unit` prop; bare
+"0"), a floating in-plot crosshair tooltip led by the hh:mm:ss timestamp,
+and by-<tag> legend labels trimmed to the tag value; TopList drops its
+background track (r=2 bars) and the Heatmap x-axis label count adapts to
+grid width (B6 cohort collision fix). (3) Entity-status pills sweep —
+labeled StatusPills replace lowercase status text on AlertChannelCard
+(friendly `name` + masked target + degraded `failure_note`), APIKeyRow
+(per-signal scope chips, grace/rejects meta), the B7 lists (full labeled
+pills; dot-only reserved for §5 colorblind), and AlertFeedRow collapses to
+the master's single line. (4) NavRail per the adjudication — Dashboards
+ungrouped above TELEMETRY, master foot (chevron square + user avatar via
+`useCurrentUserName`), the §8.1 reconciled rail-icon list. (5) The shared
+`BrandMark` (bolt + wordmark) replaces the green "U" tile at every brand
+site; /signin matches frame 124:6. (6) IncidentBanner keeps the global
+strip and gains "open Xm" + "View incident →" / "Postmortem →". (7)
+Assorted: B1 dashboard rows carry "N widgets", brand-green favorite stars,
+TopBar/TimePicker normalized to the master (43px, "prod", "Custom"/"LIVE",
+"Search"), LogLine level row tints + 3px left bars (master 47:163; code's
+timestamp format kept), SLOCard per-state captions (`Slo.exhausted_at`),
+B12 usage 64px rows + B-promotion ("5.6B") + unwrapped plan copy, and the
+B7 `?run=` deep link accepts run number or id with a "run not found" state.
+
 Screen-state parity **[Directive 2026-07-18, carried from design.md §8.1]**:
 every data-driven screen ships default, empty, and loading states — the
 three-frame rule applies to the implementation exactly as it does to the

--- a/web/e2e/dashboard.spec.ts
+++ b/web/e2e/dashboard.spec.ts
@@ -296,7 +296,7 @@ test("full journey: onboarding → B1 → dashboards → explorer → logs → t
   // live tail streams batches
   const liveToggle = page
     .getByRole("banner")
-    .getByRole("button", { name: "live" });
+    .getByRole("button", { name: "LIVE" });
   await liveToggle.click();
   const tailCount = await page
     .getByRole("list", { name: "Log lines" })

--- a/web/e2e/home.spec.ts
+++ b/web/e2e/home.spec.ts
@@ -78,13 +78,43 @@ test("home renders every Part A section", async ({ page }) => {
     ),
   ).toBeVisible();
   // CTA-dedupe canon: the one GitHub+Discord pair lives in A13; A8 carries
-  // the CueLABS™ card + docs links
+  // the public-status CARD (canvas 225:11191 + pages.md A8) with roadmap +
+  // CueLABS™ links beside it
   await expect(
     page.getByText("Discord — #upstat-lab on the CueLABS™ server"),
   ).toBeVisible();
+  const statusCard = page
+    .locator("#community")
+    .getByRole("link", { name: /Public status — we run upstat on upstat/ });
+  await expect(statusCard).toHaveAttribute("href", "/status/upstat");
+  await expect(statusCard).toContainText("View live →");
   await expect(
-    page.getByText("CueLABS™ — more open-source software from Cuesoft"),
-  ).toBeVisible();
+    page.getByRole("link", {
+      name: "CueLABS™ — more open-source software from Cuesoft →",
+    }),
+  ).toHaveAttribute("href", "https://cuelabs.cuesoft.io");
+  // A9 docs deep-link rows (canvas 135:763 + 259:3474): label copy with
+  // hyperlinks, no raw URL strings. The self-host label renders twice —
+  // the A9 row and its A14 twin (164:9388) — both at the ratified GitBook
+  // deployment guide.
+  const selfHostLinks = page.getByRole("link", {
+    name: "Self-host guide — step-by-step deploy docs →",
+  });
+  await expect(selfHostLinks).toHaveCount(2);
+  for (const link of await selfHostLinks.all()) {
+    await expect(link).toHaveAttribute(
+      "href",
+      "https://cuesoft.gitbook.io/upstat/system/deployment",
+    );
+  }
+  await expect(
+    page.getByRole("link", {
+      name: "Query grammar — one grammar across all eight pillars →",
+    }),
+  ).toHaveAttribute(
+    "href",
+    "https://cuesoft.gitbook.io/upstat/system/query-grammar",
+  );
 
   // A15 FAQ · A16 CTA band · A10 footer
   await expect(page.getByText("Questions, answered.")).toBeVisible();

--- a/web/e2e/signin.spec.ts
+++ b/web/e2e/signin.spec.ts
@@ -10,9 +10,11 @@ test("signin → dashboard home via the single Google CTA", async ({ page }) => 
 
   const screen = page.getByTestId("signin-screen");
   await expect(screen).toBeVisible();
+  // frame 124:6: centered bolt + wordmark over the org subline
   await expect(
-    screen.getByRole("heading", { name: "Sign in to Upstat" }),
+    screen.getByRole("heading", { name: "Sign in to your organization" }),
   ).toBeVisible();
+  await expect(screen.getByText("upstat", { exact: true })).toBeVisible();
 
   // X-1: a single auth affordance, Google only (scoped to the screen —
   // the Next dev overlay injects its own buttons in dev mode).

--- a/web/src/app/dashboard/metrics/page.tsx
+++ b/web/src/app/dashboard/metrics/page.tsx
@@ -171,6 +171,8 @@ export default function MetricsExplorerPage() {
                 ? `p95 latency — ${metricName}`
                 : metricName
             }
+            // unit-suffixed y labels where the metric name declares one
+            unit={metricName.endsWith("_ms") ? "ms" : undefined}
             query={ctrl.activeQuery}
             series={ts?.series ?? []}
             loading={ctrl.running}

--- a/web/src/app/dashboard/page.tsx
+++ b/web/src/app/dashboard/page.tsx
@@ -73,6 +73,8 @@ export default function DashboardHomePage() {
                     updated={`updated ${ageLabel(d.updated_at)} ago`}
                     favorite={d.favorite}
                     shared={d.shared}
+                    // "N widgets" meta per the B1 frame rows (125:13)
+                    meta={`${d.widgets.length} widget${d.widgets.length === 1 ? "" : "s"}`}
                     onClick={() => router.push(`/dashboard/dashboards/${d.id}`)}
                   />
                 </li>

--- a/web/src/app/dashboard/shell.tsx
+++ b/web/src/app/dashboard/shell.tsx
@@ -20,7 +20,11 @@ import { ShortcutCheatsheet } from "@/components/ui/ShortcutCheatsheet";
 import { TimePicker, type TimePreset } from "@/components/ui/TimePicker";
 import { TopBar } from "@/components/ui/TopBar";
 import { ZoomStackChip } from "@/components/ui/ZoomStackChip";
-import { ageLabel, useShellController } from "@/controllers/shell";
+import {
+  ageLabel,
+  useCurrentUserName,
+  useShellController,
+} from "@/controllers/shell";
 import { SHORTCUTS, useKeyboardMap } from "@/controllers/keyboard";
 import { TimeRangeProvider, useTimeRange } from "@/controllers/time-range";
 import type { Sev } from "@/components/ui/SevChip";
@@ -90,6 +94,7 @@ function ShellChrome({ children }: { children: ReactNode }) {
   const router = useRouter();
   const pathname = usePathname();
   const shell = useShellController();
+  const userName = useCurrentUserName();
   const keys = useKeyboardMap();
   const [bellOpen, setBellOpen] = useState(false);
   const [orgOpen, setOrgOpen] = useState(false);
@@ -116,6 +121,7 @@ function ShellChrome({ children }: { children: ReactNode }) {
       <NavRail
         activeKey={activeKeyFor(pathname)}
         onNavigate={(key) => router.push(PILLAR_ROUTES[key] ?? "/dashboard")}
+        userName={userName}
       />
 
       <div className="flex min-w-0 flex-1 flex-col">

--- a/web/src/app/dashboard/traces/services/[service]/page.tsx
+++ b/web/src/app/dashboard/traces/services/[service]/page.tsx
@@ -206,6 +206,7 @@ export default function ServiceDetailPage() {
       <section aria-label="Latency percentiles">
         <TimeseriesPanel
           title={`latency percentiles — ${service}`}
+          unit="ms"
           query={`metric:http.request.duration_ms service:${service} | p50(), p95(), p99()`}
           series={ts?.series ?? []}
           loading={latency.loading}

--- a/web/src/app/dashboard/uptime/[id]/page.tsx
+++ b/web/src/app/dashboard/uptime/[id]/page.tsx
@@ -99,6 +99,7 @@ export default function MonitorDetailPage() {
 
           <TimeseriesPanel
             title="Response time — recent checks"
+            unit="ms"
             query={`uptime(check:${m.name.toLowerCase().replace(/\s+/g, "-")}) response_ms`}
             series={responseSeries}
             loading={history.loading}

--- a/web/src/app/dashboard/uptime/checks/[id]/page.tsx
+++ b/web/src/app/dashboard/uptime/checks/[id]/page.tsx
@@ -34,7 +34,10 @@ export default function SyntheticRunPage() {
   const { id } = useParams<{ id: string }>();
   const router = useRouter();
   const runId = useSearchParams().get("run");
-  const { check, runs, selected } = useSyntheticRunController(id, runId);
+  const { check, runs, selected, notFound } = useSyntheticRunController(
+    id,
+    runId,
+  );
   const context = useSyntheticContext(check.data);
   const synthetics = useSyntheticsController();
 
@@ -173,6 +176,11 @@ export default function SyntheticRunPage() {
             )}
           </div>
         </>
+      ) : notFound ? (
+        // never "No runs yet" while runs exist — a bad ?run= says so
+        <p className="text-[13px] text-text-2" data-testid="run-not-found">
+          Run {runId} not found — pick one from the run history below.
+        </p>
       ) : (
         <p className="text-[13px] text-text-2">
           No runs yet — Run once to execute the steps now.

--- a/web/src/app/dashboard/uptime/page.tsx
+++ b/web/src/app/dashboard/uptime/page.tsx
@@ -90,6 +90,8 @@ export default function UptimePage() {
                   href={`/dashboard/uptime/checks/${check.id}`}
                   className="flex h-10 items-center gap-3 border-b border-border px-3 transition-colors duration-[var(--duration-fast)] ease-standard hover:bg-bg-elev"
                 >
+                  {/* labeled pill — dot-only is the §5 colorblind rendering
+                      (systemic adjudication 2026-07-20) */}
                   <StatusPill
                     status={
                       check.last_run_status === null
@@ -98,7 +100,7 @@ export default function UptimePage() {
                           ? "ok"
                           : "crit"
                     }
-                    dotOnly
+                    className="shrink-0"
                   />
                   <span className="w-64 truncate text-[13px] font-medium text-text">
                     {check.name}

--- a/web/src/app/signin/page.tsx
+++ b/web/src/app/signin/page.tsx
@@ -1,13 +1,16 @@
 "use client";
 
 import { useAuthController } from "@/controllers/auth";
+import { BrandMark } from "@/components/ui/BrandMark";
 import { GoogleAuthButton } from "@/components/ui/GoogleAuthButton";
 
 /**
  * /signin — the single auth screen (X-1: Google sign-in only, product-wide;
  * flows/auth.md; route standard: /signin is the ONLY auth route — no
  * /login or /signup exists, and stale links 404 on the branded page
- * [Directive 2026-07-19]). One CTA, nothing else.
+ * [Directive 2026-07-19]). One CTA, nothing else. Composition per the X-1
+ * canon frame (124:6): centered bolt + wordmark over "Sign in to your
+ * organization" over the Google CTA.
  */
 export default function SignInPage() {
   const { signInWithGoogle, loading, error } = useAuthController();
@@ -17,24 +20,22 @@ export default function SignInPage() {
       data-testid="signin-screen"
       className="font-ui flex min-h-screen items-center justify-center bg-bg px-[var(--space-4)] text-text"
     >
-      <main className="flex w-full max-w-[360px] flex-col gap-[var(--space-6)]">
-        <header className="flex flex-col gap-[var(--space-2)]">
-          <span
-            aria-hidden="true"
-            className="mb-[var(--space-2)] inline-flex size-8 items-center justify-center rounded-(--radius) bg-brand text-[16px] font-semibold text-on-brand"
-          >
-            U
-          </span>
-          <h1 className="text-[20px] font-semibold">Sign in to Upstat</h1>
-          <p className="text-[13px] leading-[1.45] text-text-2">
-            Continue with your Google account — it&apos;s the only sign-in
-            Upstat has.
-          </p>
+      <main className="flex w-full max-w-[360px] flex-col items-center gap-[var(--space-6)] text-center">
+        <header className="flex flex-col items-center gap-[var(--space-3)]">
+          <BrandMark
+            wordmark
+            className="gap-2.5 text-[26px]"
+            glyphClassName="size-7"
+          />
+          <h1 className="text-[14px] font-normal leading-[1.45] text-text-2">
+            Sign in to your organization
+          </h1>
         </header>
 
         <GoogleAuthButton
           onClick={() => void signInWithGoogle()}
           loading={loading}
+          className="w-full max-w-[280px]"
         />
 
         {error && (

--- a/web/src/app/status/[slug]/page.tsx
+++ b/web/src/app/status/[slug]/page.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { useParams } from "next/navigation";
+import { BrandMark } from "@/components/ui/BrandMark";
 import { IncidentHistoryEntry } from "@/components/ui/IncidentHistoryEntry";
 import { Skeleton } from "@/components/ui/Skeleton";
 import { StatusPageComponentRow } from "@/components/ui/StatusPageComponentRow";
@@ -57,13 +58,10 @@ export default function StatusPage() {
       className="mx-auto flex w-full max-w-[960px] flex-col gap-6 px-6 py-10"
     >
       <header className="flex flex-col gap-2">
+        {/* bolt brand mark per frame 132:3530 (systemic adjudication
+            2026-07-20 — the "U" tile is retired) */}
         <h1 className="flex items-center gap-2 text-[24px] font-semibold">
-          <span
-            aria-hidden="true"
-            className="inline-flex size-7 items-center justify-center rounded-(--radius) bg-brand text-[14px] font-semibold text-on-brand"
-          >
-            U
-          </span>
+          <BrandMark glyphClassName="size-6" />
           {page.org_name.toLowerCase()} status
         </h1>
         {/* no subscribe affordance yet (pages.md B7 subscribe = Later) —

--- a/web/src/components/home/HomeView.test.tsx
+++ b/web/src/components/home/HomeView.test.tsx
@@ -75,15 +75,44 @@ describe("HomeView (pages.md Part A — Figma frame 135:2)", () => {
         "Go gRPC services · Next.js + React/TS · ClickHouse · OpenTelemetry",
       ),
     ).toBeInTheDocument();
-    // A8 community
-    // CTA-dedupe canon: A13 keeps the one GitHub+Discord pair; A8 points at
-    // the lab + docs instead
+    // A8 community — the public-status CARD (canvas 225:11191 + pages.md
+    // A8: "View live →" → the product's own status page) with roadmap +
+    // CueLABS™ links beside it. CTA-dedupe canon: A13 keeps the one
+    // GitHub+Discord pair.
     expect(
       screen.getByText("Discord — #upstat-lab on the CueLABS™ server"),
     ).toBeInTheDocument();
+    const statusCard = screen
+      .getByText("Public status — we run upstat on upstat")
+      .closest("a");
+    expect(statusCard).toHaveAttribute("href", "/status/upstat");
+    expect(statusCard).toHaveTextContent("View live →");
     expect(
-      screen.getByText("CueLABS™ — more open-source software from Cuesoft"),
-    ).toBeInTheDocument();
+      screen.getByRole("link", {
+        name: "CueLABS™ — more open-source software from Cuesoft →",
+      }),
+    ).toHaveAttribute("href", "https://cuelabs.cuesoft.io");
+    // A9 docs deep-link rows (canvas 135:763 + 259:3474): label copy with
+    // hyperlinks, no raw URL strings — the self-host label renders twice
+    // (the A9 row + its A14 twin, 164:9388), both at the GitBook guide
+    const selfHostLinks = screen.getAllByRole("link", {
+      name: "Self-host guide — step-by-step deploy docs →",
+    });
+    expect(selfHostLinks).toHaveLength(2);
+    for (const link of selfHostLinks) {
+      expect(link).toHaveAttribute(
+        "href",
+        "https://cuesoft.gitbook.io/upstat/system/deployment",
+      );
+    }
+    expect(
+      screen.getByRole("link", {
+        name: "Query grammar — one grammar across all eight pillars →",
+      }),
+    ).toHaveAttribute(
+      "href",
+      "https://cuesoft.gitbook.io/upstat/system/query-grammar",
+    );
     // A15 FAQ + A16 CTA band
     expect(screen.getByText("Questions, answered.")).toBeInTheDocument();
     expect(screen.getByText("OTLP in. Answers out.")).toBeInTheDocument();

--- a/web/src/components/home/HomeView.test.tsx
+++ b/web/src/components/home/HomeView.test.tsx
@@ -157,10 +157,13 @@ describe("HomeView (pages.md Part A — Figma frame 135:2)", () => {
 
   it("accuracy: MIT copy present, no fabricated pricing", () => {
     renderHome();
+    // the MIT mention lives in the legal bar (the brand tagline is the
+    // master 290:2 line, no license copy)
     expect(
-      screen.getByText(
-        /Open-source observability by CueLABS™\. MIT licensed\./,
-      ),
+      screen.getByRole("link", { name: "MIT License" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("All your telemetry. One open platform."),
     ).toBeInTheDocument();
     expect(
       screen.getByText(

--- a/web/src/components/home/sections-bottom.tsx
+++ b/web/src/components/home/sections-bottom.tsx
@@ -5,14 +5,7 @@
  * (A13), community (A8), FAQ (A15), final CTA band (A16).
  */
 
-import {
-  Activity,
-  BookOpen,
-  Check,
-  ExternalLink,
-  FileText,
-  FlaskConical,
-} from "lucide-react";
+import { Activity, Check, FileText, Search } from "lucide-react";
 import Link from "next/link";
 import { useState } from "react";
 import { Button } from "@/components/ui/Button";
@@ -68,12 +61,14 @@ export function SelfHostSection({ onSelfHostDocs }: SelfHostSectionProps) {
               </li>
             ))}
           </ul>
+          {/* label copy, no raw URL strings (pages.md A9/A14 [Revised
+              2026-07-19]) — the href is the ratified GitBook deployment guide */}
           <a
             href={SELF_HOST_DOCS_URL}
             onClick={onSelfHostDocs}
             className="text-[13px] font-medium text-brand transition-colors duration-[var(--duration-fast)] hover:text-brand-deep"
           >
-            Self-host guide: cuesoft.gitbook.io/upstat/system/deployment →
+            Self-host guide — step-by-step deploy docs →
           </a>
         </div>
 
@@ -174,25 +169,26 @@ export function CloudSelfHostSection({
             </span>
           </code>
           {/* CTA-dedupe canon (2026-07-19): GitHub/Discord conversion lives in
-              the nav badge, A13 and the footer — this section carries
-              differentiated real destinations instead */}
+              the nav badge, A13 and the footer — these are the A9 docs
+              deep-link rows per the canvas (135:763 + 259:3474): label copy
+              with hyperlinks, no raw URL strings */}
+          <a
+            href={SELF_HOST_DOCS_URL}
+            className="flex items-center gap-2.5 text-[13px] text-text-2 transition-colors duration-[var(--duration-fast)] hover:text-text"
+          >
+            <FileText
+              aria-hidden="true"
+              className="size-5 shrink-0 text-text"
+            />
+            Self-host guide — step-by-step deploy docs →
+          </a>
           <a
             href={QUERY_GRAMMAR_DOCS_URL}
             className="flex items-center gap-2.5 text-[13px] text-text-2 transition-colors duration-[var(--duration-fast)] hover:text-text"
           >
-            <BookOpen
-              aria-hidden="true"
-              className="size-6 shrink-0 text-text"
-            />
-            Query grammar — the one grammar across logs, metrics and traces
+            <Search aria-hidden="true" className="size-5 shrink-0 text-text" />
+            Query grammar — one grammar across all eight pillars →
           </a>
-          <Link
-            href="/status/upstat"
-            className="flex items-center gap-2.5 text-[13px] text-text-2 transition-colors duration-[var(--duration-fast)] hover:text-text"
-          >
-            <Activity aria-hidden="true" className="size-6 shrink-0 text-ok" />
-            /status/upstat — we run upstat on upstat, publicly
-          </Link>
         </div>
       </div>
     </Section>
@@ -277,30 +273,33 @@ export function DevelopersSection({ onGithub }: DevelopersSectionProps) {
 export function CommunitySection() {
   return (
     <Section id="community" title="Community">
-      {/* CTA-dedupe canon (2026-07-19): the GitHub/Discord pair lives in A13 —
-          this section points at the lab and the docs instead */}
+      {/* A8 per the canvas (225:11191, user-ratified) + pages.md A8: the
+          CARD is the public-status dogfooding moment ("View live →" → the
+          product's own status page); CueLABS™ and the roadmap ride as
+          links. CTA-dedupe canon (2026-07-19): the GitHub/Discord pair
+          lives in A13. */}
       <div className="grid items-start gap-12 lg:grid-cols-[1fr_480px]">
-        <a
-          href={CUELABS_URL}
+        <Link
+          href="/status/upstat"
           className="flex items-start gap-4 rounded-(--radius) border border-border bg-bg-elev p-4 transition-colors duration-[var(--duration-base)] hover:border-text-2"
         >
-          <FlaskConical
+          <Activity
             aria-hidden="true"
-            className="mt-1 size-7 shrink-0 text-brand"
+            className="mt-1 size-7 shrink-0 text-text"
           />
           <span className="flex min-w-0 flex-1 flex-col gap-1">
             <span className="text-[14px] font-semibold text-text">
-              CueLABS™ — more open-source software from Cuesoft
+              Public status — we run upstat on upstat
             </span>
             <span className="text-[13px] text-text-2">
-              The division upstat ships from — see what else is built in the
-              open.
+              Live uptime and incident history at
+              upstat.cuesoft.io/status/upstat — we run upstat on upstat.
             </span>
           </span>
           <span className="shrink-0 text-[13px] font-medium text-brand">
-            Explore →
+            View live →
           </span>
-        </a>
+        </Link>
         <div className="flex flex-col gap-4 lg:pt-2">
           <a
             href={ROADMAP_URL}
@@ -309,11 +308,10 @@ export function CommunitySection() {
             Public roadmap →
           </a>
           <a
-            href={SELF_HOST_DOCS_URL}
-            className="flex items-center gap-1.5 text-[13px] font-medium text-brand transition-colors duration-[var(--duration-fast)] hover:text-brand-deep"
+            href={CUELABS_URL}
+            className="text-[13px] font-medium text-brand transition-colors duration-[var(--duration-fast)] hover:text-brand-deep"
           >
-            Self-host guide — run it on your infrastructure
-            <ExternalLink aria-hidden="true" className="size-3.5" />
+            CueLABS™ — more open-source software from Cuesoft →
           </a>
         </div>
       </div>

--- a/web/src/components/home/sections-demo.tsx
+++ b/web/src/components/home/sections-demo.tsx
@@ -45,6 +45,7 @@ export function DemoBandSection({
         <TimeseriesPanel
           title="p95 latency — api-common"
           titleAs="p"
+          unit="ms"
           query={query}
           series={series}
           height={190}
@@ -143,6 +144,7 @@ export function UseCasesSection({
           <TimeseriesPanel
             title="p95 latency — api-common"
             titleAs="p"
+            unit="ms"
             query={query}
             series={series}
             height={140}

--- a/web/src/components/home/sections-top.tsx
+++ b/web/src/components/home/sections-top.tsx
@@ -68,6 +68,7 @@ export function HeroSection({
           <TimeseriesPanel
             title="p95 latency — api-common"
             titleAs="p"
+            unit="ms"
             query={query}
             series={series}
             height={190}
@@ -239,6 +240,7 @@ export function HowItWorksSection({ series }: HowItWorksSectionProps) {
           <TimeseriesPanel
             title="p95 latency — api-common"
             titleAs="p"
+            unit="ms"
             series={series}
             height={130}
           />

--- a/web/src/components/ui/APIKeyRow.test.tsx
+++ b/web/src/components/ui/APIKeyRow.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from "@testing-library/react";
 import { APIKeyRow } from "./APIKeyRow";
 
 describe("APIKeyRow", () => {
-  it("hides revoke on revoked keys", () => {
+  it("hides revoke on revoked keys (REVOKED pill)", () => {
     render(
       <APIKeyRow
         apiKey={{
@@ -19,11 +19,17 @@ describe("APIKeyRow", () => {
         onRevoke={() => undefined}
       />,
     );
-    expect(screen.getByText("revoked")).toBeInTheDocument();
+    // entity status renders as a labeled pill, not lowercase text
+    expect(screen.getByText("REVOKED")).toBeInTheDocument();
+    expect(screen.queryByText("revoked")).toBeNull();
     expect(screen.queryByLabelText("Revoke Old collector")).toBeNull();
+    // OTLP ingestion tokens carry per-signal scope chips (master anatomy)
+    for (const signal of ["logs", "metrics", "traces"]) {
+      expect(screen.getByText(signal)).toBeInTheDocument();
+    }
   });
 
-  it("shows the rotation-grace state + rejection counter", () => {
+  it("shows the ROTATING pill + grace copy on rotation-grace keys", () => {
     render(
       <APIKeyRow
         apiKey={{
@@ -38,7 +44,32 @@ describe("APIKeyRow", () => {
         }}
       />,
     );
-    expect(screen.getByText("rotation grace (24h)")).toBeInTheDocument();
-    expect(screen.getByText("431 rejected")).toBeInTheDocument();
+    expect(screen.getByText("ROTATING")).toBeInTheDocument();
+    expect(screen.getByText("grace ends in 24h")).toBeInTheDocument();
+    // property keys chip their single RUM signal
+    expect(screen.getByText("rum")).toBeInTheDocument();
+  });
+
+  it("shows the ACTIVE pill + 24h rejects counter on active keys", () => {
+    render(
+      <APIKeyRow
+        apiKey={{
+          id: "key_3",
+          kind: "ingestion_token",
+          name: "prod ingest — api-common",
+          scope: "otlp",
+          key_masked: "uk_live_9f2c…3d1a",
+          status: "active",
+          created_at: "2026-01-01T00:00:00Z",
+          rejected_count: 0,
+        }}
+        onRevoke={() => undefined}
+      />,
+    );
+    expect(screen.getByText("ACTIVE")).toBeInTheDocument();
+    expect(screen.getByText("0 rejects (24h)")).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Revoke prod ingest — api-common"),
+    ).toBeInTheDocument();
   });
 });

--- a/web/src/components/ui/APIKeyRow.tsx
+++ b/web/src/components/ui/APIKeyRow.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import { clsx } from "clsx";
-import { Check, Copy, Trash2 } from "lucide-react";
+import { Check, Copy, Key, Trash2 } from "lucide-react";
 import { useState } from "react";
 import type { ApiKey } from "@/models";
+import { StatusPill, type StatusPillStatus } from "./StatusPill";
 
 export interface APIKeyRowProps {
   apiKey: ApiKey;
@@ -11,16 +12,30 @@ export interface APIKeyRowProps {
   className?: string;
 }
 
-const STATUS_LABEL: Record<ApiKey["status"], string> = {
-  active: "active",
-  rotation_grace: "rotation grace (24h)",
-  revoked: "revoked",
+/** Entity-status pill mapping (systemic adjudication 2026-07-20: labeled
+ *  StatusPills, never lowercase colored text). */
+const STATUS_PILL: Record<
+  ApiKey["status"],
+  { status: StatusPillStatus; label: string }
+> = {
+  active: { status: "ok", label: "ACTIVE" },
+  rotation_grace: { status: "warn", label: "ROTATING" },
+  revoked: { status: "nodata", label: "REVOKED" },
+};
+
+/** Per-signal scope chips (master anatomy: [logs][metrics][traces] / [rum]). */
+const SCOPE_SIGNALS: Record<ApiKey["scope"], string[]> = {
+  otlp: ["logs", "metrics", "traces"],
+  rum: ["rum"],
+  statsd: ["metrics"],
+  all: ["logs", "metrics", "traces", "rum"],
 };
 
 /**
  * APIKeyRow / PropertyKeyRow — §8.2b: kind ingestion-token (scope chips) /
  * property-key (RUM) · active / rotation-grace / revoked · mono key + copy +
- * rejection counter.
+ * rejection counter. Master anatomy: key icon · name · masked key chip ·
+ * per-signal scope chips · grace/rejects meta · labeled StatusPill.
  */
 export function APIKeyRow({ apiKey, onRevoke, className }: APIKeyRowProps) {
   const [copied, setCopied] = useState(false);
@@ -35,57 +50,67 @@ export function APIKeyRow({ apiKey, onRevoke, className }: APIKeyRowProps) {
     setTimeout(() => setCopied(false), 1200);
   };
 
+  const pill = STATUS_PILL[apiKey.status];
+  // master copy: rotating rows carry the grace deadline (24h rotation
+  // contract, data-model.md §2); active rows the 24h rejection counter
+  const meta =
+    apiKey.status === "rotation_grace"
+      ? "grace ends in 24h"
+      : apiKey.status === "active"
+        ? `${apiKey.rejected_count} rejects (24h)`
+        : null;
+
   return (
     <div
       data-status={apiKey.status}
       data-kind={apiKey.kind}
       className={clsx(
-        "font-ui @container flex items-center gap-3 border-b border-border px-3 py-2",
+        "font-ui @container flex items-center gap-3 border-b border-border px-3 py-2.5",
         apiKey.status === "revoked" && "opacity-60",
         className,
       )}
     >
-      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-        <span className="flex items-center gap-2 text-[13px] font-medium text-text">
-          {apiKey.name}
-          <span className="rounded-(--radius) border border-border px-1 text-[10px] uppercase tracking-wide text-text-2">
-            {apiKey.kind === "property_key" ? "property" : apiKey.scope}
-          </span>
-        </span>
-        <span className="flex items-center gap-2">
-          <code className="font-data text-[12px] text-text-2">
-            {apiKey.key_masked}
-          </code>
-          <button
-            type="button"
-            aria-label={`Copy key ${apiKey.name}`}
-            onClick={() => void copy()}
-            className="text-text-2 transition-colors duration-[var(--duration-fast)] hover:text-text"
-          >
-            {copied ? (
-              <Check className="size-3 text-ok" />
-            ) : (
-              <Copy className="size-3" />
-            )}
-          </button>
-        </span>
-      </div>
-      <span
-        className={clsx(
-          "shrink-0 text-[12px]",
-          apiKey.status === "active" && "text-ok",
-          apiKey.status === "rotation_grace" && "text-warn",
-          apiKey.status === "revoked" && "text-nodata",
-        )}
-      >
-        {STATUS_LABEL[apiKey.status]}
+      <Key aria-hidden="true" className="size-4 shrink-0 text-text-2" />
+      <span className="min-w-0 shrink truncate text-[13px] font-medium text-text">
+        {apiKey.name}
       </span>
-      {/* Trailing stat clips in narrow compositions (368px how-it-works
+      <span className="flex shrink-0 items-center gap-1.5 rounded-(--radius) border border-border px-1.5 py-0.5">
+        <code className="font-data text-[12px] text-text-2">
+          {apiKey.key_masked}
+        </code>
+        <button
+          type="button"
+          aria-label={`Copy key ${apiKey.name}`}
+          onClick={() => void copy()}
+          className="text-text-2 transition-colors duration-[var(--duration-fast)] hover:text-text"
+        >
+          {copied ? (
+            <Check className="size-3 text-ok" />
+          ) : (
+            <Copy className="size-3" />
+          )}
+        </button>
+      </span>
+      <span className="hidden items-center gap-1 @[26rem]:flex">
+        {SCOPE_SIGNALS[apiKey.scope].map((signal) => (
+          <span
+            key={signal}
+            className="font-data rounded-(--radius) border border-border px-1 py-px text-[10px] tracking-wide text-text-2"
+          >
+            {signal}
+          </span>
+        ))}
+      </span>
+      <span className="min-w-0 flex-1" />
+      {/* Trailing meta clips in narrow compositions (368px how-it-works
           column) — the Figma master hides it there, so the row hides it
           below 416px of its own width (container query, not viewport). */}
-      <span className="hidden w-24 shrink-0 text-right text-[12px] tabular-nums text-text-2 @[26rem]:block">
-        {apiKey.rejected_count} rejected
-      </span>
+      {meta && (
+        <span className="font-data hidden shrink-0 text-[12px] tabular-nums text-text-2 @[26rem]:block">
+          {meta}
+        </span>
+      )}
+      <StatusPill status={pill.status} label={pill.label} />
       {onRevoke && apiKey.status !== "revoked" && (
         <button
           type="button"

--- a/web/src/components/ui/APIKeyRow.tsx
+++ b/web/src/components/ui/APIKeyRow.tsx
@@ -74,15 +74,18 @@ export function APIKeyRow({ apiKey, onRevoke, className }: APIKeyRowProps) {
       <span className="min-w-0 shrink truncate text-[13px] font-medium text-text">
         {apiKey.name}
       </span>
-      <span className="flex shrink-0 items-center gap-1.5 rounded-(--radius) border border-border px-1.5 py-0.5">
-        <code className="font-data text-[12px] text-text-2">
+      {/* the key chip shares the shrink budget with the name (mobile-width
+          canon: no horizontal document pan at 390 — the masked key
+          truncates; the full value was only ever visible at creation) */}
+      <span className="flex min-w-0 shrink items-center gap-1.5 rounded-(--radius) border border-border px-1.5 py-0.5">
+        <code className="font-data min-w-0 truncate text-[12px] text-text-2">
           {apiKey.key_masked}
         </code>
         <button
           type="button"
           aria-label={`Copy key ${apiKey.name}`}
           onClick={() => void copy()}
-          className="text-text-2 transition-colors duration-[var(--duration-fast)] hover:text-text"
+          className="shrink-0 text-text-2 transition-colors duration-[var(--duration-fast)] hover:text-text"
         >
           {copied ? (
             <Check className="size-3 text-ok" />
@@ -110,7 +113,12 @@ export function APIKeyRow({ apiKey, onRevoke, className }: APIKeyRowProps) {
           {meta}
         </span>
       )}
-      <StatusPill status={pill.status} label={pill.label} />
+      {/* the pill keeps its label at every width (labels-not-dots canon) */}
+      <StatusPill
+        status={pill.status}
+        label={pill.label}
+        className="shrink-0"
+      />
       {onRevoke && apiKey.status !== "revoked" && (
         <button
           type="button"

--- a/web/src/components/ui/AlertChannelCard.test.tsx
+++ b/web/src/components/ui/AlertChannelCard.test.tsx
@@ -1,14 +1,15 @@
 import { describe, expect, it } from "vitest";
 import { render, screen } from "@testing-library/react";
-import { AlertChannelCard } from "./AlertChannelCard";
+import { AlertChannelCard, maskChannelTarget } from "./AlertChannelCard";
 
 describe("AlertChannelCard", () => {
-  it("offers Verify only while unverified", () => {
+  it("offers Verify only while unverified (UNVERIFIED pill)", () => {
     const { rerender } = render(
       <AlertChannelCard
         channel={{
           id: "ch",
           kind: "webhook",
+          name: "Ops pager webhook",
           target: "https://x",
           health: "unverified",
           created_at: "",
@@ -17,11 +18,13 @@ describe("AlertChannelCard", () => {
       />,
     );
     expect(screen.getByRole("button", { name: "Verify" })).toBeInTheDocument();
+    expect(screen.getByText("UNVERIFIED")).toBeInTheDocument();
     rerender(
       <AlertChannelCard
         channel={{
           id: "ch",
           kind: "webhook",
+          name: "Ops pager webhook",
           target: "https://x",
           health: "verified",
           created_at: "",
@@ -30,21 +33,57 @@ describe("AlertChannelCard", () => {
       />,
     );
     expect(screen.queryByRole("button", { name: "Verify" })).toBeNull();
+    // entity status renders as a labeled pill, not lowercase text
+    expect(screen.getByText("VERIFIED")).toBeInTheDocument();
+    expect(screen.queryByText("verified")).toBeNull();
   });
 
-  it("renders the degraded state for email channels", () => {
+  it("renders the degraded state with the failure caption (master anatomy)", () => {
     render(
       <AlertChannelCard
         channel={{
           id: "ch2",
           kind: "email",
+          name: "On-call email",
           target: "oncall@upstat.dev",
           health: "degraded",
+          failure_note: "Last delivery failed 12m ago — 3 retries exhausted",
           created_at: "",
         }}
       />,
     );
+    expect(screen.getByText("On-call email")).toBeInTheDocument();
     expect(screen.getByText("oncall@upstat.dev")).toBeInTheDocument();
-    expect(screen.getByText("degraded")).toBeInTheDocument();
+    expect(screen.getByText("DEGRADED")).toBeInTheDocument();
+    expect(
+      screen.getByText("Last delivery failed 12m ago — 3 retries exhausted"),
+    ).toBeInTheDocument();
+  });
+
+  it("falls back to the kind label when unnamed", () => {
+    render(
+      <AlertChannelCard
+        channel={{
+          id: "ch3",
+          kind: "email",
+          target: "ops@upstat.dev",
+          health: "verified",
+          created_at: "",
+        }}
+      />,
+    );
+    expect(screen.getByText("Email")).toBeInTheDocument();
+  });
+
+  it("masks webhook targets after the first path segment", () => {
+    expect(
+      maskChannelTarget(
+        "https://hooks.slack.com/services/T0UPSTAT/B0ALERTS/xxxx",
+      ),
+    ).toBe("https://hooks.slack.com/services/T0UP…/B0AL…/xxxx");
+    expect(maskChannelTarget("oncall@upstat.dev")).toBe("oncall@upstat.dev");
+    expect(maskChannelTarget("https://ops.cuesoft.io/hooks/upstat")).toBe(
+      "https://ops.cuesoft.io/hooks/upst…",
+    );
   });
 });

--- a/web/src/components/ui/AlertChannelCard.tsx
+++ b/web/src/components/ui/AlertChannelCard.tsx
@@ -3,6 +3,7 @@
 import { clsx } from "clsx";
 import { Mail, Trash2, Webhook } from "lucide-react";
 import type { AlertChannel } from "@/models";
+import { StatusPill } from "./StatusPill";
 
 export interface AlertChannelCardProps {
   channel: AlertChannel;
@@ -11,7 +12,46 @@ export interface AlertChannelCardProps {
   className?: string;
 }
 
-/** AlertChannelCard — §8.2 alert forms: webhook/email · unverified/verified/degraded. */
+const KIND_LABEL: Record<AlertChannel["kind"], string> = {
+  email: "Email",
+  webhook: "Webhook",
+};
+
+/** Entity-status pill mapping (systemic adjudication 2026-07-20: labeled
+ *  StatusPills, never lowercase colored text). */
+const HEALTH_PILL: Record<
+  AlertChannel["health"],
+  { status: "ok" | "warn" | "crit"; label: string }
+> = {
+  verified: { status: "ok", label: "VERIFIED" },
+  unverified: { status: "warn", label: "UNVERIFIED" },
+  degraded: { status: "crit", label: "DEGRADED" },
+};
+
+/**
+ * Masked display form of the channel target (master anatomy): webhook URLs
+ * keep origin + first path segment, then truncate each remaining segment
+ * ("https://hooks.slack.com/services/T0UP…/B0AL…"). Emails render verbatim.
+ */
+export function maskChannelTarget(target: string): string {
+  if (!/^https?:\/\//.test(target)) return target;
+  try {
+    const url = new URL(target);
+    const segments = url.pathname.split("/").filter(Boolean);
+    if (segments.length <= 1) return `${url.origin}${url.pathname}`;
+    const [first, ...rest] = segments;
+    const masked = rest.map((s) => (s.length > 4 ? `${s.slice(0, 4)}…` : s));
+    return `${url.origin}/${[first, ...masked].join("/")}`;
+  } catch {
+    return target;
+  }
+}
+
+/**
+ * AlertChannelCard — §8.2 alert forms: webhook/email ·
+ * unverified/verified/degraded. Master anatomy: kind icon · friendly name ·
+ * labeled StatusPill · masked target (mono) · degraded failure caption.
+ */
 export function AlertChannelCard({
   channel,
   onVerify,
@@ -19,39 +59,36 @@ export function AlertChannelCard({
   className,
 }: AlertChannelCardProps) {
   const Icon = channel.kind === "email" ? Mail : Webhook;
+  const pill = HEALTH_PILL[channel.health];
   return (
     <div
       data-kind={channel.kind}
       data-health={channel.health}
       className={clsx(
-        "font-ui flex items-center gap-3 rounded-(--radius) border border-border bg-bg-elev p-3",
+        "font-ui flex items-start gap-3 rounded-(--radius) border border-border bg-bg-elev p-3",
         className,
       )}
     >
-      <Icon aria-hidden="true" className="size-4 shrink-0 text-text-2" />
-      <div className="flex min-w-0 flex-1 flex-col">
-        <span className="text-[12px] uppercase tracking-wide text-text-2">
-          {channel.kind}
+      <Icon aria-hidden="true" className="mt-0.5 size-4 shrink-0 text-text-2" />
+      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+        <span className="flex items-center gap-2">
+          <span className="min-w-0 flex-1 truncate text-[13px] font-medium text-text">
+            {channel.name ?? KIND_LABEL[channel.kind]}
+          </span>
+          <StatusPill status={pill.status} label={pill.label} />
         </span>
-        <span className="font-data truncate text-[13px] text-text">
-          {channel.target}
+        <span className="font-data truncate text-[12px] text-text-2">
+          {maskChannelTarget(channel.target)}
         </span>
-      </div>
-      <span
-        className={clsx(
-          "shrink-0 text-[12px] font-medium",
-          channel.health === "verified" && "text-ok",
-          channel.health === "unverified" && "text-warn",
-          channel.health === "degraded" && "text-crit",
+        {channel.health === "degraded" && channel.failure_note && (
+          <span className="text-[12px] text-crit">{channel.failure_note}</span>
         )}
-      >
-        {channel.health}
-      </span>
+      </div>
       {channel.health === "unverified" && onVerify && (
         <button
           type="button"
           onClick={onVerify}
-          className="shrink-0 text-[12px] font-medium text-brand hover:text-brand-deep"
+          className="mt-0.5 shrink-0 text-[12px] font-medium text-brand hover:text-brand-deep"
         >
           Verify
         </button>
@@ -59,9 +96,9 @@ export function AlertChannelCard({
       {onDelete && (
         <button
           type="button"
-          aria-label={`Delete channel ${channel.target}`}
+          aria-label={`Delete channel ${channel.name ?? channel.target}`}
           onClick={onDelete}
-          className="shrink-0 text-text-2 transition-colors duration-[var(--duration-fast)] hover:text-crit"
+          className="mt-1 shrink-0 text-text-2 transition-colors duration-[var(--duration-fast)] hover:text-crit"
         >
           <Trash2 className="size-3.5" />
         </button>

--- a/web/src/components/ui/AlertFeedRow.test.tsx
+++ b/web/src/components/ui/AlertFeedRow.test.tsx
@@ -21,6 +21,19 @@ describe("AlertFeedRow", () => {
     expect(row).toHaveAttribute("data-unread", "true");
   });
 
+  it("renders the master's single-line construction: dot · chip · title · age", () => {
+    render(<AlertFeedRow event={EVENT} />);
+    const row = screen.getByRole("button");
+    // sev chip + title on ONE line; the message detail rides the tooltip
+    expect(screen.getByText("SEV-1")).toBeInTheDocument();
+    expect(screen.getByText("Checkout p95 latency")).toBeInTheDocument();
+    expect(screen.queryByText(EVENT.message)).toBeNull();
+    expect(row).toHaveAttribute("title", EVENT.message);
+    // relative age, unread dot
+    expect(screen.getByText(/ago$/)).toBeInTheDocument();
+    expect(screen.getByLabelText("unread")).toBeInTheDocument();
+  });
+
   it("renders the resolved tint calm (decided 2026-07-17)", () => {
     render(
       <AlertFeedRow event={{ ...EVENT, sev: "resolved", unread: false }} />,
@@ -28,6 +41,9 @@ describe("AlertFeedRow", () => {
     const row = screen.getByRole("button");
     expect(row).toHaveAttribute("data-sev", "resolved");
     expect(row).not.toHaveAttribute("data-unread");
+    // resolved rows chip OK and drop the unread dot
+    expect(screen.getByText("OK")).toBeInTheDocument();
+    expect(screen.queryByLabelText("unread")).toBeNull();
   });
 });
 

--- a/web/src/components/ui/AlertFeedRow.tsx
+++ b/web/src/components/ui/AlertFeedRow.tsx
@@ -5,32 +5,29 @@ import { clsx } from "clsx";
 import type { ReactNode } from "react";
 import type { AlertEvent } from "@/models";
 
-const MONTHS = [
-  "Jan",
-  "Feb",
-  "Mar",
-  "Apr",
-  "May",
-  "Jun",
-  "Jul",
-  "Aug",
-  "Sep",
-  "Oct",
-  "Nov",
-  "Dec",
-];
-
 /**
- * Feed timestamp — HH:mm for today's events, "MMM d" for older ones (a
- * bare "16:00" on a 4-day-old event read as today; UX walk 2026-07-19).
- * Derived from the ISO string so it renders UTC like every other data
- * surface (the TimeseriesPanel X-10 note), independent of host timezone.
+ * Feed age — relative ("2m ago" / "3h ago" / "2d ago") per the master
+ * (94:1513: dot · SevChip · title · age). Derived from the ISO string,
+ * clock-safe at zero/negative deltas.
  */
-function feedTime(ts: string): string {
-  if (ts.slice(0, 10) === new Date().toISOString().slice(0, 10))
-    return ts.slice(11, 16);
-  return `${MONTHS[Number(ts.slice(5, 7)) - 1]} ${Number(ts.slice(8, 10))}`;
+function feedAge(ts: string, now = Date.now()): string {
+  const min = Math.max(Math.round((now - Date.parse(ts)) / 60_000), 0);
+  if (min < 60) return `${min}m ago`;
+  const h = Math.floor(min / 60);
+  if (h < 24) return `${h}h ago`;
+  return `${Math.floor(h / 24)}d ago`;
 }
+
+/** Tinted mono sev chip (master construction — the feed's chip is the
+ *  tint-bg mono treatment, distinct from the solid banner SevChip). */
+const SEV_CHIP: Record<
+  AlertEvent["sev"],
+  { label: string; className: string }
+> = {
+  sev1: { label: "SEV-1", className: "bg-crit/14 text-crit" },
+  sev2: { label: "SEV-2", className: "bg-warn/14 text-warn" },
+  resolved: { label: "OK", className: "bg-ok/14 text-ok" },
+};
 
 export interface AlertFeedRowProps {
   event: AlertEvent;
@@ -40,58 +37,54 @@ export interface AlertFeedRowProps {
 
 /**
  * AlertFeedRow — §8.2b: sev tint sev1 / sev2 / resolved [Decided 2026-07-17]
- * · unread/read · 300ms slide-in (MI-14).
+ * · unread/read · 300ms slide-in (MI-14). Single-line construction per the
+ * master (94:1513): unread dot · sev chip · title · age; the message detail
+ * stays on the row tooltip.
  */
 export function AlertFeedRow({ event, onClick, className }: AlertFeedRowProps) {
+  const chip = SEV_CHIP[event.sev];
   return (
     <button
       type="button"
       onClick={onClick}
+      title={event.message}
       data-sev={event.sev}
       data-unread={event.unread || undefined}
       className={clsx(
-        "font-ui flex w-full items-center gap-2 border-b border-border px-3 py-2 text-left",
+        "font-ui flex h-8 w-full items-center gap-2 border-b border-border px-3 text-left",
         "transition-colors duration-[var(--duration-fast)] ease-standard hover:bg-bg",
         "animate-[slide-in_var(--duration-slow)_var(--ease-standard)] motion-reduce:animate-none",
         className,
       )}
     >
-      <span
-        aria-hidden="true"
-        className={clsx(
-          "size-2 shrink-0 rounded-full",
-          event.sev === "sev1" && "bg-crit",
-          event.sev === "sev2" && "bg-warn",
-          event.sev === "resolved" && "bg-ok",
+      {/* fixed slot: the brand unread dot; read rows keep the alignment */}
+      <span className="flex size-2 shrink-0 items-center justify-center">
+        {event.unread && (
+          <span aria-label="unread" className="size-2 rounded-full bg-brand" />
         )}
-      />
-      <div className="flex min-w-0 flex-1 flex-col">
-        <span
-          className={clsx(
-            "truncate text-[13px]",
-            event.unread
-              ? "font-semibold text-text"
-              : "font-normal text-text-2",
-          )}
-        >
-          {event.monitor_name}
-        </span>
-        <span className="truncate text-[12px] text-text-2">
-          {event.message}
-        </span>
-      </div>
+      </span>
+      <span
+        className={clsx(
+          "font-data inline-flex h-5 shrink-0 items-center rounded-(--radius) px-1.5 text-[11px] font-medium",
+          chip.className,
+        )}
+      >
+        {chip.label}
+      </span>
+      <span
+        className={clsx(
+          "min-w-0 flex-1 truncate text-[13px]",
+          event.unread ? "font-semibold text-text" : "font-normal text-text-2",
+        )}
+      >
+        {event.monitor_name}
+      </span>
       <time
         dateTime={event.ts}
         className="shrink-0 text-[11px] tabular-nums text-text-2"
       >
-        {feedTime(event.ts)}
+        {feedAge(event.ts)}
       </time>
-      {event.unread && (
-        <span
-          aria-label="unread"
-          className="size-1.5 shrink-0 rounded-full bg-brand"
-        />
-      )}
     </button>
   );
 }

--- a/web/src/components/ui/BrandMark.tsx
+++ b/web/src/components/ui/BrandMark.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { clsx } from "clsx";
+import { Zap } from "lucide-react";
+
+export interface BrandMarkProps {
+  /** Render the lowercase wordmark beside the bolt. */
+  wordmark?: boolean;
+  /** Glyph size class (defaults to size-5). */
+  glyphClassName?: string;
+  className?: string;
+}
+
+/**
+ * BrandMark — the product mark: filled bolt glyph (+ optional lowercase
+ * wordmark). The one brand construction across app chrome, /signin, the
+ * public status page, marketing nav and footer (systemic adjudication
+ * 2026-07-20 — replaces the green "U" tile everywhere in-app; the Figma
+ * canon is the zap + wordmark of frames 124:6 / 132:3530 / 284:2).
+ */
+export function BrandMark({
+  wordmark = false,
+  glyphClassName,
+  className,
+}: BrandMarkProps) {
+  return (
+    <span
+      className={clsx(
+        "font-ui inline-flex items-center gap-2 font-semibold text-text",
+        className,
+      )}
+    >
+      <Zap
+        aria-hidden="true"
+        fill="currentColor"
+        strokeWidth={0}
+        className={clsx("shrink-0 text-brand", glyphClassName ?? "size-5")}
+      />
+      {wordmark && "upstat"}
+    </span>
+  );
+}

--- a/web/src/components/ui/ChartTable.test.tsx
+++ b/web/src/components/ui/ChartTable.test.tsx
@@ -39,8 +39,9 @@ describe("chart data-table toggle (§5)", () => {
     expect(
       screen.getByRole("columnheader", { name: "Time" }),
     ).toBeInTheDocument();
+    // legendLabel trims the shared tag key — the column is the value part
     expect(
-      screen.getByRole("columnheader", { name: "service:web" }),
+      screen.getByRole("columnheader", { name: "web" }),
     ).toBeInTheDocument();
     expect(screen.getByRole("cell", { name: "100" })).toBeInTheDocument();
 

--- a/web/src/components/ui/DashboardListRow.tsx
+++ b/web/src/components/ui/DashboardListRow.tsx
@@ -44,7 +44,8 @@ export function DashboardListRow({
         onClick={() => onFavoriteChange?.(!favorite)}
         className={clsx(
           "transition-colors duration-[var(--duration-fast)]",
-          favorite ? "text-warn" : "text-text-2 hover:text-text",
+          // brand-green favorite star per the frames (125:13 + 126:323)
+          favorite ? "text-brand" : "text-text-2 hover:text-text",
         )}
       >
         <Star className="size-4" fill={favorite ? "currentColor" : "none"} />

--- a/web/src/components/ui/Heatmap.tsx
+++ b/web/src/components/ui/Heatmap.tsx
@@ -26,9 +26,16 @@ export function Heatmap({ columns, rows, values, className }: HeatmapProps) {
   // §5: every chart exposes a data-table alternative — one row per time
   // bucket, one numeric column per value bucket
   const [showTable, setShowTable] = useState(false);
-  // sparse x labels: first / quarter / mid / three-quarter / last
+  // sparse x labels, density-adaptive: up to first / quarter / mid /
+  // three-quarter / last, but never more than the grid width can seat at
+  // mono-11 ("Jun 15" ≈ 40px + breathing room) — narrow grids like the B6
+  // 8-column cohort axis fall back to first + last (label-collision fix)
+  const gridW = columns.length * (CELL + 1);
+  const labelCount = Math.max(2, Math.min(5, Math.floor(gridW / 56)));
   const labelIdx = new Set(
-    [0, 0.25, 0.5, 0.75, 1].map((t) => Math.round(t * (columns.length - 1))),
+    Array.from({ length: labelCount }, (_, i) =>
+      Math.round((i / (labelCount - 1)) * (columns.length - 1)),
+    ),
   );
 
   if (showTable) {

--- a/web/src/components/ui/IncidentBanner.test.tsx
+++ b/web/src/components/ui/IncidentBanner.test.tsx
@@ -13,7 +13,9 @@ describe("IncidentBanner", () => {
       />,
     );
     expect(screen.getByText("SEV-1")).toBeInTheDocument();
-    expect(screen.getByText("3h")).toBeInTheDocument();
+    // master 48:141 affordances: "open Xh" age + explicit link text
+    expect(screen.getByText("open 3h")).toBeInTheDocument();
+    expect(screen.getByText("View incident →")).toBeInTheDocument();
   });
 
   it("renders resolved as transient calm state", () => {
@@ -28,5 +30,9 @@ describe("IncidentBanner", () => {
     );
     expect(screen.getByText("RESOLVED")).toBeInTheDocument();
     expect(screen.queryByText("SEV-1")).toBeNull();
+    // resolved swaps the affordance to the postmortem link
+    expect(screen.getByText("Postmortem →")).toBeInTheDocument();
+    expect(screen.queryByText("View incident →")).toBeNull();
+    expect(screen.getByText("3h")).toBeInTheDocument();
   });
 });

--- a/web/src/components/ui/IncidentBanner.tsx
+++ b/web/src/components/ui/IncidentBanner.tsx
@@ -62,12 +62,11 @@ export function IncidentBanner({
       </span>
       <span className="min-w-0 flex-1" />
       {/* <sm the responder stack yields its width to the title (mobile
-          truncation canon); the age + link affordances stay */}
-      <AvatarStack
-        names={responders}
-        size={20}
-        className="hidden sm:inline-flex"
-      />
+          truncation canon); the age + link affordances stay. Wrapped —
+          the stack's own inline-flex would fight a passed `hidden`. */}
+      <span className="hidden sm:inline-flex">
+        <AvatarStack names={responders} size={20} />
+      </span>
       {/* the whole strip is the button; the link text is the master's
           explicit affordance */}
       <span className="shrink-0 text-[13px] font-medium text-brand">

--- a/web/src/components/ui/IncidentBanner.tsx
+++ b/web/src/components/ui/IncidentBanner.tsx
@@ -16,7 +16,12 @@ export interface IncidentBannerProps {
   className?: string;
 }
 
-/** IncidentBanner — §8.2: sev1 / sev2 (persistent) · resolved (transient). */
+/**
+ * IncidentBanner — §8.2: sev1 / sev2 (persistent) · resolved (transient).
+ * Hybrid adjudication 2026-07-20: the GLOBAL chrome-strip placement stays
+ * (docs §3), with the master's explicit affordances (48:141) — "open 12m"
+ * age copy and the "View incident →" / resolved "Postmortem →" link text.
+ */
 export function IncidentBanner({
   sev,
   title,
@@ -49,13 +54,19 @@ export function IncidentBanner({
       ) : (
         <SevChip sev={sev} />
       )}
-      <span className="min-w-0 flex-1 truncate text-[13px] font-medium text-text">
+      <span className="min-w-0 shrink truncate text-[13px] font-medium text-text">
         {title}
       </span>
       <span className="shrink-0 text-[12px] tabular-nums text-text-2">
-        {age}
+        {resolved ? age : `open ${age}`}
       </span>
+      <span className="min-w-0 flex-1" />
       <AvatarStack names={responders} size={20} />
+      {/* the whole strip is the button; the link text is the master's
+          explicit affordance */}
+      <span className="shrink-0 text-[13px] font-medium text-brand">
+        {resolved ? "Postmortem →" : "View incident →"}
+      </span>
     </button>
   );
 }

--- a/web/src/components/ui/IncidentBanner.tsx
+++ b/web/src/components/ui/IncidentBanner.tsx
@@ -61,7 +61,13 @@ export function IncidentBanner({
         {resolved ? age : `open ${age}`}
       </span>
       <span className="min-w-0 flex-1" />
-      <AvatarStack names={responders} size={20} />
+      {/* <sm the responder stack yields its width to the title (mobile
+          truncation canon); the age + link affordances stay */}
+      <AvatarStack
+        names={responders}
+        size={20}
+        className="hidden sm:inline-flex"
+      />
       {/* the whole strip is the button; the link text is the master's
           explicit affordance */}
       <span className="shrink-0 text-[13px] font-medium text-brand">

--- a/web/src/components/ui/LogLine.test.tsx
+++ b/web/src/components/ui/LogLine.test.tsx
@@ -16,6 +16,14 @@ const LOG: LogEvent = {
 };
 
 describe("LogLine", () => {
+  it("collapsed rows carry the level row tint + left bar (master 47:163)", () => {
+    const { container } = render(<LogLine event={LOG} />);
+    const row = container.querySelector('[data-level="ERROR"]')!;
+    expect(row.className).toContain("bg-crit/8");
+    // the 3px left level bar
+    expect(row.querySelector(".w-\\[3px\\].bg-crit")).not.toBeNull();
+  });
+
   it("expands into the JSON tree (MI-5)", async () => {
     render(<LogLine event={LOG} />);
     expect(screen.queryByText("attrs.env")).toBeNull();

--- a/web/src/components/ui/LogLine.tsx
+++ b/web/src/components/ui/LogLine.tsx
@@ -3,7 +3,7 @@
 import { clsx } from "clsx";
 import { Check, ChevronRight, Copy } from "lucide-react";
 import { useState } from "react";
-import type { LogEvent } from "@/models";
+import type { LogEvent, LogLevel } from "@/models";
 import { LevelChip } from "./LevelChip";
 
 export interface LogLineProps {
@@ -27,6 +27,24 @@ export const LOG_LINE_ROW_PX = 29;
 function formatTs(ts: string): string {
   return ts.slice(11, 23); // HH:MM:SS.mmm
 }
+
+/** Level ×5 full-row tint + 3px left bar (master 47:163; ratified §8.2
+ *  "level ×5 tints") — LevelChip color mapping [Decided 2026-07-16]. */
+const LEVEL_TINT: Record<LogLevel, string> = {
+  ERROR: "bg-crit/8",
+  WARN: "bg-warn/8",
+  INFO: "bg-brand/8",
+  DEBUG: "bg-text-2/8",
+  TRACE: "bg-nodata/8",
+};
+
+const LEVEL_BAR: Record<LogLevel, string> = {
+  ERROR: "bg-crit",
+  WARN: "bg-warn",
+  INFO: "bg-brand",
+  DEBUG: "bg-text-2",
+  TRACE: "bg-nodata",
+};
 
 /** LogLine — §8.2: collapsed / expanded (JSON tree) / level ×5 tints (MI-5). */
 export function LogLine({
@@ -72,10 +90,19 @@ export function LogLine({
       data-level={event.level}
       data-expanded={expanded}
       className={clsx(
-        "font-data border-b border-border text-[13px]",
+        // master 47:163: full-row level tint + 3px left level bar
+        "font-data relative border-b border-border text-[13px]",
+        LEVEL_TINT[event.level],
         className,
       )}
     >
+      <span
+        aria-hidden="true"
+        className={clsx(
+          "absolute inset-y-0 left-0 w-[3px]",
+          LEVEL_BAR[event.level],
+        )}
+      />
       <button
         type="button"
         aria-expanded={expanded}

--- a/web/src/components/ui/MarketingFooter.test.tsx
+++ b/web/src/components/ui/MarketingFooter.test.tsx
@@ -33,7 +33,11 @@ const CANON: Record<string, [string, string][]> = {
 describe("MarketingFooter (parity canon, SKILL.md 2026-07-19)", () => {
   it("renders the brand block and every canonical column link", () => {
     render(<MarketingFooter />);
-    expect(screen.getByText(/MIT licensed/)).toBeInTheDocument();
+    // bolt + lowercase wordmark and the master 290:2 tagline
+    expect(screen.getByText("upstat")).toBeInTheDocument();
+    expect(
+      screen.getByText("All your telemetry. One open platform."),
+    ).toBeInTheDocument();
     for (const [heading, links] of Object.entries(CANON)) {
       const column = screen.getByRole("navigation", { name: heading });
       for (const [label, href] of links) {

--- a/web/src/components/ui/MarketingFooter.tsx
+++ b/web/src/components/ui/MarketingFooter.tsx
@@ -2,6 +2,7 @@
 
 import { clsx } from "clsx";
 import { ShieldCheck } from "lucide-react";
+import { BrandMark } from "./BrandMark";
 
 export interface FooterLink {
   label: string;
@@ -100,17 +101,11 @@ export function MarketingFooter({
       <div className="mx-auto grid max-w-[1152px] grid-cols-2 gap-8 md:grid-cols-5">
         {showBrand && (
           <div className="col-span-2 flex max-w-56 flex-col gap-2 md:col-span-1">
-            <span className="flex items-center gap-2 text-[16px] font-semibold text-text">
-              <span
-                aria-hidden="true"
-                className="flex size-6 items-center justify-center rounded-(--radius) bg-brand text-[12px] font-semibold text-on-brand"
-              >
-                U
-              </span>
-              Upstat
-            </span>
+            {/* bolt + lowercase wordmark and tagline per master 290:2
+                (systemic adjudication 2026-07-20 — "U" tile retired) */}
+            <BrandMark wordmark className="text-[16px]" />
             <span className="text-[12px] leading-[1.45] text-text-2">
-              Open-source observability by CueLABS™. MIT licensed.
+              All your telemetry. One open platform.
             </span>
           </div>
         )}

--- a/web/src/components/ui/MarketingNav.tsx
+++ b/web/src/components/ui/MarketingNav.tsx
@@ -3,7 +3,8 @@
 import { useEffect, useRef, useState } from "react";
 import { clsx } from "clsx";
 import Link from "next/link";
-import { ChevronDown, Menu, Star, X, Zap } from "lucide-react";
+import { ChevronDown, Menu, Star, X } from "lucide-react";
+import { BrandMark } from "./BrandMark";
 import { Button } from "./Button";
 import { MARKETING_PILLARS, pillarAccent } from "./PillarCard";
 import { ThemeToggle } from "./ThemeToggle";
@@ -246,18 +247,10 @@ export function MarketingNav({
         // max-w matches the Section shell (max-w-[1200px] px-6 → 1152 content).
         className="mx-auto flex h-14 w-full max-w-[1200px] items-center gap-3 px-6 md:gap-4"
       >
-        {/* landing v2 brand mark (135:2): filled bolt glyph + lowercase wordmark */}
-        <Link
-          href="/"
-          className="flex items-center gap-2 text-[16px] font-semibold text-text"
-        >
-          <Zap
-            aria-hidden="true"
-            fill="currentColor"
-            strokeWidth={0}
-            className="size-5 text-brand"
-          />
-          upstat
+        {/* landing v2 brand mark (135:2): filled bolt glyph + lowercase
+            wordmark — the shared BrandMark construction */}
+        <Link href="/" className="flex items-center">
+          <BrandMark wordmark className="text-[16px]" />
         </Link>
 
         {NAV_LINKS.map((link) =>

--- a/web/src/components/ui/MonitorRow.tsx
+++ b/web/src/components/ui/MonitorRow.tsx
@@ -17,7 +17,11 @@ export interface MonitorRowProps {
   className?: string;
 }
 
-/** MonitorRow — §3/§8.2: status ×6 · muted toggle on/off. */
+/**
+ * MonitorRow — §3/§8.2: status ×6 · muted toggle on/off. Rows lead with the
+ * FULL labeled StatusPill per the master (dot-only is reserved for the §5
+ * colorblind rendering — adjudicated 2026-07-20).
+ */
 export function MonitorRow({
   status,
   name,
@@ -38,7 +42,7 @@ export function MonitorRow({
         className,
       )}
     >
-      <StatusPill status={status} dotOnly />
+      <StatusPill status={status} className="shrink-0" />
       <button
         type="button"
         onClick={onClick}

--- a/web/src/components/ui/NavRail.test.tsx
+++ b/web/src/components/ui/NavRail.test.tsx
@@ -42,6 +42,19 @@ describe("NavRail", () => {
     expect(NAV_SECTIONS.flatMap((s) => s.keys)).toEqual(
       NAV_PILLARS.map((p) => p.key),
     );
+    // Home AND Dashboards ungrouped above Telemetry (master 284:2,
+    // adjudicated 2026-07-20)
+    expect(NAV_SECTIONS[0].keys).toEqual(["home", "dashboards"]);
+  });
+
+  it("foot renders the chevron square + signed-in avatar (master 284:2)", () => {
+    render(<NavRail activeKey="home" userName="Ibukun Dairo" />);
+    expect(screen.getByTestId("rail-toggle")).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Signed in as Ibukun Dairo"),
+    ).toBeInTheDocument();
+    // the old text foot is gone
+    expect(screen.queryByText("Collapse")).toBeNull();
   });
 
   it("foot toggle expands the rail: aria-expanded, labels + group headers", async () => {

--- a/web/src/components/ui/NavRail.tsx
+++ b/web/src/components/ui/NavRail.tsx
@@ -22,6 +22,7 @@ import * as Dialog from "@radix-ui/react-dialog";
 import { useEffect, useState } from "react";
 import { useMediaQuery } from "@/controllers/use-media-query";
 import { Avatar } from "./Avatar";
+import { BrandMark } from "./BrandMark";
 
 export interface NavRailItemProps {
   icon: LucideIcon;
@@ -215,19 +216,16 @@ function RailBody({
   const byKey = new Map(NAV_PILLARS.map((p) => [p.key, p]));
   return (
     <>
+      {/* head: bolt + wordmark (BrandMark — systemic adjudication
+          2026-07-20; the "U" tile is retired) */}
       <span
         aria-hidden="true"
         className={clsx(
-          "font-ui mb-2 flex h-8 items-center gap-2",
-          expanded ? "px-1" : "justify-center",
+          "font-ui mb-2 flex h-8 items-center",
+          expanded ? "px-1.5" : "justify-center",
         )}
       >
-        <span className="flex size-8 shrink-0 items-center justify-center rounded-(--radius) bg-brand text-[14px] font-semibold text-on-brand">
-          U
-        </span>
-        {expanded && (
-          <span className="text-[14px] font-semibold text-text">upstat</span>
-        )}
+        <BrandMark wordmark={expanded} className="text-[14px]" />
       </span>
 
       {NAV_SECTIONS.map((section) => (

--- a/web/src/components/ui/NavRail.tsx
+++ b/web/src/components/ui/NavRail.tsx
@@ -7,20 +7,21 @@ import {
   BarChart3,
   Bell,
   BookOpen,
-  ChevronsLeft,
-  ChevronsRight,
+  ChevronLeft,
+  ChevronRight,
+  FileText,
   Flame,
-  Gauge,
+  Globe,
   House,
   LayoutDashboard,
-  Radio,
-  ScrollText,
+  Route,
   Settings,
   Target,
 } from "lucide-react";
 import * as Dialog from "@radix-ui/react-dialog";
 import { useEffect, useState } from "react";
 import { useMediaQuery } from "@/controllers/use-media-query";
+import { Avatar } from "./Avatar";
 
 export interface NavRailItemProps {
   icon: LucideIcon;
@@ -93,15 +94,26 @@ export function NavRailItem({
   );
 }
 
-/** The pages.md Part B pillar order. */
+/**
+ * The pages.md Part B pillar order. Icons are the reconciled §8.1 list
+ * (adjudicated 2026-07-20, master 284:2 vs code): the master's glyph wins
+ * where it is in the ratified Stage-0 set (pillar glyphs + extended list) —
+ * bar-chart-3 (metrics), file-text (logs), globe (RUM), activity
+ * (synthetics/uptime), bell, target, house, layout-dashboard, settings;
+ * code's glyph stays where the master's is unratified — flame (incidents;
+ * master's alert-triangle is not in §8.1), book-open (catalog; master's
+ * layers is not in §8.1). Traces takes `route` — the ratified APM/Traces
+ * pillar glyph — because code's activity moved to Synthetics per the
+ * master and the master's git-branch is unratified.
+ */
 export const NAV_PILLARS: { key: string; label: string; icon: LucideIcon }[] = [
   { key: "home", label: "Home", icon: House },
   { key: "dashboards", label: "Dashboards", icon: LayoutDashboard },
-  { key: "metrics", label: "Metrics", icon: Gauge },
-  { key: "logs", label: "Logs", icon: ScrollText },
-  { key: "traces", label: "Traces", icon: Activity },
-  { key: "rum", label: "RUM / Analytics", icon: BarChart3 },
-  { key: "uptime", label: "Synthetics / Uptime", icon: Radio },
+  { key: "metrics", label: "Metrics", icon: BarChart3 },
+  { key: "logs", label: "Logs", icon: FileText },
+  { key: "traces", label: "Traces", icon: Route },
+  { key: "rum", label: "RUM / Analytics", icon: Globe },
+  { key: "uptime", label: "Synthetics / Uptime", icon: Activity },
   { key: "monitors", label: "Monitors", icon: Bell },
   { key: "incidents", label: "Incidents", icon: Flame },
   { key: "slos", label: "SLOs", icon: Target },
@@ -110,15 +122,15 @@ export const NAV_PILLARS: { key: string; label: string; icon: LucideIcon }[] = [
 ];
 
 /**
- * Pillar section groups (design.md §2 Telemetry / Respond / Platform,
- * [Directive 2026-07-19]) — B-order preserved; Home stays ungrouped at
- * the top of the rail.
+ * Pillar section groups (design.md §2 Telemetry / Respond / Platform) —
+ * B-order preserved; Home AND Dashboards ungrouped above TELEMETRY per
+ * the master (284:2, adjudicated 2026-07-20).
  */
 export const NAV_SECTIONS: { title: string | null; keys: string[] }[] = [
-  { title: null, keys: ["home"] },
+  { title: null, keys: ["home", "dashboards"] },
   {
     title: "Telemetry",
-    keys: ["dashboards", "metrics", "logs", "traces", "rum", "uptime"],
+    keys: ["metrics", "logs", "traces", "rum", "uptime"],
   },
   { title: "Respond", keys: ["monitors", "incidents", "slos"] },
   { title: "Platform", keys: ["catalog", "settings"] },
@@ -173,11 +185,14 @@ function useRailExpanded(): [boolean, () => void] {
 export interface NavRailProps {
   activeKey: string;
   onNavigate?: (key: string) => void;
+  /** Signed-in user for the foot avatar (master 284:2 foot construction). */
+  userName?: string | null;
   className?: string;
 }
 
-/** Rail brand mark + section groups + foot toggle (shared by the inline
- *  rail and the <md overlay drawer). */
+/** Rail brand mark + section groups + foot (chevron square toggle + user
+ *  avatar per master 284:2), shared by the inline rail and the <md
+ *  overlay drawer. */
 function RailBody({
   expanded,
   activeKey,
@@ -186,6 +201,7 @@ function RailBody({
   footExpanded,
   footTestId = "rail-toggle",
   onToggle,
+  userName,
 }: {
   expanded: boolean;
   activeKey: string;
@@ -194,6 +210,7 @@ function RailBody({
   footExpanded: boolean;
   footTestId?: string;
   onToggle: () => void;
+  userName?: string | null;
 }) {
   const byKey = new Map(NAV_PILLARS.map((p) => [p.key, p]));
   return (
@@ -248,27 +265,37 @@ function RailBody({
         </div>
       ))}
 
-      <button
-        type="button"
-        data-testid={footTestId}
-        aria-label={footLabel}
-        aria-expanded={footExpanded}
-        onClick={onToggle}
+      {/* foot per master 284:2: bordered chevron square + user avatar
+          (replaces the "« Collapse" text button — adjudicated 2026-07-20) */}
+      <div
         className={clsx(
-          "mt-auto flex h-9 items-center rounded-(--radius) text-text-2",
-          "transition-colors duration-[var(--duration-fast)] ease-standard hover:bg-bg-elev hover:text-text",
-          expanded ? "w-full gap-3 px-2.5" : "size-9 justify-center",
+          "mt-auto flex flex-col gap-2",
+          expanded ? "items-start px-1" : "items-center",
         )}
       >
-        {expanded ? (
-          <>
-            <ChevronsLeft aria-hidden="true" className="size-4.5 shrink-0" />
-            <span className="truncate text-[12px]">Collapse</span>
-          </>
-        ) : (
-          <ChevronsRight aria-hidden="true" className="size-4.5" />
+        <button
+          type="button"
+          data-testid={footTestId}
+          aria-label={footLabel}
+          aria-expanded={footExpanded}
+          onClick={onToggle}
+          className={clsx(
+            "flex size-8 items-center justify-center rounded-(--radius) border border-border text-text-2",
+            "transition-colors duration-[var(--duration-fast)] ease-standard hover:bg-bg-elev hover:text-text",
+          )}
+        >
+          {footExpanded ? (
+            <ChevronLeft aria-hidden="true" className="size-4" />
+          ) : (
+            <ChevronRight aria-hidden="true" className="size-4" />
+          )}
+        </button>
+        {userName && (
+          <span title={userName} aria-label={`Signed in as ${userName}`}>
+            <Avatar name={userName} size={24} />
+          </span>
         )}
-      </button>
+      </div>
     </>
   );
 }
@@ -287,7 +314,12 @@ function RailBody({
  * and item selection close it; focus moves into the drawer and returns
  * to the toggle on close.
  */
-export function NavRail({ activeKey, onNavigate, className }: NavRailProps) {
+export function NavRail({
+  activeKey,
+  onNavigate,
+  userName,
+  className,
+}: NavRailProps) {
   const [expanded, toggleExpanded] = useRailExpanded();
   const isMobile = useMediaQuery("(max-width: 767px)");
   const [drawerOpen, setDrawerOpen] = useState(false);
@@ -323,6 +355,7 @@ export function NavRail({ activeKey, onNavigate, className }: NavRailProps) {
           }
           footExpanded={isMobile ? drawerOpen : inlineExpanded}
           onToggle={() => (isMobile ? setDrawerOpen(true) : toggleExpanded())}
+          userName={userName}
         />
       </nav>
 
@@ -358,6 +391,7 @@ export function NavRail({ activeKey, onNavigate, className }: NavRailProps) {
               footTestId="rail-drawer-close"
               footExpanded
               onToggle={() => setDrawerOpen(false)}
+              userName={userName}
             />
           </Dialog.Content>
         </Dialog.Portal>

--- a/web/src/components/ui/SLOCard.test.tsx
+++ b/web/src/components/ui/SLOCard.test.tsx
@@ -17,6 +17,31 @@ const SLO: Slo = {
 };
 
 describe("SLOCard", () => {
+  it("captions are per-state (master 48:95)", () => {
+    const { rerender } = render(<SLOCard slo={SLO} />);
+    // burning: escalation copy
+    expect(
+      screen.getByText("burn rate 6.2× — page on-call"),
+    ).toBeInTheDocument();
+    // healthy: the budget formula
+    rerender(<SLOCard slo={{ ...SLO, state: "healthy", burn_rate: 0.4 }} />);
+    expect(
+      screen.getByText("error budget 11% left · burn 0.4×"),
+    ).toBeInTheDocument();
+    // exhausted: when the budget hit zero
+    rerender(
+      <SLOCard
+        slo={{
+          ...SLO,
+          state: "exhausted",
+          budget_remaining_pct: 0,
+          exhausted_at: new Date(Date.now() - 3 * 86_400_000).toISOString(),
+        }}
+      />,
+    );
+    expect(screen.getByText("budget exhausted 3d ago")).toBeInTheDocument();
+  });
+
   it("renders the burning state with flame + meter (MI-15)", () => {
     render(<SLOCard slo={SLO} />);
     expect(

--- a/web/src/components/ui/SLOCard.tsx
+++ b/web/src/components/ui/SLOCard.tsx
@@ -9,9 +9,33 @@ export interface SLOCardProps {
   className?: string;
 }
 
+/** "3d" style age for the exhausted caption. */
+function ageOf(iso: string, now = Date.now()): string {
+  const min = Math.max(Math.round((now - Date.parse(iso)) / 60_000), 0);
+  if (min < 60) return `${min}m`;
+  const h = Math.floor(min / 60);
+  if (h < 24) return `${h}h`;
+  return `${Math.floor(h / 24)}d`;
+}
+
+/** Per-state caption per the master (48:95): healthy keeps the budget
+ *  formula; burning leads with the page-on-call escalation; exhausted
+ *  reports when the budget hit zero. */
+function stateCaption(slo: Slo): string {
+  if (slo.state === "burning")
+    return `burn rate ${slo.burn_rate.toFixed(1)}× — page on-call`;
+  if (slo.state === "exhausted")
+    return `budget exhausted${slo.exhausted_at ? ` ${ageOf(slo.exhausted_at)} ago` : ""}`;
+  const budget = Math.max(0, Math.min(100, slo.budget_remaining_pct));
+  return `error budget ${budget.toFixed(0)}% left · burn ${slo.burn_rate.toFixed(1)}×`;
+}
+
 /**
  * SLOCard — §8.2: healthy / burning (flame) / exhausted; error-budget bar
  * depletes right-to-left; burn animates on load (MI-15, reduced-motion safe).
+ * Captions are per-state (master 48:95); the burning icon stays lucide
+ * `flame` — §8.1 ratifies flame for burn-rate (the master's zap is the
+ * design-side fix).
  */
 export function SLOCard({ slo, className }: SLOCardProps) {
   const budget = Math.max(0, Math.min(100, slo.budget_remaining_pct));
@@ -74,10 +98,9 @@ export function SLOCard({ slo, className }: SLOCardProps) {
         />
       </div>
 
-      {/* single meta line (Figma 48:71) */}
+      {/* per-state caption (master 48:95) */}
       <span className="text-[12px] tabular-nums text-text-2">
-        error budget {budget.toFixed(0)}% left · burn {slo.burn_rate.toFixed(1)}
-        ×
+        {stateCaption(slo)}
       </span>
     </div>
   );

--- a/web/src/components/ui/SevChip.tsx
+++ b/web/src/components/ui/SevChip.tsx
@@ -15,7 +15,9 @@ export function SevChip({ sev, className }: SevChipProps) {
     <span
       data-sev={sev}
       className={clsx(
-        "font-ui inline-flex h-5 items-center rounded-(--radius) px-1.5 text-[11px] font-semibold",
+        // never wraps or shrinks — chips stay one line in tight chrome
+        // (390 banner regression fix 2026-07-20)
+        "font-ui inline-flex h-5 shrink-0 items-center whitespace-nowrap rounded-(--radius) px-1.5 text-[11px] font-semibold",
         sev === 1 && "bg-crit text-[#FFFFFF]", // raw white per the §2 on-crit note
         sev === 2 && "bg-warn text-on-brand",
         sev === 3 && "bg-bg-elev text-text-2 border border-border",

--- a/web/src/components/ui/ThemeToggle.tsx
+++ b/web/src/components/ui/ThemeToggle.tsx
@@ -33,7 +33,7 @@ export function themeToggleLabel(preference: ThemePreference): string {
  * light → dark → system with a distinct icon per mode (sun / moon /
  * monitor). Lives in the marketing nav, the dashboard TopBar utility
  * area and Settings; the choice persists via ThemeProvider
- * (`upstat.theme`; key absent = system).
+ * (`upstat.theme`; key absent = dark, the design default).
  */
 export function ThemeToggle({ className }: ThemeToggleProps) {
   const { preference, setPreference } = useTheme();

--- a/web/src/components/ui/TimePicker.test.tsx
+++ b/web/src/components/ui/TimePicker.test.tsx
@@ -17,7 +17,8 @@ describe("TimePicker", () => {
     );
     await userEvent.click(screen.getByRole("button", { name: "4h" }));
     expect(onChange).toHaveBeenCalledWith("4h");
-    await userEvent.click(screen.getByRole("button", { name: /live/ }));
+    // master casing: the live toggle reads "LIVE"
+    await userEvent.click(screen.getByRole("button", { name: "LIVE" }));
     expect(onLive).toHaveBeenCalledWith(true);
   });
 

--- a/web/src/components/ui/TimePicker.tsx
+++ b/web/src/components/ui/TimePicker.tsx
@@ -81,8 +81,10 @@ export function TimePicker({
               : "text-text-2 hover:text-text",
           )}
         >
-          <Calendar aria-hidden="true" className="size-3.5" />
-          <span className="hidden md:inline">custom</span>
+          {/* the calendar glyph is the <md collapse affordance; desktop is
+              the master's text-only "Custom" */}
+          <Calendar aria-hidden="true" className="size-3.5 md:hidden" />
+          <span className="hidden md:inline">Custom</span>
         </button>
         {customOpen && (
           <div
@@ -130,7 +132,7 @@ export function TimePicker({
                 : "bg-text-2",
             )}
           />
-          live
+          LIVE
         </button>
       )}
     </div>

--- a/web/src/components/ui/TimeseriesPanel.test.tsx
+++ b/web/src/components/ui/TimeseriesPanel.test.tsx
@@ -30,6 +30,26 @@ describe("TimeseriesPanel", () => {
     expect(legend).toHaveAttribute("aria-pressed", "false");
   });
 
+  it("crosshair renders the floating timestamp-led tooltip (master 50:407)", () => {
+    const { container } = render(
+      <TimeseriesPanel title="t" unit="ms" series={SERIES} cursor={0} />,
+    );
+    const tooltip = screen.getByTestId("crosshair-tooltip");
+    // led by the hh:mm:ss timestamp of the hovered bucket
+    expect(tooltip).toHaveTextContent(SERIES[0].points[0].ts.slice(11, 19));
+    // values carry the unit suffix
+    expect(tooltip).toHaveTextContent("100 ms");
+    // the tooltip floats INSIDE the plot wrapper, not below it
+    expect(tooltip.parentElement!.querySelector("svg")).not.toBeNull();
+    // four y ticks with the unit suffix, zero rendered bare
+    const labels = Array.from(container.querySelectorAll("svg g text")).map(
+      (t) => t.textContent,
+    );
+    expect(labels).toHaveLength(4);
+    expect(labels).toContain("0");
+    expect(labels.filter((l) => l?.endsWith(" ms"))).toHaveLength(3);
+  });
+
   it("shows axis-first loading and radar empty states (MI-16)", () => {
     const { container, rerender } = render(
       <TimeseriesPanel title="t" series={[]} loading />,
@@ -57,8 +77,10 @@ describe("TimeseriesPanel", () => {
     }));
     render(<TimeseriesPanel title="t" series={grouped} />);
     // right-truncating the full names rendered N identical legend entries;
-    // the discriminating suffix is the label, the full name is the tooltip
-    const label = screen.getByText("service:api-common");
+    // the discriminating suffix is the label — with the shared `service:`
+    // key trimmed off (master 50:407 legends carry values only) — and the
+    // full name is the tooltip
+    const label = screen.getByText("api-common");
     expect(label).toBeInTheDocument();
     expect(label.closest("button")).toHaveAttribute(
       "title",

--- a/web/src/components/ui/TimeseriesPanel.tsx
+++ b/web/src/components/ui/TimeseriesPanel.tsx
@@ -25,6 +25,11 @@ export interface TimeseriesPanelProps {
   titleAs?: "h2" | "h3" | "h4" | "p";
   /** Query chip text (mono). */
   query?: string;
+  /**
+   * Value unit suffix for axis labels + crosshair tooltip ("ms", "%").
+   * Per the master (50:407) the zero tick renders bare ("0", no unit).
+   */
+  unit?: string;
   series: Series[];
   mode?: TimeseriesMode;
   withLegend?: boolean;
@@ -50,7 +55,8 @@ export interface TimeseriesPanelProps {
 }
 
 const PLOT_W = 600;
-const PAD_L = 44;
+// 52px y gutter: fits unit-suffixed tick labels ("520 ms") at mono-11
+const PAD_L = 52;
 const PAD_B = 18;
 const PAD_T = 6;
 
@@ -60,6 +66,8 @@ function seriesColor(i: number): string {
 
 function formatValue(v: number): string {
   if (Math.abs(v) >= 1000) return `${(v / 1000).toFixed(1)}k`;
+  // ≥100 the fractional digit is axis noise ("520 ms", not "520.2 ms")
+  if (Math.abs(v) >= 100) return String(Math.round(v));
   return v % 1 === 0 ? String(v) : v.toFixed(1);
 }
 
@@ -68,16 +76,26 @@ function formatTime(ts: string): string {
   return ts.slice(11, 16);
 }
 
+function formatTimeSeconds(ts: string): string {
+  // hh:mm:ss for the crosshair tooltip header (master 50:407: "14:32:00").
+  return ts.slice(11, 19);
+}
+
 /**
  * Legend label — the DISTINGUISHING part of a series name. Grouped query
  * names ("p95(http.request.duration_ms) service:api-common") all share the
  * fn(metric) prefix; truncating from the right rendered eight identical
- * legend entries (system-QA finding 2026-07-19). Prefer the tag suffix;
- * the full name stays on the title tooltip.
+ * legend entries (system-QA finding 2026-07-19). Prefer the tag suffix,
+ * and trim a lone shared `key:` prefix off the tag pair — by-<tag> groups
+ * read "api-common", not "service:api-common". The full name stays on the
+ * title tooltip.
  */
 function legendLabel(name: string): string {
   const idx = name.indexOf(") ");
-  return idx === -1 ? name : name.slice(idx + 2);
+  const suffix = idx === -1 ? name : name.slice(idx + 2);
+  // a single key:value tag pair → the value is the distinguishing part
+  const pair = /^[\w.]+:(\S+)$/.exec(suffix);
+  return pair ? pair[1] : suffix;
 }
 
 /**
@@ -90,6 +108,7 @@ export function TimeseriesPanel({
   title,
   titleAs: TitleTag = "h3",
   query,
+  unit,
   series,
   mode = "line",
   withLegend = true,
@@ -274,221 +293,252 @@ export function TimeseriesPanel({
           className="border-0 bg-transparent p-0"
         />
       ) : (
-        <svg
-          ref={svgRef}
-          viewBox={`0 0 ${PLOT_W} ${plotH}`}
-          role="img"
-          aria-label={`${title} chart`}
-          // min-w-0: the viewBox's intrinsic 600px must not set the panel's
-          // min-content width (375w home); rendering at fixed widths unchanged
-          className="w-full min-w-0"
-          style={{ height: plotH }}
-          onMouseMove={handleMove}
-          onMouseLeave={handleLeave}
-          onMouseDown={handleDown}
-          onMouseUp={handleUp}
-          onDoubleClick={onZoomReset}
-          data-testid="timeseries-plot"
-        >
-          {/* y grid + axis labels (11px, §2 ramp) */}
-          {[0, 0.5, 1].map((t) => {
-            const v = min + (max - min) * t;
-            return (
-              <g key={t}>
-                <line
-                  x1={PAD_L}
-                  x2={PLOT_W - 8}
-                  y1={y(v)}
-                  y2={y(v)}
-                  stroke="var(--color-border)"
-                  strokeWidth={1}
-                />
-                <text
-                  x={PAD_L - 6}
-                  y={y(v) + 3}
-                  textAnchor="end"
-                  fontSize={11}
-                  fill="var(--color-text-2)"
-                  className="font-data tabular-nums"
-                >
-                  {formatValue(v)}
-                </text>
-              </g>
-            );
-          })}
-
-          {/* x-axis time labels (mono 11, §2 ramp — Figma 50:100) */}
-          {visible[0] &&
-            [0, 0.25, 0.5, 0.75, 1].map((t) => {
-              const pts = visible[0].points;
-              const idx = Math.round(t * (pts.length - 1));
-              const ts = pts[idx]?.ts;
-              if (!ts) return null;
+        <div className="relative min-w-0">
+          <svg
+            ref={svgRef}
+            viewBox={`0 0 ${PLOT_W} ${plotH}`}
+            role="img"
+            aria-label={`${title} chart`}
+            // min-w-0: the viewBox's intrinsic 600px must not set the panel's
+            // min-content width (375w home); rendering at fixed widths unchanged
+            className="w-full min-w-0"
+            style={{ height: plotH }}
+            onMouseMove={handleMove}
+            onMouseLeave={handleLeave}
+            onMouseDown={handleDown}
+            onMouseUp={handleUp}
+            onDoubleClick={onZoomReset}
+            data-testid="timeseries-plot"
+          >
+            {/* y grid + axis labels (11px, §2 ramp) — FOUR ticks with the
+              zero baseline, unit-suffixed except the bare "0" (master
+              50:407: "600 ms / 400 ms / 200 ms / 0") */}
+            {[0, 1 / 3, 2 / 3, 1].map((t) => {
+              const v = min + (max - min) * t;
               return (
-                <text
-                  key={`x${t}`}
-                  x={PAD_L + t * innerW}
-                  y={plotH - 4}
-                  textAnchor={t === 0 ? "start" : t === 1 ? "end" : "middle"}
-                  fontSize={11}
-                  fill="var(--color-text-2)"
-                  className="font-data tabular-nums"
-                >
-                  {formatTime(ts)}
-                </text>
+                <g key={t}>
+                  <line
+                    x1={PAD_L}
+                    x2={PLOT_W - 8}
+                    y1={y(v)}
+                    y2={y(v)}
+                    stroke="var(--color-border)"
+                    strokeWidth={1}
+                  />
+                  <text
+                    x={PAD_L - 6}
+                    y={y(v) + 3}
+                    textAnchor="end"
+                    fontSize={11}
+                    fill="var(--color-text-2)"
+                    className="font-data tabular-nums"
+                  >
+                    {v === 0 || !unit
+                      ? formatValue(v)
+                      : `${formatValue(v)} ${unit}`}
+                  </text>
+                </g>
               );
             })}
 
-          {/* §5 colorblind mode: per-series hatch patterns for bar fills —
-              angle/pitch vary by index, index 0 stays solid */}
-          {patterns && mode === "bars" && (
-            <defs>
-              {series.map((s, i) => (
-                <pattern
-                  key={s.name}
-                  id={barPatternId(i)}
-                  width={5}
-                  height={5}
-                  patternUnits="userSpaceOnUse"
-                  patternTransform={`rotate(${[0, 45, 135, 90, 25, 115, 65, 155][i % 8]})`}
-                >
-                  <rect width={5} height={5} fill={seriesColor(i)} />
-                  {i % 8 !== 0 && (
-                    <line
-                      x1={0}
-                      y1={0}
-                      x2={0}
-                      y2={5}
-                      stroke="var(--color-bg-elev)"
-                      strokeWidth={1.75}
-                    />
-                  )}
-                </pattern>
-              ))}
-            </defs>
-          )}
+            {/* x-axis time labels (mono 11, §2 ramp — Figma 50:100) */}
+            {visible[0] &&
+              [0, 0.25, 0.5, 0.75, 1].map((t) => {
+                const pts = visible[0].points;
+                const idx = Math.round(t * (pts.length - 1));
+                const ts = pts[idx]?.ts;
+                if (!ts) return null;
+                return (
+                  <text
+                    key={`x${t}`}
+                    x={PAD_L + t * innerW}
+                    y={plotH - 4}
+                    textAnchor={t === 0 ? "start" : t === 1 ? "end" : "middle"}
+                    fontSize={11}
+                    fill="var(--color-text-2)"
+                    className="font-data tabular-nums"
+                  >
+                    {formatTime(ts)}
+                  </text>
+                );
+              })}
 
-          {/* series */}
-          {visible.map((s, si) => {
-            const pts = s.points;
-            const color = seriesColor(series.indexOf(s));
-            if (mode === "bars") {
-              const bw = Math.max((innerW / Math.max(pts.length, 1)) * 0.7, 1);
-              const fill = patterns
-                ? `url(#${barPatternId(series.indexOf(s))})`
-                : color;
+            {/* §5 colorblind mode: per-series hatch patterns for bar fills —
+              angle/pitch vary by index, index 0 stays solid */}
+            {patterns && mode === "bars" && (
+              <defs>
+                {series.map((s, i) => (
+                  <pattern
+                    key={s.name}
+                    id={barPatternId(i)}
+                    width={5}
+                    height={5}
+                    patternUnits="userSpaceOnUse"
+                    patternTransform={`rotate(${[0, 45, 135, 90, 25, 115, 65, 155][i % 8]})`}
+                  >
+                    <rect width={5} height={5} fill={seriesColor(i)} />
+                    {i % 8 !== 0 && (
+                      <line
+                        x1={0}
+                        y1={0}
+                        x2={0}
+                        y2={5}
+                        stroke="var(--color-bg-elev)"
+                        strokeWidth={1.75}
+                      />
+                    )}
+                  </pattern>
+                ))}
+              </defs>
+            )}
+
+            {/* series */}
+            {visible.map((s, si) => {
+              const pts = s.points;
+              const color = seriesColor(series.indexOf(s));
+              if (mode === "bars") {
+                const bw = Math.max(
+                  (innerW / Math.max(pts.length, 1)) * 0.7,
+                  1,
+                );
+                const fill = patterns
+                  ? `url(#${barPatternId(series.indexOf(s))})`
+                  : color;
+                return (
+                  <g key={s.name}>
+                    {pts.map((p, i) =>
+                      p.value === null ? null : (
+                        <rect
+                          key={i}
+                          x={x(i, pts.length) - bw / 2}
+                          y={y(p.value)}
+                          width={bw}
+                          height={Math.max(PAD_T + innerH - y(p.value), 0)}
+                          fill={fill}
+                          opacity={0.85}
+                        />
+                      ),
+                    )}
+                  </g>
+                );
+              }
+              const path = pts
+                .map((p, i) =>
+                  p.value === null
+                    ? null
+                    : `${i === 0 || pts[i - 1]?.value === null ? "M" : "L"}${x(i, pts.length)},${y(p.value)}`,
+                )
+                .filter(Boolean)
+                .join(" ");
               return (
                 <g key={s.name}>
-                  {pts.map((p, i) =>
-                    p.value === null ? null : (
-                      <rect
-                        key={i}
-                        x={x(i, pts.length) - bw / 2}
-                        y={y(p.value)}
-                        width={bw}
-                        height={Math.max(PAD_T + innerH - y(p.value), 0)}
-                        fill={fill}
-                        opacity={0.85}
-                      />
-                    ),
+                  {mode === "area" && (
+                    <path
+                      d={`${path} L${x(pts.length - 1, pts.length)},${PAD_T + innerH} L${x(0, pts.length)},${PAD_T + innerH} Z`}
+                      fill={color}
+                      opacity={0.15}
+                    />
+                  )}
+                  <path
+                    d={path}
+                    fill="none"
+                    stroke={color}
+                    strokeWidth={1.5}
+                    // §5 colorblind mode: series-index dash arrays (first
+                    // series stays solid)
+                    strokeDasharray={
+                      patterns
+                        ? seriesDash(series.indexOf(s)) || undefined
+                        : undefined
+                    }
+                  />
+                  {/* crosshair value dots (MI-2) */}
+                  {cursorIndex !== null && pts[cursorIndex]?.value !== null && (
+                    <circle
+                      cx={x(cursorIndex, pts.length)}
+                      cy={y(pts[cursorIndex].value!)}
+                      r={2.5}
+                      fill={color}
+                    />
+                  )}
+                  {si === 0 && cursorIndex !== null && (
+                    <line
+                      x1={x(cursorIndex, pts.length)}
+                      x2={x(cursorIndex, pts.length)}
+                      y1={PAD_T}
+                      y2={PAD_T + innerH}
+                      stroke="var(--color-text-2)"
+                      strokeWidth={1}
+                      strokeDasharray="2 2"
+                    />
                   )}
                 </g>
               );
-            }
-            const path = pts
-              .map((p, i) =>
-                p.value === null
-                  ? null
-                  : `${i === 0 || pts[i - 1]?.value === null ? "M" : "L"}${x(i, pts.length)},${y(p.value)}`,
-              )
-              .filter(Boolean)
-              .join(" ");
-            return (
-              <g key={s.name}>
-                {mode === "area" && (
-                  <path
-                    d={`${path} L${x(pts.length - 1, pts.length)},${PAD_T + innerH} L${x(0, pts.length)},${PAD_T + innerH} Z`}
-                    fill={color}
-                    opacity={0.15}
-                  />
-                )}
-                <path
-                  d={path}
-                  fill="none"
-                  stroke={color}
-                  strokeWidth={1.5}
-                  // §5 colorblind mode: series-index dash arrays (first
-                  // series stays solid)
-                  strokeDasharray={
-                    patterns
-                      ? seriesDash(series.indexOf(s)) || undefined
-                      : undefined
-                  }
-                />
-                {/* crosshair value dots (MI-2) */}
-                {cursorIndex !== null && pts[cursorIndex]?.value !== null && (
-                  <circle
-                    cx={x(cursorIndex, pts.length)}
-                    cy={y(pts[cursorIndex].value!)}
-                    r={2.5}
-                    fill={color}
-                  />
-                )}
-                {si === 0 && cursorIndex !== null && (
-                  <line
-                    x1={x(cursorIndex, pts.length)}
-                    x2={x(cursorIndex, pts.length)}
-                    y1={PAD_T}
-                    y2={PAD_T + innerH}
-                    stroke="var(--color-text-2)"
-                    strokeWidth={1}
-                    strokeDasharray="2 2"
-                  />
-                )}
-              </g>
-            );
-          })}
+            })}
 
-          {/* MI-3 drag-to-zoom selection region */}
-          {drag && Math.abs(drag.to - drag.from) > 0 && (
-            <rect
-              x={PAD_L + Math.min(drag.from, drag.to) * innerW}
-              y={PAD_T}
-              width={Math.abs(drag.to - drag.from) * innerW}
-              height={innerH}
-              fill="var(--color-brand)"
-              opacity={0.12}
-              stroke="var(--color-brand)"
-              strokeWidth={1}
-              data-testid="zoom-selection"
-            />
-          )}
-        </svg>
-      )}
-
-      {/* crosshair tooltip values */}
-      {!loading && !empty && !showTable && cursorIndex !== null && (
-        <div className="font-data flex flex-wrap gap-x-4 gap-y-0.5 text-[11px] tabular-nums text-text-2">
-          {visible.map((s) => (
-            <span
-              key={s.name}
-              className="inline-flex items-center gap-1"
-              title={s.name}
-            >
-              <span
-                className="size-1.5 rounded-full"
-                style={{ background: seriesColor(series.indexOf(s)) }}
+            {/* MI-3 drag-to-zoom selection region */}
+            {drag && Math.abs(drag.to - drag.from) > 0 && (
+              <rect
+                x={PAD_L + Math.min(drag.from, drag.to) * innerW}
+                y={PAD_T}
+                width={Math.abs(drag.to - drag.from) * innerW}
+                height={innerH}
+                fill="var(--color-brand)"
+                opacity={0.12}
+                stroke="var(--color-brand)"
+                strokeWidth={1}
+                data-testid="zoom-selection"
               />
-              {/* MI-2 "per-series values" — a bare number row wasn't
-                  attributable to a series; carry the short label */}
-              {visible.length > 1 && (
-                <span className="max-w-32 truncate">{legendLabel(s.name)}</span>
+            )}
+          </svg>
+
+          {/* crosshair tooltip — FLOATING at the crosshair inside the plot,
+            led by the timestamp (master 50:407 crosshair variant:
+            "14:32:00 · p50 84 ms · …"); flips sides past plot center so
+            it never leaves the panel */}
+          {cursorIndex !== null && visible[0]?.points[cursorIndex] && (
+            <div
+              data-testid="crosshair-tooltip"
+              className={clsx(
+                "font-data pointer-events-none absolute top-2 z-10 flex flex-col gap-0.5",
+                "rounded-(--radius) border border-border bg-bg-elev/95 px-2 py-1.5 text-[11px] tabular-nums shadow-lg",
               )}
-              {s.points[cursorIndex]?.value === null
-                ? "—"
-                : formatValue(s.points[cursorIndex]?.value ?? 0)}
-            </span>
-          ))}
+              style={{
+                left: `${((PAD_L + (cursorIndex / Math.max(n - 1, 1)) * innerW) / PLOT_W) * 100}%`,
+                transform:
+                  cursorIndex / Math.max(n - 1, 1) > 0.55
+                    ? "translateX(calc(-100% - 8px))"
+                    : "translateX(8px)",
+              }}
+            >
+              <span className="text-text-2">
+                {formatTimeSeconds(visible[0].points[cursorIndex].ts)}
+              </span>
+              {visible.map((s) => (
+                <span
+                  key={s.name}
+                  className="inline-flex items-center gap-1.5 whitespace-nowrap text-text"
+                  title={s.name}
+                >
+                  <span
+                    aria-hidden="true"
+                    className="size-1.5 shrink-0 rounded-full"
+                    style={{ background: seriesColor(series.indexOf(s)) }}
+                  />
+                  {/* MI-2 "per-series values" — a bare number row wasn't
+                    attributable to a series; carry the short label */}
+                  {visible.length > 1 && (
+                    <span className="max-w-32 truncate text-text-2">
+                      {legendLabel(s.name)}
+                    </span>
+                  )}
+                  {s.points[cursorIndex]?.value === null
+                    ? "—"
+                    : `${formatValue(s.points[cursorIndex]?.value ?? 0)}${unit ? ` ${unit}` : ""}`}
+                </span>
+              ))}
+            </div>
+          )}
         </div>
       )}
 

--- a/web/src/components/ui/TopBar.test.tsx
+++ b/web/src/components/ui/TopBar.test.tsx
@@ -14,7 +14,7 @@ describe("TopBar", () => {
   it("carries org switcher, search hint and unread bell (MI-14)", () => {
     renderBar({ orgName: "Upstat", unreadCount: 3 });
     expect(screen.getByText("Upstat")).toBeInTheDocument();
-    expect(screen.getByText("Search…")).toBeInTheDocument();
+    expect(screen.getByText("Search")).toBeInTheDocument();
     expect(
       screen.getByLabelText("Notifications (3 unread)"),
     ).toBeInTheDocument();

--- a/web/src/components/ui/TopBar.tsx
+++ b/web/src/components/ui/TopBar.tsx
@@ -46,7 +46,7 @@ export function TopBar({
   return (
     <header
       className={clsx(
-        "font-ui sticky top-0 z-[var(--z-sticky)] flex h-12 items-center gap-1.5 md:gap-3",
+        "font-ui sticky top-0 z-[var(--z-sticky)] flex h-[43px] items-center gap-1.5 md:gap-3",
         "border-b border-border bg-bg px-3",
         className,
       )}
@@ -58,7 +58,7 @@ export function TopBar({
         className="flex min-w-0 items-center gap-1.5 rounded-(--radius) px-2 py-1 text-[13px] font-medium text-text transition-colors duration-[var(--duration-fast)] hover:bg-bg-elev"
       >
         <span className="max-w-[96px] truncate md:max-w-none">{orgName}</span>
-        <span className="hidden rounded-(--radius) border border-border px-1 text-[10px] uppercase tracking-wide text-text-2 md:inline-block">
+        <span className="hidden rounded-(--radius) border border-border px-1 text-[10px] tracking-wide text-text-2 md:inline-block">
           {env}
         </span>
         <ChevronDown
@@ -78,7 +78,7 @@ export function TopBar({
         className="flex h-8 w-8 items-center justify-center gap-2 rounded-(--radius) border border-border bg-bg-elev text-[13px] text-text-2 transition-colors duration-[var(--duration-fast)] hover:border-text-2 md:w-56 md:justify-start md:px-2"
       >
         <Search aria-hidden="true" className="size-3.5 shrink-0" />
-        <span className="hidden flex-1 text-left md:block">Search…</span>
+        <span className="hidden flex-1 text-left md:block">Search</span>
         <span className="hidden md:inline-flex">
           <KbdChip keys="/" />
         </span>

--- a/web/src/components/ui/TopList.tsx
+++ b/web/src/components/ui/TopList.tsx
@@ -45,9 +45,10 @@ export function TopList({ entries, loading = false, className }: TopListProps) {
           <span className="w-36 truncate text-[12px] text-text">
             {entry.label}
           </span>
-          <span className="relative h-3.5 flex-1 overflow-hidden rounded-[1px] bg-bg">
+          {/* master 70:599: bare bars — no background track; r=2 corners */}
+          <span className="relative h-3.5 flex-1 overflow-hidden rounded-[2px]">
             <span
-              className="absolute inset-y-0 left-0 rounded-[1px]"
+              className="absolute inset-y-0 left-0 rounded-[2px]"
               style={{
                 width: `${(entry.value / max) * 100}%`,
                 ...(patterns

--- a/web/src/components/ui/UsageMeterRow.tsx
+++ b/web/src/components/ui/UsageMeterRow.tsx
@@ -23,7 +23,8 @@ export function UsageMeterRow({ meter, className }: UsageMeterRowProps) {
       data-pillar={meter.pillar}
       className={clsx(
         "font-ui flex flex-col gap-3 rounded-(--radius) border border-border bg-bg-elev px-4 py-4",
-        "sm:h-[72px] sm:flex-row sm:items-center sm:gap-4 sm:py-0",
+        // 64px row per the master (B12 usage frame 334:14499)
+        "sm:h-16 sm:flex-row sm:items-center sm:gap-4 sm:py-0",
         className,
       )}
     >
@@ -46,7 +47,8 @@ export function UsageMeterRow({ meter, className }: UsageMeterRowProps) {
           style={{ width: `${Math.max(pct, 1)}%` }}
         />
       </span>
-      <span className="shrink-0 text-[12px] text-text-2 sm:w-64 sm:text-right">
+      {/* single line at desktop widths (1440 QA — the fixed w-64 wrapped) */}
+      <span className="shrink-0 text-[12px] text-text-2 sm:whitespace-nowrap sm:text-right">
         {meter.plan}
       </span>
     </div>

--- a/web/src/controllers/shell.ts
+++ b/web/src/controllers/shell.ts
@@ -7,7 +7,8 @@
  */
 
 import { useRouter } from "next/navigation";
-import { useCallback } from "react";
+import { useCallback, useEffect, useState } from "react";
+import { getAuthProvider } from "@/auth";
 import type { Incident } from "@/models";
 import { alertsRepo, incidentsRepo, orgsRepo } from "@/models/repositories";
 import { useRequest } from "./use-request";
@@ -18,6 +19,24 @@ export function ageLabel(iso: string, now = Date.now()): string {
   const h = Math.floor(min / 60);
   if (h < 24) return `${h}h`;
   return `${Math.floor(h / 24)}d`;
+}
+
+/**
+ * Signed-in user's display name for the rail-foot avatar (NavRail master
+ * foot construction). Resolved post-mount — the session lives in browser
+ * storage, so SSR/hydration must render without it (NavRail pattern).
+ */
+export function useCurrentUserName(): string | null {
+  const [name, setName] = useState<string | null>(null);
+  // Deferred a tick (use-request pattern): setState stays out of the
+  // synchronous effect body.
+  useEffect(() => {
+    const t = window.setTimeout(() => {
+      setName(getAuthProvider().currentUser()?.name ?? null);
+    }, 0);
+    return () => window.clearTimeout(t);
+  }, []);
+  return name;
 }
 
 export function useShellController() {

--- a/web/src/controllers/synthetics.ts
+++ b/web/src/controllers/synthetics.ts
@@ -63,7 +63,11 @@ export function useSyntheticCheckController(id: string | null) {
 /**
  * Run view read model — the check, its run list (newest first) and the
  * selected run (`runId` from the URL; latest when absent). Deep-linkable
- * state rides the query string per the §4 route-map rule.
+ * state rides the query string per the §4 route-map rule. `?run=` accepts
+ * the internal id (synrun_0007) OR the visible run number ("482" / "#482")
+ * — the frame addresses runs by number; a value that matches neither
+ * reports `notFound` so the page never claims "No runs yet" while runs
+ * exist (audit fix 2026-07-20).
  */
 export function useSyntheticRunController(
   checkId: string,
@@ -71,11 +75,15 @@ export function useSyntheticRunController(
 ) {
   const check = useRequest(() => syntheticsRepo.get(checkId), [checkId]);
   const runs = useRequest(() => syntheticsRepo.runs(checkId), [checkId]);
-  const selected =
-    (runId
-      ? (runs.data ?? []).find((r) => r.id === runId)
-      : (runs.data ?? [])[0]) ?? null;
-  return { check, runs, selected };
+  const list = runs.data ?? [];
+  const selected = runId
+    ? (list.find((r) => r.id === runId) ??
+      list.find((r) => String(r.number) === runId.replace(/^#/, "")) ??
+      null)
+    : (list[0] ?? null);
+  const notFound =
+    runId !== null && !runs.loading && list.length > 0 && selected === null;
+  return { check, runs, selected, notFound };
 }
 
 /**

--- a/web/src/design/ThemeProvider.tsx
+++ b/web/src/design/ThemeProvider.tsx
@@ -6,8 +6,8 @@
  * expendit and upstat):
  *
  * - `preference` is what the user chose; persisted at `upstat.theme`
- *   ("light"/"dark" stored explicitly; KEY ABSENT = system — the
- *   cross-product storage convention).
+ *   ("light"/"dark"/"system" stored explicitly; KEY ABSENT = dark, the
+ *   design default — per e43f01c and the cross-product theme contract).
  * - `data-theme` on <html> always carries the RESOLVED theme ("light" or
  *   "dark"): explicit preferences resolve to themselves; system resolves
  *   via `prefers-color-scheme` and tracks it LIVE (matchMedia listener —

--- a/web/src/mocks/seed.ts
+++ b/web/src/mocks/seed.ts
@@ -737,6 +737,7 @@ export function buildSeed(now: number): MockDb {
       budget_remaining_pct: 0,
       burn_rate: 2.8,
       state: "exhausted",
+      exhausted_at: iso(now - 3 * DAY),
     },
   ];
 

--- a/web/src/mocks/seed.ts
+++ b/web/src/mocks/seed.ts
@@ -369,10 +369,12 @@ export function buildSeed(now: number): MockDb {
     },
   ];
 
+  // friendly names lead the AlertChannelCard per the master anatomy
   const channels: AlertChannel[] = [
     {
       id: "ch_email",
       kind: "email",
+      name: "On-call email",
       target: "ops@cuesoft.io",
       health: "verified",
       created_at: iso(now - 100 * DAY),
@@ -380,6 +382,7 @@ export function buildSeed(now: number): MockDb {
     {
       id: "ch_slack",
       kind: "webhook",
+      name: "Slack #incidents webhook",
       target: "https://hooks.slack.com/services/T0UPSTAT/B0ALERTS/xxxx",
       health: "verified",
       created_at: iso(now - 90 * DAY),
@@ -387,6 +390,7 @@ export function buildSeed(now: number): MockDb {
     {
       id: "ch_pager",
       kind: "webhook",
+      name: "Ops pager webhook",
       target: "https://ops.cuesoft.io/hooks/upstat",
       health: "unverified",
       created_at: iso(now - 2 * DAY),

--- a/web/src/mocks/usage.test.ts
+++ b/web/src/mocks/usage.test.ts
@@ -70,6 +70,11 @@ describe("buildUsageReport (honest sums from the seed)", () => {
     // the derivation produced a plausibly large, peak-bounded figure
     expect(traces.value).toBeGreaterThan(1_000_000);
     expect(traces.value).toBeLessThanOrEqual(traces.peak);
+    // compact units promote past 1000M ("5.6B", never "5551.4M")
+    expect(traces.display).not.toMatch(/\d{4,}(\.\d+)?M$/);
+    if (traces.value >= 1_000_000_000) {
+      expect(traces.display).toMatch(/B$/);
+    }
   });
 
   it("every row carries the verbatim plan copy and a usable bar scale", () => {

--- a/web/src/mocks/usage.ts
+++ b/web/src/mocks/usage.ts
@@ -107,6 +107,8 @@ function integratedRequests(db: MockDb, fromMs: number, toMs: number): number {
 }
 
 function fmtCount(n: number): string {
+  // promote past 1000M — "5.6B", never "5551.4M" (compact-unit canon)
+  if (n >= 1_000_000_000) return `${(n / 1_000_000_000).toFixed(1)}B`;
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
   if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
   return String(Math.round(n));

--- a/web/src/models/alerts.ts
+++ b/web/src/models/alerts.ts
@@ -10,9 +10,15 @@ export type ChannelHealth = "unverified" | "verified" | "degraded";
 export interface AlertChannel {
   id: string;
   kind: ChannelKind;
+  /** Friendly display name ("Slack #incidents webhook") — the card's lead
+   *  line per the AlertChannelCard master; falls back to the kind label. */
+  name?: string;
   /** email address or webhook URL (display form). */
   target: string;
   health: ChannelHealth;
+  /** Degraded-state caption ("Last delivery failed 12m ago — 3 retries
+   *  exhausted") — rendered only while health = degraded (master anatomy). */
+  failure_note?: string;
   created_at: string;
 }
 

--- a/web/src/models/slos.ts
+++ b/web/src/models/slos.ts
@@ -19,4 +19,7 @@ export interface Slo {
   /** Burn rate multiple (1 = burning exactly at budget). */
   burn_rate: number;
   state: SloState;
+  /** When the budget hit zero — drives the exhausted caption ("budget
+   *  exhausted 3d ago", SLOCard master per-state captions). */
+  exhausted_at?: string;
 }


### PR DESCRIPTION
## Summary

The adjudicated CODE-side items from the 2026-07-20 Figma↔code audit, as eight sequenced commits (canvas/masters are the ratified truth; per-item adjudications in the audit ledger):

1. **A8/A9 home content (HIGH)** — A8 card restored to the public-status dogfooding moment per canvas 225:11191 ("Public status — we run upstat on upstat" · "View live →" → `/status/upstat`), with Public roadmap + CueLABS™ links; A9 rows per canvas 135:763 + 259:3474 ("Self-host guide — step-by-step deploy docs →" file-text · "Query grammar — one grammar across all eight pillars →" search); A14 twin renders label copy (no raw URL) at the GitBook deployment guide. Parity e2e + unit assertions updated.
2. **TimeseriesPanel per master 50:407** — four zero-baseline y ticks, unit-suffixed labels (new `unit` prop; bare "0"), floating in-plot crosshair tooltip led by the hh:mm:ss timestamp (replaces the sub-plot readout), by-`<tag>` legend labels trimmed to the tag value. TopList per 70:599 (no track, r=2). Heatmap x-labels adapt to grid width (B6 cohort collision fix).
3. **Entity-status pills sweep (systemic)** — labeled StatusPills replace lowercase status text: AlertChannelCard (friendly name + VERIFIED/UNVERIFIED/DEGRADED pill + masked target + degraded failure caption), APIKeyRow (per-signal scope chips + ACTIVE/ROTATING/REVOKED pills + "grace ends in 24h" / "N rejects (24h)"), B7 lists lead with FULL labeled pills (dot-only reserved for §5 colorblind), AlertFeedRow → master's single line (unread dot · tinted mono sev chip · title · relative age).
4. **NavRail reconcile** — code's fuller labels kept; master's grouping (Dashboards ungrouped above TELEMETRY) and foot (chevron square + signed-in avatar) adopted; icons reconciled to ONE list (see below), codified in design.md §8.1.
5. **Brand mark (systemic)** — shared `BrandMark` (filled bolt + lowercase wordmark) replaces the green "U" tile at the rail head, `/signin`, the public status page and the footer brand; `/signin` aligns to frame 124:6 (centered, "Sign in to your organization").
6. **IncidentBanner (hybrid)** — global strip placement stays (docs §3); the master's affordances land: "open 12m"-style age + "View incident →" / resolved "Postmortem →".
7. **Assorted** — B1 watched-dashboard rows pass "N widgets"; favorite star brand green; TopBar normalized to the master (43px, lowercase "prod", "Custom"/"● LIVE", "Search"); LogLine level row tint + 3px left bar (code's timestamp format kept); SLOCard per-state captions (flame stays per §8.1); B12 usage 64px rows, "5.6B" promotion, unwrapped plan copy; B7 `?run=` accepts run number or id + "run not found" state; footer tagline per master ("All your telemetry. One open platform."; legal-bar cluster stays [Security · language] per sibling parity); stale theme docstrings fixed (key absent = dark).
8. **Docs** — design.md §8.1 rail-icon list + affected §8.2/§8.2b rows present-tense; web-implementation.md audit-convergence as-built.

## Final NavRail icon list (for design + docs codification)

house · layout-dashboard · bar-chart-3 · file-text · route · globe · activity · bell · flame · target · book-open · settings

(master wins where §8.1-ratified: bar-chart-3, file-text, globe, activity; code keeps flame + book-open where the master's glyph is unratified; traces takes `route` — the ratified APM/Traces pillar glyph — since activity moved to Synthetics.)

## Gates

- `npm run lint` (prettier + eslint + boundaries) ✓
- `npm run typecheck` ✓
- `npm test` — 331 passed ✓
- `NEXT_PUBLIC_TEST_MODE=1 npm run build` ✓
- `CI=1 npm run test:e2e` (TEST_MODE prod server) — exit 0, no failure artifacts ✓

Branch is rebased on `main` @ d48a887 (post docs PR #179).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
