### PR TITLE
fix(web): re-cut FacetGroup header + unitless count() metric sniff

### DIFF
--- a/docs/web-implementation.md
+++ b/docs/web-implementation.md
@@ -509,9 +509,11 @@ site; /signin matches frame 124:6 (centered mark over "Sign in to your
 organization"; the CTA stays the GoogleAuthButton canon). (6)
 IncidentBanner keeps the global strip and gains "open Xm" + "View
 incident →" / "Postmortem →". (7) B4 constructions per masters —
-FacetGroup (chevron LEFT of the lowercase medium-12 header, mono values
-12 / counts 11, "Show N more" at 11px) and LogLine level row tints + 3px
-left bars (master 47:163; code's timestamp format kept). (8) The B8
+FacetGroup (chevron RIGHT of the uppercase semibold-12 tracked header,
+mono values 12 / counts 11 right-aligned, "Show all N" at 11px in
+brand — re-cut master 45:67, **[Adjudicated 2026-07-20]**) and LogLine
+level row tints + 3px left bars (master 47:163; code's timestamp format
+kept). (8) The B8
 edit-rule panel composes per frame 130:2621 — the MI-9 test replay
 renders INLINE under "Thresholds · test replay (last 24h)" (auto-runs on
 rule select; Test rule re-runs), Query is a mono Select over the org's

--- a/web/src/components/ui/FacetGroup.test.tsx
+++ b/web/src/components/ui/FacetGroup.test.tsx
@@ -37,8 +37,8 @@ describe("FacetGroup", () => {
       />,
     );
     expect(screen.queryByText("svc-5")).toBeNull();
-    // master affordance copy: remaining count ("Show 5 more")
-    await userEvent.click(screen.getByRole("button", { name: "Show 5 more" }));
+    // master affordance copy: total count ("Show all 8")
+    await userEvent.click(screen.getByRole("button", { name: "Show all 8" }));
     expect(screen.getByText("svc-5")).toBeInTheDocument();
   });
 });

--- a/web/src/components/ui/FacetGroup.tsx
+++ b/web/src/components/ui/FacetGroup.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { clsx } from "clsx";
-import { ChevronDown } from "lucide-react";
+import { ChevronDown, ChevronRight } from "lucide-react";
 import { useState } from "react";
 import { Checkbox } from "./Checkbox";
 
@@ -23,7 +23,7 @@ export interface FacetGroupProps {
   className?: string;
 }
 
-/** FacetGroup — the §3 FacetSidebar group (naming per §8.2). */
+/** FacetGroup — the §3 FacetSidebar group (naming per §8.2, re-cut master 45:67). */
 export function FacetGroup({
   name,
   values,
@@ -39,23 +39,26 @@ export function FacetGroup({
 
   return (
     <div className={clsx("font-ui", className)} data-expanded={expanded}>
-      {/* master construction (B4 FacetGroup): chevron LEFT of the
-          lowercase medium 12px header — the uppercase/right-chevron
-          header was drift (adjudicated 2026-07-20) */}
       <button
         type="button"
         aria-expanded={expanded}
         onClick={() => setExpanded((e) => !e)}
-        className="flex w-full items-center gap-1.5 py-1.5 text-left"
+        className="flex w-full items-center justify-between gap-1.5 py-1.5 text-left"
       >
-        <ChevronDown
-          aria-hidden="true"
-          className={clsx(
-            "size-3.5 shrink-0 text-text-2 transition-transform duration-[var(--duration-fast)] ease-standard",
-            !expanded && "-rotate-90",
-          )}
-        />
-        <span className="text-[12px] font-medium text-text-2">{name}</span>
+        <span className="text-[12px] font-semibold uppercase tracking-wide text-text-2">
+          {name}
+        </span>
+        {expanded ? (
+          <ChevronDown
+            aria-hidden="true"
+            className="size-3.5 shrink-0 text-text-2"
+          />
+        ) : (
+          <ChevronRight
+            aria-hidden="true"
+            className="size-3.5 shrink-0 text-text-2"
+          />
+        )}
       </button>
       {expanded && (
         <ul className="flex flex-col">
@@ -83,14 +86,14 @@ export function FacetGroup({
           ))}
           {values.length > topN && (
             <li>
-              {/* master affordance copy: "Show 12 more" (remaining count,
-                  11px) — was "Show all N" at 12px */}
+              {/* master affordance copy: "Show all N" (total count, 11px,
+                  brand) */}
               <button
                 type="button"
                 onClick={() => setShowAll((s) => !s)}
                 className="py-1 text-[11px] text-brand hover:text-brand-deep"
               >
-                {showAll ? "Show less" : `Show ${values.length - topN} more`}
+                {showAll ? "Show less" : `Show all ${values.length}`}
               </button>
             </li>
           )}

--- a/web/src/components/ui/TimeseriesPanel.test.tsx
+++ b/web/src/components/ui/TimeseriesPanel.test.tsx
@@ -60,6 +60,59 @@ describe("TimeseriesPanel", () => {
     expect(labels).toEqual(["0", "50 ms", "100 ms", "150 ms"]);
   });
 
+  it("a count() aggregation is unitless — it must not sniff `_ms` off the metric name", () => {
+    const countSeries: Series[] = [
+      {
+        name: "count(http.request.duration_ms)",
+        tags: {},
+        points: SERIES[0].points,
+      },
+    ];
+    const { container } = render(
+      <TimeseriesPanel
+        title="t"
+        query="metric:http.request.duration_ms | count()"
+        series={countSeries}
+      />,
+    );
+    const labels = Array.from(container.querySelectorAll("svg g text")).map(
+      (t) => t.textContent,
+    );
+    // same nice ladder as the p95 case, but bare — no " ms" suffix anywhere
+    expect(labels).toEqual(["0", "50", "100", "150"]);
+  });
+
+  it("uniq() (count-distinct per the grammar) is also unitless", () => {
+    // adversarial: the field name itself carries `_ms` — the outer fn still wins
+    const uniqSeries: Series[] = [
+      { name: "uniq(request_duration_ms)", tags: {}, points: SERIES[0].points },
+    ];
+    const { container } = render(
+      <TimeseriesPanel title="t" series={uniqSeries} />,
+    );
+    const labels = Array.from(container.querySelectorAll("svg g text")).map(
+      (t) => t.textContent,
+    );
+    expect(labels.some((l) => l?.endsWith(" ms"))).toBe(false);
+  });
+
+  it("an explicit unit prop still overrides the count() guard", () => {
+    const countSeries: Series[] = [
+      {
+        name: "count(http.request.duration_ms)",
+        tags: {},
+        points: SERIES[0].points,
+      },
+    ];
+    const { container } = render(
+      <TimeseriesPanel title="t" unit="req" series={countSeries} />,
+    );
+    const labels = Array.from(container.querySelectorAll("svg g text")).map(
+      (t) => t.textContent,
+    );
+    expect(labels).toEqual(["0", "50 req", "100 req", "150 req"]);
+  });
+
   it("shows axis-first loading and radar empty states (MI-16)", () => {
     const { container, rerender } = render(
       <TimeseriesPanel title="t" series={[]} loading />,

--- a/web/src/components/ui/TimeseriesPanel.tsx
+++ b/web/src/components/ui/TimeseriesPanel.tsx
@@ -80,8 +80,27 @@ function formatValue(v: number, unit?: string): string {
   return unit && v !== 0 ? `${compact} ${unit}` : compact;
 }
 
+/**
+ * True when the query/series' OUTER aggregation is a count-type fn — `count()`
+ * (row/point count) or `uniq()` (the grammar's count-distinct, query-
+ * grammar.md §4 function table). Those return a unitless number no matter
+ * what the aggregated metric is named, so `count(http.request.duration_ms)`
+ * must not sniff "ms" off the field just because it contains `_ms`. Series
+ * names and query strings both lead with the fn (`Series.name` is
+ * `fn(field) tags…`; the query string's aggregation clause follows `|`), so
+ * matching at the start of either or right after a `|` catches the OUTER fn
+ * without tripping on an inner field name.
+ */
+const OUTER_COUNT_AGG = /(?:^|\|\s*)(?:count|count_distinct|uniq)\s*\(/i;
+
 /** Unit sniff for the default: seeded metric names carry `*_ms`. */
 function deriveUnit(series: Series[], query?: string): string | undefined {
+  if (
+    OUTER_COUNT_AGG.test(series[0]?.name ?? "") ||
+    OUTER_COUNT_AGG.test(query ?? "")
+  ) {
+    return undefined;
+  }
   const haystack = `${series[0]?.name ?? ""} ${query ?? ""}`;
   return /_ms\b/.test(haystack) ? "ms" : undefined;
 }


### PR DESCRIPTION
## Summary
- **FacetGroup**: aligns to the re-cut Figma master (45:67) — uppercase 12px SemiBold tracked header with the chevron moved to the RIGHT (chevron-down open / chevron-right collapsed), real Checkbox rows (already real), 11px tabular counts right-aligned, and a "Show all N" affordance in brand. This replaces the lowercase/chevron-left construction and its divergence comment from a since-superseded adjudication. `FacetGroup.test.tsx`'s affordance-text assertion is updated; `docs/web-implementation.md`'s B4 note (present tense) is updated to match. No e2e selector pinned the old lowercase form.
- **`deriveUnit` (TimeseriesPanel, metrics)**: fixes a mislabel where a count-type aggregation (`count()`/`uniq()` — the query grammar's count and count-distinct fns) sniffed "ms" off the aggregated metric's name, e.g. `count(http.request.duration_ms)` rendered as "… ms" even though a count is unitless. The outer aggregation is now checked first — count()/uniq() short-circuits to unitless regardless of the metric-name suffix. Explicit `unit` props still override.

## Test plan
- [x] `npm run lint` (prettier + eslint + check:boundaries) — clean
- [x] `npm run typecheck` — clean
- [x] `npm run test` (vitest) — 344/344 passing across 100 files, including new `TimeseriesPanel.test.tsx` cases for the `count()`/`uniq()` shapes and the explicit-`unit`-override interaction
- [x] `NEXT_PUBLIC_TEST_MODE=1 npm run build` — succeeds
- [x] `npx playwright test` (CI mode, built app) — 58/58 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)