### PR TITLE
feat(web): self-host snippet goes tabbed — Docker Compose | Helm (Figma 413:2)

### DIFF
--- a/docs/web-implementation.md
+++ b/docs/web-implementation.md
@@ -535,6 +535,26 @@ Figma templates (EmptyState/MI-16 + first-run copy; Skeleton loading; a
 demo-data toggle where the screen's spec calls for one — first application
 B1/B2/B4/B5), and the QA loop checks all three.
 
+**Self-host tabbed snippet as-built (2026-07-20, PR #184).** A14's static
+compose-output `pre` is now the user-approved Docker Compose | Helm tab
+pair (Figma proposal 413:2), an extension of the §8.2b `CodeSnippet` +
+Tabs kit component: new `tabsLabel` (tablist accessible name — "Install
+method" here; the §8.2b "Language" default stands) and `prompt`
+(decorative select-none `$ ` prompts in the brand command color; the copy
+payload stays the raw commands) props, plus roving tabindex +
+Arrow/Home/End on the tablist — A5's OTel tabs inherit the keyboard
+semantics. Mirrored two-line commands: `git clone
+https://github.com/cuesoftinc/upstat` shared; `cd upstat && docker
+compose up --build -d` (the repo's `make up`) vs `cd upstat && helm
+install upstat deploy/helm` (the real chart path). The shared muted
+caption renders once under the block — "Compose ships MongoDB; the Helm
+chart expects yours (MONGO_URI). All 8 pillars come up on :3000." —
+visible in both tab states, so switching never shifts layout. The
+`COMPOSE_OUTPUT` seed lines retire with the `pre` they decorated. Unit:
+`CodeSnippet.test.tsx` (tabsLabel, prompt payload, per-tab copy, roving
+focus, copied-morph reset); e2e: `home.spec.ts` pins helm-tab copy → the
+clipboard payload, caption persistence and the 1440/390 container fit.
+
 ## 3. Token mapping — design.md §2 → `web/src/design/tokens.css`
 
 One custom property per Figma variable in the `upstat/tokens` collection

--- a/web/e2e/home.spec.ts
+++ b/web/e2e/home.spec.ts
@@ -419,6 +419,58 @@ test("home is responsive at 375w (mobile)", async ({ page }) => {
   ).toBeHidden();
 });
 
+// A14 tabbed snippet (Figma 413:2): tab switch is instant with no layout
+// shift, the shared MONGO_URI caption persists in both tab states, copy
+// targets the ACTIVE tab's full two-line block, and the block fits the
+// 1440/390 container canons.
+test("A14 self-host tabs — helm copy + caption persists", async ({
+  page,
+  context,
+}) => {
+  await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await page.goto("/");
+  const block = page.getByTestId("selfhost-snippet");
+  await block.scrollIntoViewIfNeeded();
+  const caption = block.getByText(
+    "Compose ships MongoDB; the Helm chart expects yours (MONGO_URI). All 8 pillars come up on :3000.",
+  );
+  await expect(caption).toBeVisible();
+  const tablist = block.getByRole("tablist", { name: "Install method" });
+
+  const before = await block.boundingBox();
+  await tablist.getByRole("tab", { name: "Helm" }).click();
+  await expect(
+    block.getByText("cd upstat && helm install upstat deploy/helm"),
+  ).toBeVisible();
+  await expect(caption).toBeVisible();
+  // no layout shift — mirrored two-line block + always-rendered caption
+  const after = await block.boundingBox();
+  expect(after!.height).toBe(before!.height);
+  expect(after!.width).toBe(before!.width);
+
+  await block.getByRole("button", { name: "Copy snippet" }).click();
+  const clip = await page.evaluate(() => navigator.clipboard.readText());
+  expect(clip).toBe(
+    "git clone https://github.com/cuesoftinc/upstat\ncd upstat && helm install upstat deploy/helm",
+  );
+
+  // 390 canon: block inside the viewport, no document overflow
+  await page.setViewportSize({ width: 390, height: 844 });
+  await block.scrollIntoViewIfNeeded();
+  await expect(caption).toBeVisible();
+  const mobile = await block.boundingBox();
+  expect(mobile!.width).toBeLessThanOrEqual(390);
+  const mobileOverflow = await page.evaluate(
+    () =>
+      Math.max(
+        document.documentElement.scrollWidth,
+        document.body.scrollWidth,
+      ) - document.documentElement.clientWidth,
+  );
+  expect(mobileOverflow).toBeLessThanOrEqual(0);
+});
+
 test("enabled controls carry the pointer cursor (Directive 2026-07-19)", async ({
   page,
 }) => {

--- a/web/src/app/dev/components/gallery.tsx
+++ b/web/src/app/dev/components/gallery.tsx
@@ -458,6 +458,17 @@ const TIMEZONES = [
   "UTC",
 ].map((tz) => ({ value: tz, label: tz }));
 
+const SELF_HOST_SNIPPET_TABS = [
+  {
+    label: "Docker Compose",
+    code: "git clone https://github.com/cuesoftinc/upstat\ncd upstat && docker compose up --build -d",
+  },
+  {
+    label: "Helm",
+    code: "git clone https://github.com/cuesoftinc/upstat\ncd upstat && helm install upstat deploy/helm",
+  },
+];
+
 const SNIPPET_TABS = [
   {
     label: "Go",
@@ -1535,6 +1546,17 @@ function GalleryAll() {
         </Cell>
         <Cell label="CodeSnippet + Tabs (Go/Python/Node/k8s, copy ✓)" grow>
           <CodeSnippet tabs={SNIPPET_TABS} className="max-w-[640px]" />
+        </Cell>
+        <Cell
+          label="CodeSnippet + Tabs, prompt mode (A14: Docker Compose | Helm)"
+          grow
+        >
+          <CodeSnippet
+            tabs={SELF_HOST_SNIPPET_TABS}
+            tabsLabel="Install method"
+            prompt
+            className="max-w-[640px]"
+          />
         </Cell>
         <Cell label="CloudVsSelfHostTable (A9)" grow>
           <CloudVsSelfHostTable className="max-w-[640px]" />

--- a/web/src/components/home/content.ts
+++ b/web/src/components/home/content.ts
@@ -106,11 +106,24 @@ export const SELF_HOST_CHECKLIST = [
   "Helm chart for Kubernetes when you outgrow compose",
 ];
 
-export const COMPOSE_OUTPUT = [
-  "Pulling upstat images ......... done",
-  "ClickHouse + Postgres ready ... done",
-  "All 8 pillars live on :3000",
+/** A14 — the mirrored two-line self-host snippets (tabbed CodeSnippet,
+ *  Figma 413:2). Line 1 shared; line 2 is `make up` (compose) or the real
+ *  chart at deploy/helm. */
+export const SELF_HOST_SNIPPET_TABS: CodeSnippetTab[] = [
+  {
+    label: "Docker Compose",
+    code: "git clone https://github.com/cuesoftinc/upstat\ncd upstat && docker compose up --build -d",
+  },
+  {
+    label: "Helm",
+    code: "git clone https://github.com/cuesoftinc/upstat\ncd upstat && helm install upstat deploy/helm",
+  },
 ];
+
+/** A14 — shared muted caption under the snippet, visible in both tab
+ *  states (user-approved copy). */
+export const SELF_HOST_CAPTION =
+  "Compose ships MongoDB; the Helm chart expects yours (MONGO_URI). All 8 pillars come up on :3000.";
 
 export const ARCHITECTURE_FLOW = [
   "OTel SDK / collector",

--- a/web/src/components/home/sections-bottom.tsx
+++ b/web/src/components/home/sections-bottom.tsx
@@ -10,11 +10,11 @@ import Link from "next/link";
 import { useState } from "react";
 import { Button } from "@/components/ui/Button";
 import { CloudVsSelfHostTable } from "@/components/ui/CloudVsSelfHostTable";
+import { CodeSnippet } from "@/components/ui/CodeSnippet";
 import { FAQItem } from "@/components/ui/FAQItem";
 import { DiscordIcon, GithubIcon } from "./BrandIcons";
 import {
   ARCHITECTURE_FLOW,
-  COMPOSE_OUTPUT,
   CUELABS_URL,
   DISCORD_URL,
   SELF_HOST_DOCS_URL,
@@ -25,7 +25,9 @@ import {
   PROBLEM_CHIPS,
   QUERY_GRAMMAR_DOCS_URL,
   ROADMAP_URL,
+  SELF_HOST_CAPTION,
   SELF_HOST_CHECKLIST,
+  SELF_HOST_SNIPPET_TABS,
   STACK_LINE,
 } from "./content";
 import { Section } from "./Section";
@@ -73,17 +75,22 @@ export function SelfHostSection({ onSelfHostDocs }: SelfHostSectionProps) {
         </div>
 
         <div className="min-w-0 flex flex-col gap-6">
-          <div className="overflow-x-auto rounded-(--radius) border border-border bg-bg-elev p-4">
-            <pre className="font-data text-[13px] leading-[1.6]">
-              <span className="text-brand">$ docker compose up -d</span>
-              {"\n"}
-              {COMPOSE_OUTPUT.map((line) => (
-                <span key={line} className="text-text-2">
-                  {line}
-                  {"\n"}
-                </span>
-              ))}
-            </pre>
+          {/* A14 tabbed snippet (Figma 413:2): Docker Compose | Helm,
+              mirrored two-line commands; copy targets the active tab. The
+              caption is shared — rendered once, outside the tab panel, so
+              both tab states keep it and switching never shifts layout. */}
+          <div
+            className="min-w-0 flex flex-col gap-2"
+            data-testid="selfhost-snippet"
+          >
+            <CodeSnippet
+              tabs={SELF_HOST_SNIPPET_TABS}
+              tabsLabel="Install method"
+              prompt
+            />
+            <p className="text-[12px] leading-normal text-text-2">
+              {SELF_HOST_CAPTION}
+            </p>
           </div>
           <div
             className="flex flex-wrap items-center gap-2"

--- a/web/src/components/ui/CodeSnippet.test.tsx
+++ b/web/src/components/ui/CodeSnippet.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { CodeSnippet } from "./CodeSnippet";
@@ -7,6 +7,26 @@ const TABS = [
   { label: "Go", code: "otel.SetTracerProvider(tp)" },
   { label: "Node", code: "sdk.start()" },
 ];
+
+const SELF_HOST_TABS = [
+  {
+    label: "Docker Compose",
+    code: "git clone https://github.com/cuesoftinc/upstat\ncd upstat && docker compose up --build -d",
+  },
+  {
+    label: "Helm",
+    code: "git clone https://github.com/cuesoftinc/upstat\ncd upstat && helm install upstat deploy/helm",
+  },
+];
+
+function mockClipboard() {
+  const writeText = vi.fn().mockResolvedValue(undefined);
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText },
+    configurable: true,
+  });
+  return writeText;
+}
 
 describe("CodeSnippet", () => {
   it("switches tabs", async () => {
@@ -21,5 +41,69 @@ describe("CodeSnippet", () => {
     const button = screen.getByLabelText("Copy snippet");
     await userEvent.click(button);
     expect(button.querySelector(".text-ok")).not.toBeNull();
+  });
+
+  it("labels the tablist — §8.2b language axis by default, overridable", () => {
+    const { unmount } = render(<CodeSnippet tabs={TABS} />);
+    expect(
+      screen.getByRole("tablist", { name: "Language" }),
+    ).toBeInTheDocument();
+    unmount();
+    render(<CodeSnippet tabs={SELF_HOST_TABS} tabsLabel="Install method" />);
+    expect(
+      screen.getByRole("tablist", { name: "Install method" }),
+    ).toBeInTheDocument();
+  });
+
+  it("roves focus with arrow keys (tablist semantics)", async () => {
+    render(<CodeSnippet tabs={TABS} />);
+    const go = screen.getByRole("tab", { name: "Go" });
+    const node = screen.getByRole("tab", { name: "Node" });
+    expect(go).toHaveAttribute("tabindex", "0");
+    expect(node).toHaveAttribute("tabindex", "-1");
+    go.focus();
+    await userEvent.keyboard("{ArrowRight}");
+    expect(node).toHaveFocus();
+    expect(node).toHaveAttribute("aria-selected", "true");
+    await userEvent.keyboard("{ArrowLeft}");
+    expect(go).toHaveFocus();
+    expect(go).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("prompt mode (A14): decorative $ prompts, raw commands in the payload", async () => {
+    const writeText = mockClipboard();
+    render(
+      <CodeSnippet tabs={SELF_HOST_TABS} tabsLabel="Install method" prompt />,
+    );
+    // both lines render with the select-none prompt decor
+    expect(screen.getAllByText("$")).toHaveLength(2);
+    expect(
+      screen.getByText(/cd upstat && docker compose up --build -d/),
+    ).toBeInTheDocument();
+    await userEvent.click(screen.getByLabelText("Copy snippet"));
+    expect(writeText).toHaveBeenCalledWith(SELF_HOST_TABS[0].code);
+  });
+
+  it("copy targets the ACTIVE tab — helm block after a switch", async () => {
+    const writeText = mockClipboard();
+    render(
+      <CodeSnippet tabs={SELF_HOST_TABS} tabsLabel="Install method" prompt />,
+    );
+    await userEvent.click(screen.getByRole("tab", { name: "Helm" }));
+    expect(
+      screen.getByText(/helm install upstat deploy\/helm/),
+    ).toBeInTheDocument();
+    await userEvent.click(screen.getByLabelText("Copy snippet"));
+    expect(writeText).toHaveBeenCalledWith(SELF_HOST_TABS[1].code);
+  });
+
+  it("copied check resets when the tab switches", async () => {
+    mockClipboard();
+    render(<CodeSnippet tabs={TABS} />);
+    const button = screen.getByLabelText("Copy snippet");
+    await userEvent.click(button);
+    expect(button.querySelector(".text-ok")).not.toBeNull();
+    await userEvent.click(screen.getByRole("tab", { name: "Node" }));
+    expect(button.querySelector(".text-ok")).toBeNull();
   });
 });

--- a/web/src/components/ui/CodeSnippet.tsx
+++ b/web/src/components/ui/CodeSnippet.tsx
@@ -2,26 +2,41 @@
 
 import { clsx } from "clsx";
 import { Check, Copy } from "lucide-react";
-import { useState } from "react";
+import { useRef, useState } from "react";
 
 export interface CodeSnippetTab {
-  /** Tab label — Go / Python / Node / k8s (§8.2b). */
+  /** Tab label — Go / Python / Node / k8s (§8.2b) or an install method. */
   label: string;
   code: string;
 }
 
 export interface CodeSnippetProps {
   tabs: CodeSnippetTab[];
+  /** Accessible name for the tablist (the §8.2b language axis by default). */
+  tabsLabel?: string;
+  /**
+   * Shell-command mode (A14 self-host, Figma 413:2): each code line renders
+   * a decorative select-none `$ ` prompt in the brand command color — the
+   * copy payload stays the raw commands, prompt-free.
+   */
+  prompt?: boolean;
   className?: string;
 }
 
 /**
  * CodeSnippet + Tabs — §8.2b: tab axis Go/Python/Node/k8s (active/inactive),
- * copy idle/copied-check, mono block on bg-elev.
+ * copy idle/copied-check, mono block on bg-elev. The tablist carries roving
+ * tabindex + Arrow/Home/End focus; copy always targets the ACTIVE tab.
  */
-export function CodeSnippet({ tabs, className }: CodeSnippetProps) {
+export function CodeSnippet({
+  tabs,
+  tabsLabel = "Language",
+  prompt = false,
+  className,
+}: CodeSnippetProps) {
   const [active, setActive] = useState(0);
   const [copied, setCopied] = useState(false);
+  const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
 
   const copy = async () => {
     try {
@@ -33,6 +48,24 @@ export function CodeSnippet({ tabs, className }: CodeSnippetProps) {
     setTimeout(() => setCopied(false), 1200);
   };
 
+  const select = (i: number) => {
+    setActive(i);
+    setCopied(false);
+  };
+
+  const onTabKeyDown = (event: React.KeyboardEvent, index: number) => {
+    const last = tabs.length - 1;
+    let next: number | null = null;
+    if (event.key === "ArrowRight") next = index === last ? 0 : index + 1;
+    else if (event.key === "ArrowLeft") next = index === 0 ? last : index - 1;
+    else if (event.key === "Home") next = 0;
+    else if (event.key === "End") next = last;
+    if (next === null) return;
+    event.preventDefault();
+    select(next);
+    tabRefs.current[next]?.focus();
+  };
+
   return (
     <div
       className={clsx(
@@ -41,17 +74,19 @@ export function CodeSnippet({ tabs, className }: CodeSnippetProps) {
       )}
     >
       <div className="flex items-center border-b border-border">
-        <div role="tablist" aria-label="Language" className="flex flex-1">
+        <div role="tablist" aria-label={tabsLabel} className="flex flex-1">
           {tabs.map((tab, i) => (
             <button
               key={tab.label}
+              ref={(el) => {
+                tabRefs.current[i] = el;
+              }}
               type="button"
               role="tab"
               aria-selected={i === active}
-              onClick={() => {
-                setActive(i);
-                setCopied(false);
-              }}
+              tabIndex={i === active ? 0 : -1}
+              onClick={() => select(i)}
+              onKeyDown={(event) => onTabKeyDown(event, i)}
               className={clsx(
                 "px-3 py-2 text-[13px] font-medium transition-colors duration-[var(--duration-fast)]",
                 i === active
@@ -78,7 +113,16 @@ export function CodeSnippet({ tabs, className }: CodeSnippetProps) {
       </div>
       <pre className="overflow-x-auto p-4">
         <code className="font-data text-[13px] leading-[1.6] text-text">
-          {tabs[active].code}
+          {prompt
+            ? tabs[active].code.split("\n").map((line) => (
+                <span key={line} className="block whitespace-nowrap text-brand">
+                  <span aria-hidden="true" className="select-none">
+                    {"$ "}
+                  </span>
+                  {line}
+                </span>
+              ))
+            : tabs[active].code}
         </code>
       </pre>
     </div>


### PR DESCRIPTION
## Summary
- A14's static compose-output `pre` is now the user-approved tabbed block (Figma proposal 413:2): **Docker Compose | Helm**, mirrored two-line commands — `git clone https://github.com/cuesoftinc/upstat` shared; `cd upstat && docker compose up --build -d` (the repo's `make up`) vs `cd upstat && helm install upstat deploy/helm` (the real chart at `deploy/helm`).
- Extends the existing §8.2b `CodeSnippet` + Tabs: new `tabsLabel` (tablist accessible name — “Install method” here; “Language” default stands) and `prompt` (decorative select-none `$ ` prompts in the brand command color; copy payload stays the raw commands) props, plus roving tabindex + Arrow/Home/End on the tablist — A5's OTel tabs inherit the keyboard semantics.
- Copy targets the ACTIVE tab; ✓ morph resets on switch. Shared muted caption renders once under the block, visible in both tab states (no layout shift): “Compose ships MongoDB; the Helm chart expects yours (MONGO_URI). All 8 pillars come up on :3000.”
- `COMPOSE_OUTPUT` seed lines retire with the `pre` they decorated. Dev gallery prompt-mode cell + web-implementation.md as-built note.

## Tests
- Unit (`CodeSnippet.test.tsx`): tabsLabel default/override, prompt-mode payload, per-tab copy, roving focus, copied-morph reset.
- e2e (`home.spec.ts`): switch to Helm → copy → clipboard equals the full two-line helm block; caption persists across both states; block box stable; in-viewport at 1440/390.

## Gates
prettier ✓ eslint ✓ boundaries ✓ typecheck ✓ vitest ✓ next build ✓ playwright (full suite) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)