### PR TITLE
fix(web): landing renders the canvas weight — fleet font-smoothing standard + per-role type lock

### DIFF
--- a/web/e2e/home.spec.ts
+++ b/web/e2e/home.spec.ts
@@ -622,3 +622,70 @@ test("mobile nav is a menu-button disclosure at 390w (SKILL.md mobile clause)", 
   await barCta.click();
   await page.waitForURL("**/signin");
 });
+
+// Type contract — the landing's key roles render the Figma Home frame's
+// (135:2) computed type (fleet font-weight audit 2026-07-20): Display/44
+// Semi Bold hero, 28/600 section headings, 16/600 pillar titles, and the
+// fleet font-smoothing standard (grayscale antialiasing — Figma rasterizes
+// grayscale; subpixel reads heavier than the approved canvas).
+test.describe("type contract — Figma Home frame roles", () => {
+  test("per-role computed family/weight/size and smoothing match", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1440, height: 1200 });
+    await page.goto("/");
+
+    const roles = [
+      {
+        role: "hero H1 (Display/44 Semi Bold)",
+        locator: page.getByRole("heading", { level: 1 }),
+        family: /^Inter\b/,
+        weight: "600",
+        size: "44px",
+      },
+      {
+        role: "pillars heading (28 Semi Bold)",
+        locator: page.getByRole("heading", {
+          name: "Eight pillars. One query grammar.",
+        }),
+        family: /^Inter\b/,
+        weight: "600",
+        size: "28px",
+      },
+      {
+        role: "pillar title (16 Semi Bold)",
+        locator: page
+          .getByRole("link", { name: /Uptime & Synthetics/ })
+          .getByText("Uptime & Synthetics"),
+        family: /^Inter\b/,
+        weight: "600",
+        size: "16px",
+      },
+      {
+        role: "query value (Mono 28 Regular)",
+        locator: page.getByText("99.98%", { exact: true }).first(),
+        family: /^"?JetBrains Mono\b/,
+        weight: "400",
+        size: "28px",
+      },
+    ] as const;
+
+    for (const r of roles) {
+      const cs = await r.locator.evaluate((el) => {
+        const s = getComputedStyle(el);
+        return {
+          fontFamily: s.fontFamily,
+          fontWeight: s.fontWeight,
+          fontSize: s.fontSize,
+          webkitFontSmoothing: s.getPropertyValue("-webkit-font-smoothing"),
+        };
+      });
+      expect.soft(cs.fontFamily, `${r.role} family`).toMatch(r.family);
+      expect.soft(cs.fontWeight, `${r.role} weight`).toBe(r.weight);
+      expect.soft(cs.fontSize, `${r.role} size`).toBe(r.size);
+      expect
+        .soft(cs.webkitFontSmoothing, `${r.role} smoothing`)
+        .toBe("antialiased");
+    }
+  });
+});

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -157,6 +157,12 @@
     font-family: var(--font-inter), ui-sans-serif, system-ui, sans-serif;
     background: var(--color-bg);
     color: var(--color-text);
+    /* Fleet font-smoothing standard (2026-07-20 type audit): grayscale
+       antialiasing everywhere — Figma rasterizes grayscale, and macOS
+       subpixel rendering reads visibly heavier than the approved canvas.
+       Same pair apparule and expendit ship. */
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
   }
 
   a {


### PR DESCRIPTION
## Why

Third leg of the fleet font-weight audit (apparule #119, expendit #242 — both merged). Same method: per-role `getComputedStyle` vs the Figma Home frame (135:2) at the 1440 frame.

## Per-role verdict — type already clean

| Role | Figma (135:2) | Web (computed) | Verdict |
| --- | --- | --- | --- |
| Hero H1 | `Display/44 Semi Bold` — Inter 600 · 44/normal · ls 0 | Inter 600 · 44/52.8 (leading-[1.2] ≈ normal) · ls 0 | ✓ |
| Section headings ×10 | Inter 600 · 28/normal · ls 0 | Inter 600 · 28/normal · ls 0 | ✓ exact |
| Pillar titles | Inter 600 · 16 | Inter 600 · 16 | ✓ |
| Pillar captions | Inter 400 · 12 | Inter 400 · 12 (lh 1.45 vs canvas normal — ramp's documented data-view leading, kept) | ✓ |
| Query values | JetBrains Mono 400 · 28 | JetBrains Mono 400 · 28 | ✓ |

## The one real delta: font smoothing

upstat rendered with `-webkit-font-smoothing: auto` — macOS subpixel rendering draws every weight visibly heavier than the approved canvas (Figma rasterizes grayscale). apparule and expendit already ship grayscale antialiasing; upstat was the fleet hold-out.

**Fleet adjudication (2026-07-20, to be codified in the org SKILL.md):** all three products set `-webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale` on `body` in globals.css — grayscale AA matches the canvas rasterization, and it's what 2/3 of the fleet already shipped.

## Verification

- e2e "type contract" lock: per-role computed family/weight/size at 1440 + the smoothing assertion.
- Gates: lint/boundaries ✓ · typecheck ✓ · vitest 349 (100 files) ✓ · e2e 60 ✓ · `next build` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)