### PR TITLE
fix(web): cross-check classes — TimePicker panel anatomy (43:59) + monitors editor panel dead-whitespace (130:2621)

### DIFF
--- a/web/e2e/dashboard.spec.ts
+++ b/web/e2e/dashboard.spec.ts
@@ -189,6 +189,53 @@ test("right-anchored TopBar layers stay inside the viewport (review class 2026-0
   }
 });
 
+test("absolute-range panel: master anatomy (43:59) + bottom-edge safety (crosscheck 2026-07-20)", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await signIn(page);
+
+  // 900 = the canonical QA height; 700 = the shallow-chrome squeeze case
+  for (const height of [900, 700]) {
+    await page.setViewportSize({ width: 1440, height });
+    const scrollHBefore = await page.evaluate(
+      () => document.documentElement.scrollHeight,
+    );
+
+    await page
+      .getByRole("banner")
+      .getByRole("button", { name: "Custom range" })
+      .click();
+    const dialog = page.getByRole("dialog", { name: "Absolute range" });
+    await expect(dialog).toBeVisible();
+
+    // the open layer never leaves the viewport on either axis, and never
+    // grows the document (no popover-induced page scrollbar)
+    const box = (await dialog.boundingBox())!;
+    expect(box.x).toBeGreaterThanOrEqual(0);
+    expect(box.y).toBeGreaterThanOrEqual(0);
+    expect(box.x + box.width).toBeLessThanOrEqual(1440);
+    expect(box.y + box.height).toBeLessThanOrEqual(height);
+    expect(
+      await page.evaluate(() => document.documentElement.scrollHeight),
+    ).toBe(scrollHBefore);
+
+    // master anatomy: from → to on ONE row, inset from the panel edge
+    // (p-12 — the row is not flush), commit via the brand Apply button
+    const from = (await dialog.getByLabel("From").boundingBox())!;
+    const to = (await dialog.getByLabel("To").boundingBox())!;
+    expect(Math.abs(from.y - to.y)).toBeLessThanOrEqual(2);
+    expect(to.x).toBeGreaterThan(from.x + from.width);
+    expect(from.x - box.x).toBeGreaterThanOrEqual(8);
+    expect(from.y - box.y).toBeGreaterThanOrEqual(8);
+
+    const apply = dialog.getByRole("button", { name: "Apply range" });
+    await expect(apply).toBeVisible();
+    await apply.click();
+    await expect(dialog).toBeHidden();
+  }
+});
+
 test("full journey: onboarding → B1 → dashboards → explorer → logs → trace → monitor → incident → status page", async ({
   page,
 }) => {

--- a/web/e2e/monitors-grouped.spec.ts
+++ b/web/e2e/monitors-grouped.spec.ts
@@ -85,3 +85,30 @@ test("?view=state deep-links the grouped view", async ({ page }) => {
   await expect(page.getByTestId("rules-by-state")).toBeHidden();
   await expect(page).toHaveURL(/\/dashboard\/monitors$/);
 });
+
+test("rule editor panel hugs its content — no dead panel below the form (130:2621; crosscheck 2026-07-20)", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await signIn(page);
+  await page.goto("/dashboard/monitors");
+  await page.getByTestId("rule-rule_checkout_p95").click();
+  await expect(
+    page.getByRole("heading", { name: /Edit rule — Checkout p95 latency/ }),
+  ).toBeVisible();
+  const form = page.getByTestId("rule-editor");
+  await expect(form).toBeVisible();
+  // let the async replay slot settle before measuring
+  await page.waitForTimeout(600);
+
+  const panelBox = (await page
+    .locator('section[aria-labelledby="editor-heading"]')
+    .boundingBox())!;
+  const formBox = (await form.boundingBox())!;
+  // the frame shows the panel at content height: form bottom + p-5 (20px)
+  // + 1px border. More slack than that = the grid-stretch dead-whitespace
+  // class (the panel used to pin to the rules column's full height).
+  const slack = panelBox.y + panelBox.height - (formBox.y + formBox.height);
+  expect(slack).toBeGreaterThanOrEqual(19);
+  expect(slack).toBeLessThanOrEqual(23);
+});

--- a/web/src/app/dashboard/monitors/page.tsx
+++ b/web/src/app/dashboard/monitors/page.tsx
@@ -256,7 +256,10 @@ export default function MonitorsPage() {
 
         <section
           aria-labelledby="editor-heading"
-          className="min-w-0 rounded-(--radius) border border-border bg-bg-elev p-5"
+          // self-start: the frame (130:2621) shows the editor panel at
+          // content height while the rules column runs on below it — the
+          // default grid stretch left ~650px of empty panel under the form
+          className="min-w-0 self-start rounded-(--radius) border border-border bg-bg-elev p-5"
         >
           {selected ? (
             <>

--- a/web/src/components/ui/TimePicker.test.tsx
+++ b/web/src/components/ui/TimePicker.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { TimePicker } from "./TimePicker";
 
@@ -32,5 +32,23 @@ describe("TimePicker", () => {
     expect(
       screen.getByRole("dialog", { name: "Absolute range" }),
     ).toBeInTheDocument();
+  });
+
+  it("absolute-range panel carries the master anatomy — from/to inputs + Apply range commit (43:59)", async () => {
+    const onChange = vi.fn();
+    render(<TimePicker value="custom" onChange={onChange} />);
+    await userEvent.click(screen.getByRole("button", { name: "Custom range" }));
+    const dialog = screen.getByRole("dialog", { name: "Absolute range" });
+    // the master's row is unlabeled mono inputs — aria-only names
+    expect(within(dialog).getByLabelText("From")).toBeInTheDocument();
+    expect(within(dialog).getByLabelText("To")).toBeInTheDocument();
+    // Apply range commits "custom" and closes the panel
+    await userEvent.click(
+      within(dialog).getByRole("button", { name: "Apply range" }),
+    );
+    expect(onChange).toHaveBeenLastCalledWith("custom");
+    expect(
+      screen.queryByRole("dialog", { name: "Absolute range" }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/web/src/components/ui/TimePicker.tsx
+++ b/web/src/components/ui/TimePicker.tsx
@@ -93,22 +93,42 @@ export function TimePicker({
             // never leaves the viewport (review class 2026-07-19, expendit):
             // <md a fixed full-width sheet under the bar; md+ right-anchored
             // to the control with the max-w clamp
-            className="fixed inset-x-2 top-14 z-[var(--z-dropdown)] flex flex-col gap-2 rounded-(--radius) border border-border bg-bg-elev p-3 shadow-lg md:absolute md:inset-x-auto md:right-0 md:top-full md:mt-1 md:w-64 md:max-w-[calc(100vw-16px)]"
+            className="fixed inset-x-2 top-14 z-[var(--z-dropdown)] flex flex-col gap-2 rounded-(--radius) border border-border bg-bg-elev p-3 shadow-lg md:absolute md:inset-x-auto md:right-0 md:top-full md:mt-1 md:w-max md:max-w-[calc(100vw-16px)]"
+            onKeyDown={(e) => {
+              if (e.key === "Escape") setCustomOpen(false);
+            }}
           >
-            <label className="flex flex-col gap-1 text-[12px] text-text-2">
-              From
+            {/* master anatomy (43:59): one [from] → [to] row of mono
+                values — no visible field labels — over the brand commit
+                button; panel p-12 / gap-8 */}
+            <div className="flex items-center gap-2">
               <input
                 type="datetime-local"
-                className="font-data h-7 rounded-(--radius) border border-border bg-bg px-1.5 text-[12px] text-text"
+                aria-label="From"
+                className="font-data h-7 min-w-0 flex-1 rounded-(--radius) border border-border bg-bg px-1.5 text-[12px] text-text md:w-44 md:flex-none"
               />
-            </label>
-            <label className="flex flex-col gap-1 text-[12px] text-text-2">
-              To
+              <span aria-hidden="true" className="text-[12px] text-text-2">
+                →
+              </span>
               <input
                 type="datetime-local"
-                className="font-data h-7 rounded-(--radius) border border-border bg-bg px-1.5 text-[12px] text-text"
+                aria-label="To"
+                className="font-data h-7 min-w-0 flex-1 rounded-(--radius) border border-border bg-bg px-1.5 text-[12px] text-text md:w-44 md:flex-none"
               />
-            </label>
+            </div>
+            {/* the master's explicit commit affordance — Apply range
+                closes the panel and re-commits "custom" (MI-1: the
+                URL-synced screen owner reacts to the committed value) */}
+            <button
+              type="button"
+              onClick={() => {
+                setCustomOpen(false);
+                onChange("custom");
+              }}
+              className="h-7 self-start rounded-(--radius) bg-brand px-3 text-[12px] font-medium text-on-brand transition-colors duration-[var(--duration-fast)] ease-standard hover:bg-brand-deep"
+            >
+              Apply range
+            </button>
           </div>
         )}
       </div>


### PR DESCRIPTION
Cross-repo finding-class sweep (three classes user-reported on expendit), verified against upstat's own Figma masters in the TEST_MODE build. Two verified hits, fixed and e2e-locked; the rest of the surfaces audited clean with evidence.

## C1 — popover anatomy + Y-overflow: **HIT (anatomy), fixed**
- The TimePicker absolute-range dialog diverged from the master (43:59): code had two stacked, visibly-labeled `From`/`To` fields and **no commit affordance**; the master is one `[from] → [to]` row of mono inputs over a brand **Apply range** button.
- Re-cut per the master: one row, aria-only labels, `Apply range` closes + re-commits `custom` (MI-1), Escape now closes from inside the panel too. Panel geometry (p-12/gap-8, border, elev, shadow) and the #158 clamps kept; `md:w-64 → md:w-max` for the row.
- Bottom-edge: the panel is TopBar-anchored (always top-of-viewport); e2e now asserts at **1440×900 and 1440×700** that the open panel stays inside the viewport on both axes and never grows the document. The only other bottom-edge-capable poppers are the Radix layers (below).
- No other date/time inputs exist (`datetime-local`/`type=date` grep: TimePicker only).

## C2 — modal-embedded select clipping: **CLEAN (verified empirically)**
Enumerated every dropdown inside a Modal/Sheet: DeclareIncidentModal (Severity + Commander), metrics save-to-dashboard (Dashboard). All ride the shared `Select` (Radix Popover → `Popover.Portal` to body, `z-toast` above the modal overlay, `collisionPadding=8`, `max-h-56` padded menu — the repo's established modal-safe pattern). Screenshot-verified at 1440×900 **and** 1440×700: the Commander menu renders over and past the modal footer unclipped, zero overflow-clipping ancestors, no document scrollbar. Widget-editor modal carries the WidgetTypePicker strip + inputs (no selects, per the master). In-page panels (rule editor `window`, status-page builder rows, settings, onboarding) portal the same way — the last builder row's menu **flips above** its trigger at 1440×700 and stays in-viewport.

## C3 — dashboard band balance: **HIT (monitors), fixed; B1 clean**
- **Monitors (B8, 130:2621):** the editor `<section>` (bordered bg-elev) stretched to the rules column's full grid-row height — ~650px of dead panel under the form (panel bottom 1273 vs form bottom 621 at 1440×900). The frame shows the panel at content height while the rules column continues below it. Fixed with `self-start`; e2e locks panel-bottom = form-bottom + p-5 + border (21px ±2).
- **B1 Home (125:13):** clean — the mid-band is two natural row-lists (watched dashboards / triggered monitors) exactly like the frame's construction; measured deltas are seeded-data row counts, no stretched chrome. The B2 widget grid is fixed row-unit construction (layout.h × ROW_H) — no flexible-height imbalance class.
- **Incident detail (131:2901):** single-column per the frame; code matches (no two-column band exists).

## Gates
- vitest: 100 files / 350 tests ✓ (incl. new anatomy + Apply-commit locks)
- prettier / eslint / check:boundaries ✓
- `NEXT_PUBLIC_TEST_MODE=1 next build` ✓
- Playwright (serial, port 3131): dashboard.spec 5/5 ✓ (incl. new 900/700 lock), monitors-grouped.spec 3/3 ✓ (incl. new content-height lock)

🤖 Generated with [Claude Code](https://claude.com/claude-code)