### PR TITLE
fix(web): self-host checklist claims the shipping stack — MongoDB, not the U-1 target

### DIFF
--- a/web/src/components/home/content.ts
+++ b/web/src/components/home/content.ts
@@ -102,7 +102,10 @@ export const GOOD_FIRST_ISSUES = [
 
 export const SELF_HOST_CHECKLIST = [
   "Every pillar ships: uptime, RUM, metrics, logs, traces, dashboards, alerts, SLOs, status pages",
-  "ClickHouse for telemetry, Postgres for the control plane — batteries included",
+  // Current-system truth: the compose stack runs on MongoDB (architecture.md);
+  // the ratified ClickHouse telemetry store (decisions.md U-1) lands with
+  // OBS-001 and stays out of shipping claims until it ships.
+  "MongoDB ships in the box — one datastore, nothing else to stand up",
   "Helm chart for Kubernetes when you outgrow compose",
 ];
 


### PR DESCRIPTION
User-flagged incoherence: the self-host checklist promised **ClickHouse + Postgres, batteries included** while the compose ships `mongo:7` — and the user-approved caption directly below says "Compose ships MongoDB". One screen, two datastore stories.

**Adjudication:** decisions.md U-1 ratifies ClickHouse as the telemetry store *at OBS-001* (not built — backend phase unauthorized); architecture.md + docker-compose.yml agree today's stack is MongoDB. Per the docs-current-system doctrine, **shipping claims** describe the current system, so the checklist row becomes *"MongoDB ships in the box — one datastore, nothing else to stand up"*. The designed-platform story (hero "ClickHouse-fast", FAQ, architecture flow) is the ratified U-1 target the demo simulates and stands unchanged.

Figma A14 checklist text sync is queued to the active design lane in the same pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)