### PR TITLE
chore(web): retire dead NEXT_PUBLIC_BASE_URL plumbing; docs name the real var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,5 @@ UPSTAT_GRPC_AUTH_TOKEN=
 UPSTAT_GRPC_CHECK_LIMIT=100
 
 # --- web (build-time, inlined into the image) ---
-NEXT_PUBLIC_BASE_URL=http://localhost:8080
 # gRPC-Web endpoint (Envoy) as seen from the browser.
 NEXT_PUBLIC_ENVOY_URL=http://localhost:8082

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,7 +79,6 @@ services:
       dockerfile: web/Dockerfile
       # NEXT_PUBLIC_* are inlined into the standalone build, so pass them here.
       args:
-        NEXT_PUBLIC_BASE_URL: ${NEXT_PUBLIC_BASE_URL:-http://localhost:8080}
         NEXT_PUBLIC_ENVOY_URL: ${NEXT_PUBLIC_ENVOY_URL:-http://localhost:8082}
     ports:
       - "3000:3000"

--- a/docs/web-implementation.md
+++ b/docs/web-implementation.md
@@ -676,12 +676,12 @@ on it:
    server — `/api/mock/v1/*` mirrors the `/v1/*` surface path-for-path, so
    repositories are identical in both modes except for the base URL.
 
-Unset (or `0`) → real `FirebaseAuthProvider` + `NEXT_PUBLIC_BASE_URL`
-(api/common HTTP). The new app consumes **HTTP/JSON only** (U-5/X-8 — no
-new gRPC-Web surface); until monitors-v2 lands, the real-backend monitor
-path is bridged inside the models seam (§8), never in views. TEST_MODE is
-how Playwright runs in CI and how W1–W3 are built before the backend
-surfaces exist.
+Unset (or `0`) → real `FirebaseAuthProvider` + the real API base from
+`NEXT_PUBLIC_API_BASE` (api/common HTTP). The new app consumes **HTTP/JSON
+only** (U-5/X-8 — no new gRPC-Web surface); until monitors-v2 lands, the
+real-backend monitor path is bridged inside the models seam (§8), never in
+views. TEST_MODE is how Playwright runs in CI and how W1–W3 are built
+before the backend surfaces exist.
 
 ## 6. Mock server & seed narrative
 

--- a/web/.env.example
+++ b/web/.env.example
@@ -1,4 +1,3 @@
 # Native-run config for web (compose users: use the root .env instead).
 # NEXT_PUBLIC_* are inlined at build time.
-NEXT_PUBLIC_BASE_URL=http://localhost:8080
 NEXT_PUBLIC_ENVOY_URL=http://localhost:8082

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -18,9 +18,7 @@ COPY --from=deps /app/web/node_modules ./node_modules
 COPY web/ ./
 COPY docs/api/openapi.yaml /app/docs/api/openapi.yaml
 # NEXT_PUBLIC_* are inlined at build time.
-ARG NEXT_PUBLIC_BASE_URL
 ARG NEXT_PUBLIC_ENVOY_URL
-ENV NEXT_PUBLIC_BASE_URL=$NEXT_PUBLIC_BASE_URL
 ENV NEXT_PUBLIC_ENVOY_URL=$NEXT_PUBLIC_ENVOY_URL
 RUN npm run build
 


### PR DESCRIPTION
## Summary

Fleet-level dead-env cleanup, item 2 (naming drift), converged from the per-repo sweeps (#190, apparule#122, expendit#247). `NEXT_PUBLIC_BASE_URL` is plumbed through the build/deploy surface but never read — the code's real API base var is `NEXT_PUBLIC_API_BASE`. The unread plumbing goes; the docs line that named the wrong var now names the real one.

## Evidence — no reader exists

- `web/src/models/repositories/client.ts:15` → `process.env.NEXT_PUBLIC_API_BASE || "/api/mock"` — the models-layer base var is `NEXT_PUBLIC_API_BASE`, not `NEXT_PUBLIC_BASE_URL`.
- `git grep "process.env.NEXT_PUBLIC" web/` → readers are `API_BASE`, `ENVOY_URL` (`web/src/client.ts`), `TEST_MODE`, `ANALYTICS`. No `BASE_URL` reader.
- Removal is behavior-neutral: the var never reached any code, so built images are byte-identical in behavior.

## Removals (per row) — BASE_URL rows only

| File | Row removed |
| --- | --- |
| `web/Dockerfile` | `ARG NEXT_PUBLIC_BASE_URL` + `ENV NEXT_PUBLIC_BASE_URL=...` (ENVOY_URL ARG/ENV stay — read) |
| `docker-compose.yml` | web build arg `NEXT_PUBLIC_BASE_URL: ...` (ENVOY_URL arg stays) |
| `.env.example` | `NEXT_PUBLIC_BASE_URL=` row (web section + ENVOY_URL row stay) |
| `web/.env.example` | `NEXT_PUBLIC_BASE_URL=` row |

Not touched: api-common's Go `BASE_URL` in `.env.example` — a different backend var.

## Docs fix (describe the current system)

`docs/web-implementation.md` §5: "real `FirebaseAuthProvider` + `NEXT_PUBLIC_BASE_URL` (api/common HTTP)" → "the real API base from `NEXT_PUBLIC_API_BASE` (api/common HTTP)" — names the var the code actually reads. (`NEXT_PUBLIC_API_BASE` remains intentionally unplumbed for now: TEST_MODE/mock is the ratified pre-backend mode, and adding build plumbing would be a behavior change outside this cleanup's scope.)

## Fleet parity

- expendit: same removal landed in expendit#248 (its base is the hardcoded relative `/api/v1` — no env var at all).
- apparule: **keeps** `NEXT_PUBLIC_BASE_URL` — its `web/src/config/env.ts` genuinely reads it.

## Gates

- `npm run lint` (prettier check + eslint + boundaries) — clean
- `npm run typecheck` — clean
- `npm test` — 101 files / 354 tests passed
- `npm run build` (next build) — success
- `docker compose config -q` — OK

No overlap with the active `fix/ledger-closeout` lane (controllers/docstrings); base re-fetched before push — main unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)