### PR TITLE
fix(web)+figma: convergence-ledger closeout — ?run= lock; IncidentBanner chrome-strip placement lands on all frames

### DIFF
--- a/web/src/controllers/synthetics.test.ts
+++ b/web/src/controllers/synthetics.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import type { SyntheticRun } from "@/models";
+import { selectRun } from "./synthetics";
+
+function run(id: string, number: number): SyntheticRun {
+  return {
+    id,
+    check_id: "syn_checkout",
+    number,
+    status: "pass",
+    started_at: "2026-07-20T10:00:00Z",
+    total_ms: 754,
+    steps: [],
+    steps_total: 5,
+    failure_screenshot: null,
+  };
+}
+
+// newest first, as the repo returns them
+const RUNS = [run("synrun_0009", 482), run("synrun_0008", 481)];
+
+describe("B7 ?run= deep link (audit fix 2026-07-20 — id OR visible number)", () => {
+  it("selects the latest run when no ?run= is given", () => {
+    expect(selectRun(RUNS, null)?.id).toBe("synrun_0009");
+    expect(selectRun([], null)).toBeNull();
+  });
+
+  it("resolves the internal id (synrun_0008)", () => {
+    expect(selectRun(RUNS, "synrun_0008")?.number).toBe(481);
+  });
+
+  it("resolves the visible run number — the frame addresses run #482", () => {
+    expect(selectRun(RUNS, "482")?.id).toBe("synrun_0009");
+    expect(selectRun(RUNS, "#482")?.id).toBe("synrun_0009");
+  });
+
+  it("returns null for an unknown value — the page says 'Run … not found', never the 'No runs yet' empty copy", () => {
+    expect(selectRun(RUNS, "synrun_9999")).toBeNull();
+    expect(selectRun(RUNS, "#9999")).toBeNull();
+  });
+});

--- a/web/src/controllers/synthetics.ts
+++ b/web/src/controllers/synthetics.ts
@@ -6,7 +6,12 @@
  */
 
 import { useCallback } from "react";
-import type { Monitor, SyntheticCheck, SyntheticCheckInput } from "@/models";
+import type {
+  Monitor,
+  SyntheticCheck,
+  SyntheticCheckInput,
+  SyntheticRun,
+} from "@/models";
 import { monitorsRepo, syntheticsRepo } from "@/models/repositories";
 import { useRequest } from "./use-request";
 
@@ -76,14 +81,28 @@ export function useSyntheticRunController(
   const check = useRequest(() => syntheticsRepo.get(checkId), [checkId]);
   const runs = useRequest(() => syntheticsRepo.runs(checkId), [checkId]);
   const list = runs.data ?? [];
-  const selected = runId
-    ? (list.find((r) => r.id === runId) ??
-      list.find((r) => String(r.number) === runId.replace(/^#/, "")) ??
-      null)
-    : (list[0] ?? null);
+  const selected = selectRun(list, runId);
   const notFound =
     runId !== null && !runs.loading && list.length > 0 && selected === null;
   return { check, runs, selected, notFound };
+}
+
+/**
+ * Pure `?run=` resolution (extracted for the regression lock): internal id
+ * first, then the visible run number with or without the `#` prefix; null
+ * when nothing matches (the page renders "Run … not found", never the
+ * "No runs yet" empty copy). No `runId` selects the latest run.
+ */
+export function selectRun(
+  list: SyntheticRun[],
+  runId: string | null,
+): SyntheticRun | null {
+  if (!runId) return list[0] ?? null;
+  return (
+    list.find((r) => r.id === runId) ??
+    list.find((r) => String(r.number) === runId.replace(/^#/, "")) ??
+    null
+  );
 }
 
 /**


### PR DESCRIPTION
## Ledger closeout — verify-then-fix (2026-07-21)

Closes the remaining open rows of the Figma↔code convergence ledger. The verification pass found the design/code waves (#179–#189) had already closed nearly every candidate row — this PR locks the one behavior that shipped without a regression test, and the residual canvas work landed directly in Figma (file `F2b1icjCmZp1MvOft6HMCV`).

### Repo change

- **B7 `?run=` deep link — regression lock.** The audit fix (accept internal id OR visible run number; unknown → "Run … not found", never the "No runs yet" empty copy) merged in #181 without a unit lock. The `?run=` resolution is extracted to a pure `selectRun()` (same pattern as `contextMonitorFor`) and locked: latest-when-absent, id hit, `482`/`#482` number hit, unknown → null.

### Canvas change (Figma, already applied + verified)

- **B1 IncidentBanner placement.** Master 48:141 and `B1 — Home` were already converged to the adjudicated hybrid (design.md §8.2: global chrome strip under the TopBar carrying the master's "open 12m" age + "View incident →"/"Postmortem →" link text). The six remaining frames still drew the old in-content placement — re-placed to the chrome strip (x = rail edge, y = 43 under the TopBar, full content width; header row shifted to y=108 to match `B1 — Home`):
  - `B9 — Incidents` (131:3009), `B1 — Home (Light QA)` (133:3952), `B1 — Home (rail expanded)` (286:6, x=240/w=1200 for the expanded rail), `B9 — Declare incident (modal)` (173:5809), `B9 — Incident detail (postmortem)` (382:13253), `B9 — Postmortem composer (modal)` (383:10114).
  - Writes verified by geometry read-back + rendered screenshot.

### Verified already closed (no action)

- B12 usage formatter B-promotion (`fmtCount`, locked in `usage.test.ts`) · B7 `?run=` behavior (#181) · ThemeToggle docstring (absent = dark) · NavRail icons (code + master 284:2 + design.md §8.1 all on the ratified 12-glyph list) · B4 pill grammar (`level:error` on 333:14165 and 128:1236) · `/docs/api` exemplar frames (Dark + Light, Home page) — no §8 docs-exemption needed · status-page builder footnote, usage caption, A14 label-copy link, public-status subline, LogPatternRow single master w/ LevelChip, StatusPageBuilderRow 48px master, footer tagline — all converged on canvas or locked in code by #179–#189.

### Gates

- lint (prettier + eslint + boundaries) ✓ · typecheck ✓ · unit 102 files / 358 tests ✓
- serial e2e: first run (PW_PORT=4414) 65/66 — one env flake (`home.spec` theme persistence hit a dev-server `__next_error__` page during a host memory squeeze; unrelated surface); full re-run (PW_PORT=4418) **66/66 green**, `.last-run.json` status `passed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
