### PR TITLE
fix(web): a11y blockers — pinch-zoom restored, rail links, palette dismissal + focus restore

### DIFF
--- a/docs/web-implementation.md
+++ b/docs/web-implementation.md
@@ -579,6 +579,29 @@ visible in both tab states, so switching never shifts layout. The
 focus, copied-morph reset); e2e: `home.spec.ts` pins helm-tab copy → the
 clipboard payload, caption persistence and the 1440/390 container fit.
 
+**A11y blockers as-built (2026-07-21 audit).** Three contracts hardened:
+
+- **Pinch-zoom stays available.** The root `viewport` export carries no
+  `maximumScale` (the audit's 18/18-route axe `meta-viewport` blocker;
+  siblings' viewport export is the fleet pattern). Locked in
+  `mobile-responsive.spec.ts`.
+- **Rail items are real links.** `NavRailItem` renders a next/link `<a>`
+  when given `href`; `NavRail` takes `hrefFor` (pillar key → route — the
+  shell passes `PILLAR_ROUTES`) so middle-click/new-tab and AT link
+  navigation work. Active semantics (`aria-current="page"`, brand bar)
+  and the expandable-rail behavior are unchanged; `onNavigate` remains
+  for action-only/button fall-back call sites and MUST NOT `router.push`
+  when `hrefFor` is set (the link navigates). The `g …` chords keep their
+  programmatic `router.push` (keyboard.ts). Unit: `NavRail.test.tsx`
+  link-mode lock; e2e: `navrail.spec.ts` navigates by link role + href.
+- **Palette dismissal + focus restore (fleet P4).** `CommandPalette`
+  handles Escape on the dialog container (it was input-only — after Tab
+  to an option the palette was un-dismissable), is announced
+  `aria-modal`, and snapshots the opener on open / refocuses it on close
+  (previously focus fell to `<body>`). Unit: `CommandPalette.test.tsx`;
+  e2e: `focus-restore.spec.ts` (open → Tab inside → Escape → trigger
+  refocused, plus the "/" hotkey path).
+
 ## 3. Token mapping — design.md §2 → `web/src/design/tokens.css`
 
 One custom property per Figma variable in the `upstat/tokens` collection

--- a/web/e2e/dashboard.spec.ts
+++ b/web/e2e/dashboard.spec.ts
@@ -47,7 +47,7 @@ async function signIn(page: Page) {
 async function goTo(page: Page, pillar: string) {
   await page
     .getByRole("navigation", { name: "Product navigation" })
-    .getByRole("button", { name: pillar, exact: true })
+    .getByRole("link", { name: pillar, exact: true })
     .click();
 }
 
@@ -389,7 +389,11 @@ test("full journey: onboarding → B1 → dashboards → explorer → logs → t
   await goTo(page, "Traces");
   await expect(page.getByTestId("apm-services")).toBeVisible();
   await expect(page.getByRole("rowheader", { name: "checkout" })).toBeVisible();
-  await page.getByRole("link", { name: "Traces" }).click();
+  // scoped: the rail's Traces item is a link too (a11y-audit nav semantics)
+  await page
+    .getByRole("navigation", { name: "APM views" })
+    .getByRole("link", { name: "Traces" })
+    .click();
   await page.waitForURL("**/dashboard/traces/explorer**");
   await page.getByTestId("trace-9f86d081").click();
   await expect(page.getByTestId("trace-waterfall")).toBeVisible();

--- a/web/e2e/focus-restore.spec.ts
+++ b/web/e2e/focus-restore.spec.ts
@@ -1,0 +1,54 @@
+// Overlay focus-restore + dismissal canon (2026-07-21 a11y audit, fleet
+// finding P4): closing the command palette must return focus to the element
+// that opened it, and Escape must dismiss from ANYWHERE inside the dialog.
+// Before the fix Escape was bound on the search input only — after Tab
+// moved focus to an option the palette became un-dismissable — and closing
+// dropped focus on <body>. Probe shape: open → move focus inside → Escape →
+// closed AND focus back on the trigger.
+import { expect, test, type Page } from "@playwright/test";
+
+async function signIn(page: Page) {
+  await page.goto("/signin");
+  await page.getByRole("button", { name: /continue with google/i }).click();
+  await page.waitForURL("**/dashboard**");
+  await expect(page.getByTestId("dashboard-home")).toBeVisible();
+}
+
+test("palette: Escape works from an option and focus returns to the trigger", async ({
+  page,
+}) => {
+  await signIn(page);
+  const trigger = page.getByRole("button", { name: "Search" });
+  await trigger.click();
+
+  const palette = page.getByRole("dialog", { name: "Command palette" });
+  await expect(palette).toBeVisible();
+  await expect(palette).toHaveAttribute("aria-modal", "true");
+
+  // Move focus off the search input and onto an option — the audit's
+  // broken case (Escape was a no-op here, stillOpen:true).
+  await page.keyboard.press("Tab");
+  await page.keyboard.press("Escape");
+
+  await expect(palette).toBeHidden();
+  await expect(trigger).toBeFocused();
+});
+
+test('palette: "/" opens it and Escape from the input restores focus too', async ({
+  page,
+}) => {
+  await signIn(page);
+  // Anchor focus somewhere stable first — the pre-open element is the
+  // restore target for the hotkey path.
+  const anchor = page.getByTestId("rail-toggle");
+  await anchor.focus();
+  await expect(anchor).toBeFocused();
+
+  await page.keyboard.press("/");
+  const palette = page.getByRole("dialog", { name: "Command palette" });
+  await expect(palette).toBeVisible();
+
+  await page.keyboard.press("Escape");
+  await expect(palette).toBeHidden();
+  await expect(anchor).toBeFocused();
+});

--- a/web/e2e/mobile-responsive.spec.ts
+++ b/web/e2e/mobile-responsive.spec.ts
@@ -12,6 +12,19 @@ import { expect, test, type Page, type TestInfo } from "@playwright/test";
 const MOBILE = { width: 390, height: 844 };
 const TABLET = { width: 768, height: 1024 };
 
+// Pinch-zoom stays available (2026-07-21 a11y audit blocker: the root
+// viewport export shipped maximumScale:1 — axe meta-viewport on 18/18
+// route-loads; siblings' viewport export is the fleet pattern).
+test("viewport meta never disables pinch-zoom", async ({ page }) => {
+  await page.goto("/");
+  const content = await page
+    .locator('meta[name="viewport"]')
+    .getAttribute("content");
+  expect(content).toContain("width=device-width");
+  expect(content).not.toMatch(/maximum-scale/i);
+  expect(content).not.toMatch(/user-scalable\s*=\s*(no|0)/i);
+});
+
 /** Every route in the web-implementation.md §4 route map (seeded ids §6). */
 const ROUTES = [
   "/",

--- a/web/e2e/navrail.spec.ts
+++ b/web/e2e/navrail.spec.ts
@@ -146,7 +146,7 @@ test("below md, expansion is an overlay drawer — content never squeezes ([Clar
 
   // selecting a pillar navigates AND closes the drawer
   await page.getByTestId("rail-toggle").click();
-  await drawer.getByRole("button", { name: "Logs", exact: true }).click();
+  await drawer.getByRole("link", { name: "Logs", exact: true }).click();
   await page.waitForURL("**/dashboard/logs");
   await expect(drawer).toBeHidden();
 
@@ -162,15 +162,17 @@ test("navigation works at both rail widths (charts unaffected)", async ({
   await page.setViewportSize({ width: 1440, height: 900 });
   await signIn(page);
   // expanded: click by visible label row
-  await rail(page)
-    .getByRole("button", { name: "Dashboards", exact: true })
-    .click();
+  // pillar items are real links (a11y audit) — role + href locked here
+  const dashboards = rail(page).getByRole("link", {
+    name: "Dashboards",
+    exact: true,
+  });
+  await expect(dashboards).toHaveAttribute("href", "/dashboard/dashboards");
+  await dashboards.click();
   await page.waitForURL("**/dashboard/dashboards");
   // collapse and navigate by icon (aria-label)
   await page.getByTestId("rail-toggle").click();
-  await rail(page)
-    .getByRole("button", { name: "Metrics", exact: true })
-    .click();
+  await rail(page).getByRole("link", { name: "Metrics", exact: true }).click();
   await page.waitForURL("**/dashboard/metrics");
   await expect(page.getByTestId("timeseries-plot")).toBeVisible();
 });

--- a/web/e2e/settings-tabs.spec.ts
+++ b/web/e2e/settings-tabs.spec.ts
@@ -119,7 +119,7 @@ test("deep link direct-loads the Usage tab; NavRail stays active on sub-routes",
   await expect(
     page
       .getByRole("navigation", { name: "Product navigation" })
-      .getByRole("button", { name: "Settings" }),
+      .getByRole("link", { name: "Settings" }),
   ).toHaveAttribute("aria-current", "page");
 });
 

--- a/web/src/app/dashboard/shell.tsx
+++ b/web/src/app/dashboard/shell.tsx
@@ -118,9 +118,11 @@ function ShellChrome({ children }: { children: ReactNode }) {
     // (the logs live-tail list, MI-4 pause-on-scroll) get a real overflow
     // boundary instead of growing the body.
     <div className="font-ui flex h-dvh bg-bg text-text">
+      {/* Rail items are real <a> links (a11y audit: middle-click/new-tab,
+          AT link navigation); the g-chords keep router.push (keyboard.ts). */}
       <NavRail
         activeKey={activeKeyFor(pathname)}
-        onNavigate={(key) => router.push(PILLAR_ROUTES[key] ?? "/dashboard")}
+        hrefFor={(key) => PILLAR_ROUTES[key] ?? "/dashboard"}
         userName={userName}
       />
 

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -24,10 +24,12 @@ export const metadata: Metadata = {
   description: "The Upstat Project",
 };
 
+// No maximumScale: pinch-zoom must stay available (2026-07-21 a11y audit
+// blocker — axe meta-viewport on every route; siblings' viewport export is
+// the fleet pattern).
 export const viewport: Viewport = {
   width: "device-width",
   initialScale: 1,
-  maximumScale: 1,
 };
 
 export default function RootLayout({

--- a/web/src/components/ui/CommandPalette.test.tsx
+++ b/web/src/components/ui/CommandPalette.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { useState } from "react";
 import { CommandPalette } from "./CommandPalette";
 
 const ITEMS = [
@@ -32,5 +33,44 @@ describe("CommandPalette", () => {
     render(<CommandPalette open onClose={() => undefined} items={ITEMS} />);
     await userEvent.type(screen.getByLabelText("Search"), "zzz");
     expect(screen.getByText(/No results for/)).toBeInTheDocument();
+  });
+
+  // 2026-07-21 a11y audit: Escape was bound on the search input only —
+  // once focus moved to an option the palette became un-dismissable.
+  it("Escape closes from anywhere inside the dialog", async () => {
+    const onClose = vi.fn();
+    render(<CommandPalette open onClose={onClose} items={ITEMS} />);
+    const option = screen.getByRole("option", { name: /Service overview/ });
+    option.focus();
+    await userEvent.keyboard("{Escape}");
+    expect(onClose).toHaveBeenCalled();
+    expect(
+      screen.getByRole("dialog", { name: "Command palette" }),
+    ).toHaveAttribute("aria-modal", "true");
+  });
+
+  it("returns focus to the opener on close (fleet P4)", async () => {
+    function Harness() {
+      const [open, setOpen] = useState(false);
+      return (
+        <>
+          <button onClick={() => setOpen(true)}>Open palette</button>
+          <CommandPalette
+            open={open}
+            onClose={() => setOpen(false)}
+            items={ITEMS}
+          />
+        </>
+      );
+    }
+    render(<Harness />);
+    const opener = screen.getByRole("button", { name: "Open palette" });
+    await userEvent.click(opener);
+    expect(screen.getByLabelText("Search")).toHaveFocus();
+    await userEvent.keyboard("{Escape}");
+    expect(
+      screen.queryByRole("dialog", { name: "Command palette" }),
+    ).toBeNull();
+    expect(opener).toHaveFocus();
   });
 });

--- a/web/src/components/ui/CommandPalette.tsx
+++ b/web/src/components/ui/CommandPalette.tsx
@@ -33,6 +33,11 @@ export function CommandPalette({
   const [query, setQuery] = useState("");
   const [active, setActive] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
+  // Focus restore (2026-07-21 a11y audit, fleet P4): the palette opens
+  // programmatically ("/" or the TopBar search button), so closing must
+  // hand focus back to whatever element had it before the input grabbed
+  // focus — previously it fell to <body>.
+  const returnFocusRef = useRef<HTMLElement | null>(null);
 
   const results = useMemo(
     () =>
@@ -54,8 +59,20 @@ export function CommandPalette({
     }
   }
 
+  // Opening snapshots the opener before the input grabs focus; closing
+  // sends focus back once the palette's DOM is gone.
   useEffect(() => {
-    if (open) inputRef.current?.focus();
+    if (open) {
+      returnFocusRef.current =
+        document.activeElement instanceof HTMLElement
+          ? document.activeElement
+          : null;
+      inputRef.current?.focus();
+    } else {
+      const opener = returnFocusRef.current;
+      returnFocusRef.current = null;
+      if (opener?.isConnected) opener.focus();
+    }
   }, [open]);
 
   if (!open) return null;
@@ -68,8 +85,15 @@ export function CommandPalette({
     >
       <div
         role="dialog"
+        aria-modal="true"
         aria-label="Command palette"
         onClick={(e) => e.stopPropagation()}
+        // Escape dismisses from ANYWHERE inside the dialog (2026-07-21
+        // a11y audit: it was bound on the search input only, so after Tab
+        // moved focus to an option Escape did nothing).
+        onKeyDown={(e) => {
+          if (e.key === "Escape") onClose();
+        }}
         className={clsx(
           "font-ui w-[560px] overflow-hidden rounded-(--radius) border border-border bg-bg-elev shadow-xl",
           className,
@@ -85,7 +109,6 @@ export function CommandPalette({
               setActive(0);
             }}
             onKeyDown={(e) => {
-              if (e.key === "Escape") onClose();
               if (e.key === "ArrowDown") {
                 e.preventDefault();
                 setActive((a) => Math.min(a + 1, results.length - 1));

--- a/web/src/components/ui/NavRail.test.tsx
+++ b/web/src/components/ui/NavRail.test.tsx
@@ -30,6 +30,29 @@ describe("NavRail", () => {
     expect(onNavigate).toHaveBeenCalledWith("monitors");
   });
 
+  it("renders real <a> links when hrefFor maps routes (2026-07-21 a11y audit)", () => {
+    // Nav destinations are links, not buttons: middle-click/new-tab and
+    // AT link navigation work; active semantics stay on the anchor.
+    render(
+      <NavRail
+        activeKey="logs"
+        hrefFor={(key) => `/dashboard/${key}`}
+        onNavigate={vi.fn()}
+      />,
+    );
+    for (const pillar of NAV_PILLARS) {
+      expect(screen.getByRole("link", { name: pillar.label })).toHaveAttribute(
+        "href",
+        `/dashboard/${pillar.key}`,
+      );
+    }
+    expect(screen.getByRole("link", { name: "Logs" })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+    expect(screen.queryByRole("button", { name: "Logs" })).toBeNull();
+  });
+
   /* [Directive 2026-07-19] expandable rail — design.md §2 */
 
   it("sections cover every pillar in B order (Telemetry/Respond/Platform)", () => {

--- a/web/src/components/ui/NavRail.tsx
+++ b/web/src/components/ui/NavRail.tsx
@@ -19,6 +19,7 @@ import {
   Target,
 } from "lucide-react";
 import * as Dialog from "@radix-ui/react-dialog";
+import Link from "next/link";
 import { useEffect, useState } from "react";
 import { useMediaQuery } from "@/controllers/use-media-query";
 import { Avatar } from "./Avatar";
@@ -28,6 +29,10 @@ export interface NavRailItemProps {
   icon: LucideIcon;
   label: string;
   active?: boolean;
+  /** Route target — renders a real <a> (next/link). Nav destinations are
+   *  links, not buttons (2026-07-21 a11y audit: middle-click/new-tab and
+   *  AT link navigation; siblings' rails are the pattern). Omit only for
+   *  genuinely action-only items. */
   href?: string;
   onClick?: () => void;
   /** layout=expanded — icon + inline label row, no flyout (design.md §2
@@ -40,45 +45,67 @@ export interface NavRailItemProps {
  * NavRailItem — §8.2b: default / hover (flyout label) / active (brand
  * accent bar + brand icon, both layouts). `expanded` renders the 228px
  * icon+label row ([Directive 2026-07-19]); collapsed keeps the flyout.
+ * With `href` it renders a next/link <a>; otherwise a <button>.
  */
 export function NavRailItem({
   icon: Icon,
   label,
   active = false,
+  href,
   onClick,
   expanded = false,
 }: NavRailItemProps) {
   const [hover, setHover] = useState(false);
+  const itemClass = clsx(
+    "relative flex h-10 items-center rounded-(--radius)",
+    expanded ? "w-full gap-3 px-2.5 text-left" : "size-10 justify-center",
+    "transition-colors duration-[var(--duration-fast)] ease-standard",
+    active
+      ? "bg-brand/15 text-brand"
+      : "text-text-2 hover:bg-bg-elev hover:text-text",
+  );
+  const itemBody = (
+    <>
+      {/* active = brand accent bar + brand icon in both states (§2) */}
+      {active && (
+        <span
+          aria-hidden="true"
+          className="absolute inset-y-2 left-0 w-0.5 rounded-full bg-brand"
+        />
+      )}
+      <Icon className="size-5 shrink-0" strokeWidth={active ? 2.2 : 2} />
+      {expanded && (
+        <span className="truncate text-[13px] font-medium">{label}</span>
+      )}
+    </>
+  );
   return (
     <div className="relative">
-      <button
-        type="button"
-        aria-label={label}
-        aria-current={active ? "page" : undefined}
-        onClick={onClick}
-        onMouseEnter={() => setHover(true)}
-        onMouseLeave={() => setHover(false)}
-        className={clsx(
-          "relative flex h-10 items-center rounded-(--radius)",
-          expanded ? "w-full gap-3 px-2.5 text-left" : "size-10 justify-center",
-          "transition-colors duration-[var(--duration-fast)] ease-standard",
-          active
-            ? "bg-brand/15 text-brand"
-            : "text-text-2 hover:bg-bg-elev hover:text-text",
-        )}
-      >
-        {/* active = brand accent bar + brand icon in both states (§2) */}
-        {active && (
-          <span
-            aria-hidden="true"
-            className="absolute inset-y-2 left-0 w-0.5 rounded-full bg-brand"
-          />
-        )}
-        <Icon className="size-5 shrink-0" strokeWidth={active ? 2.2 : 2} />
-        {expanded && (
-          <span className="truncate text-[13px] font-medium">{label}</span>
-        )}
-      </button>
+      {href ? (
+        <Link
+          href={href}
+          aria-label={label}
+          aria-current={active ? "page" : undefined}
+          onClick={onClick}
+          onMouseEnter={() => setHover(true)}
+          onMouseLeave={() => setHover(false)}
+          className={itemClass}
+        >
+          {itemBody}
+        </Link>
+      ) : (
+        <button
+          type="button"
+          aria-label={label}
+          aria-current={active ? "page" : undefined}
+          onClick={onClick}
+          onMouseEnter={() => setHover(true)}
+          onMouseLeave={() => setHover(false)}
+          className={itemClass}
+        >
+          {itemBody}
+        </button>
+      )}
       {!expanded && hover && (
         <span
           role="tooltip"
@@ -185,6 +212,12 @@ function useRailExpanded(): [boolean, () => void] {
 
 export interface NavRailProps {
   activeKey: string;
+  /** Pillar key → route. When provided, items render real <a> links
+   *  (next/link) — the a11y-audit nav semantics; clicks still close the
+   *  <md overlay drawer. */
+  hrefFor?: (key: string) => string | undefined;
+  /** Selection callback. With `hrefFor` the link handles navigation and
+   *  this (if given) is side-effects only — don't router.push from it. */
   onNavigate?: (key: string) => void;
   /** Signed-in user for the foot avatar (master 284:2 foot construction). */
   userName?: string | null;
@@ -197,6 +230,7 @@ export interface NavRailProps {
 function RailBody({
   expanded,
   activeKey,
+  hrefFor,
   onSelect,
   footLabel,
   footExpanded,
@@ -206,6 +240,7 @@ function RailBody({
 }: {
   expanded: boolean;
   activeKey: string;
+  hrefFor?: (key: string) => string | undefined;
   onSelect: (key: string) => void;
   footLabel: string;
   footExpanded: boolean;
@@ -256,6 +291,7 @@ function RailBody({
                 label={pillar.label}
                 active={pillar.key === activeKey}
                 expanded={expanded}
+                href={hrefFor?.(pillar.key)}
                 onClick={() => onSelect(pillar.key)}
               />
             );
@@ -314,6 +350,7 @@ function RailBody({
  */
 export function NavRail({
   activeKey,
+  hrefFor,
   onNavigate,
   userName,
   className,
@@ -347,6 +384,7 @@ export function NavRail({
         <RailBody
           expanded={inlineExpanded}
           activeKey={activeKey}
+          hrefFor={hrefFor}
           onSelect={(key) => onNavigate?.(key)}
           footLabel={
             inlineExpanded ? "Collapse navigation" : "Expand navigation"
@@ -384,6 +422,7 @@ export function NavRail({
             <RailBody
               expanded
               activeKey={activeKey}
+              hrefFor={hrefFor}
               onSelect={select}
               footLabel="Close navigation"
               footTestId="rail-drawer-close"


### PR DESCRIPTION
## What

Fleet a11y-blocker wave (adjudicated 2026-07-21 audit), upstat slice — findings P1 (viewport), P5 (nav semantics), P4 (focus restore) + the upstat-specific palette dismissal bug.

| Fix | Where | Before (audit) | After |
|---|---|---|---|
| Pinch-zoom restored | `src/app/layout.tsx` — `maximumScale: 1` deleted from the viewport export | axe `meta-viewport` on **18/18 route-loads**; live LH a11y 92 flag | viewport meta carries no `maximum-scale`; e2e-locked |
| Rail pillars are real links | `ui/NavRail.tsx` (`NavRailItem` renders next/link `<a>` via new `hrefFor`), `dashboard/shell.tsx` passes `PILLAR_ROUTES` | 12 nav items were `<button>`s — no href, no middle-click/new-tab, invisible to AT link navigation | `<a href>` with `aria-current="page"`; active styling, flyouts, expandable rail, overlay drawer and `g …` chords unchanged (rail e2e green throughout) |
| Palette dismissable from anywhere | `ui/CommandPalette.tsx` — Escape moved from the input's keydown to the dialog container | after Tab to an option, **Escape did nothing** (probe `stillOpen:true`); `aria-modal` absent | Escape closes from any inner element; `aria-modal="true"` |
| Palette focus restore (P4) | same | close dropped focus on `<body>` | opener snapshotted on open, refocused on close |

## axe delta

- Before: moderate `meta-viewport` ×18/18 route-loads (the repo's only axe blocker class; upstat had 0 criticals).
- After: viewport meta clean — locked by the new `mobile-responsive.spec.ts` assertion (verified red against the unfixed layout). Serious light-theme color-contrast rows are token work (P2), tracked separately.

## Locks (all verified red against the unfixed code)

- e2e `focus-restore.spec.ts` — org P4 probe: open (TopBar Search button) → **Tab to an option** → Escape closes → focus back on the trigger; plus the `/` hotkey path restoring to the pre-open element.
- e2e `mobile-responsive.spec.ts` — served viewport meta never carries `maximum-scale` / `user-scalable=no`.
- Unit `NavRail.test.tsx` — link mode: all 12 pillars render `role=link` with hrefs, `aria-current="page"` on the active one; button fallback locked for action-only call sites. Unit `CommandPalette.test.tsx` — Escape-from-option + focus-restore harness.
- e2e `navrail.spec.ts` — navigates by link role, pins the Dashboards href; full expandable-rail suite (defaults, persistence, drawer, both widths) green — the rail's behavior did not regress.

Note: journey/settings e2e selectors that assumed rail *buttons* were updated to link role, and the APM-views "Traces" tab selector is now scoped to its own `<nav>` (the rail's Traces link made the bare name ambiguous).

## Gates (all green)

prettier ✓ · eslint ✓ · boundaries ✓ (376 files) · typecheck ✓ · vitest 361/361 ✓ · next build ✓ · Playwright **69/69** ✓ (PW_PORT=4428)

Docs: `docs/web-implementation.md` — a11y-blockers as-built note (viewport contract, rail link semantics + `hrefFor`, palette dismissal/focus contract).

🤖 Generated with [Claude Code](https://claude.com/claude-code)