### PR TITLE
fix(web): contrast-token canon — AA `-text` variants + the `on-crit` token

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -42,11 +42,14 @@
 | `text-2` | #6B6F7B | #9BA0AC | secondary |
 | `brand` | #00E09E | #00E09E | nav, CTAs, focus (sampled from the landing) |
 | `brand-deep` | #00A991 | #00A991 | hover/active brand states, secondary accents |
-| `on-brand` | #0E1113 | #0E1113 | labels/knobs on `brand` fills **only** — **[Decided 2026-07-16]** dark ink in *both* modes (brand teal is bright; fixes the light-mode white-on-teal contrast flag). **[Decided 2026-07-17]** destructive-fill labels stay raw `#FFFFFF` pending a possible `on-crit` token — `on-brand` does not extend to `crit` fills (matches the built destructive Button; recorded so docs and build no longer diverge silently) |
+| `on-brand` | #0E1113 | #0E1113 | labels/knobs on `brand` fills **only** — **[Decided 2026-07-16]** dark ink in *both* modes (brand teal is bright; fixes the light-mode white-on-teal contrast flag). `on-brand` does not extend to `crit` fills — those bind `on-crit` |
+| `on-crit` | #FFFFFF | #0E1113 | labels on `crit` fills (destructive Button, SevChip SEV-1, CountBadge) — white clears AA on the light crit fill (4.98) but not the dark one (3.03 on #FF5C5C), so dark uses the `on-brand` ink (6.26) |
 | `ok` | #2E9950 | #3DCC70 | up / passing |
 | `warn` | #C77D00 | #FFB020 | degraded / warn thresholds |
 | `crit` | #D32F2F | #FF5C5C | down / alerting |
 | `nodata` | #9AA0AA | #5C6270 | no data / muted monitors |
+| `brand-text` | #097955 | #00E09E | AA text variant — readable brand text (links, active nav/tabs, chip labels, INFO level) binds this; fills/borders/dots/icons/focus rings keep `brand`. Light darkens `brand` in OKLCH (L only) until ≥4.5:1 on the tinted recipe (`text-X` on `bg-X/10–15`); dark base already clears AA, so dark aliases it |
+| `ok-text/warn-text/crit-text/nodata-text/text-2-text` | #047634 / #925B03 / #C31A21 / #646A73 / #616571 | #3DCC70 / #FFB020 / #FF5C5C / #868D9C / #9BA0AC | AA text variants for status text and the chip/pill recipe (StatusPill, LevelChip, AlertFeedRow, IncidentHistoryEntry, ok/15 chips) — readable text binds the `-text` variant, fills/dots keep the base. Light values darken the base in OKLCH until ≥4.5:1 on the /14–/15 tints; dark bases already pass except `nodata`, which lightens (its `-text` is the one dark divergence) |
 | Series palette | 8-step categorical **[Decided]**: `#7C6CF0 #00B4D8 #F4A259 #E86A92 #43AA8B #B5179E #FFCA3A #4361EE` (validated ≥3:1 against both `bg` values; colorblind-checked) | same | charts; series→color stable per view session |
 
 Status semantics are sacred: `ok/warn/crit/nodata` colors are reserved — never
@@ -244,9 +247,8 @@ styles); the remaining iteration is the Style Guide *page* refresh below.
 
 Additions (2026-07-16): (1) the new `on-brand` token (§2) now exists in the
 `upstat/tokens` collection — components placing labels/knobs on `brand`
-fills bind it instead of a raw ink (**[Decided 2026-07-17]** `on-brand`
-applies to brand fills only; destructive-fill labels stay raw `#FFFFFF`
-pending a possible `on-crit` token — see §2). (2) OpenType tabular figures
+fills bind it instead of a raw ink (`on-brand` applies to brand fills only;
+destructive-fill labels bind `on-crit` — see §2). (2) OpenType tabular figures
 (`tnum`) must be enabled **manually** on numeric text styles in the Figma UI —
 the plugin API cannot set font features — so the §2 "tabular figures in all
 numeric contexts" rule is applied by hand when each numeric type style is
@@ -347,7 +349,7 @@ never on screens. A screen frame must read as the shipped product would.
 
 | Component | Variants × states |
 | --- | --- |
-| Button | kind: brand / quiet / destructive × state: default / hover / disabled — destructive labels raw `#FFFFFF` per the §2 `on-crit` decision |
+| Button | kind: brand / quiet / destructive × state: default / hover / disabled — destructive labels bind `on-crit` (§2) |
 | Input | state: default / focus / error / disabled |
 | Toast | kind: info / success / error |
 | QueryPill | state: default / hover |

--- a/docs/web-implementation.md
+++ b/docs/web-implementation.md
@@ -642,8 +642,10 @@ reload persistence.
 Notes: status semantics are sacred — `ok/warn/crit/nodata` are reserved for
 state, never decoration, and `ok` stays visually distinct from `brand`
 (design.md §2). `--on-brand` is dark ink in **both** modes and applies to
-`brand` fills only — destructive-fill labels stay raw `#FFFFFF` pending a
-possible `on-crit` token **[Decided 2026-07-17]**; that raw white is the
+`brand` fills only — destructive-fill labels bind `--on-crit` (white in
+light, `on-brand` ink in dark, §2). Readable text in a status/brand hue
+binds the `--<hue>-text` AA variant; fills/borders/dots/icons keep the
+base hue (§2). The GoogleAuthButton's brand-mandated chrome is the
 canonical example of a documented no-raw-hex exception (code comment
 required, §1). Type ramp (11/12/13/14/16/20/24–32) and fonts live in the
 Tailwind theme, not tokens.css; tabular numerals

--- a/web/e2e/contrast-tokens.spec.ts
+++ b/web/e2e/contrast-tokens.spec.ts
@@ -1,0 +1,281 @@
+// Contrast-token lock (design.md §2 AA text variants + on-crit) —
+// recomputes the 2026-07-21 audit's failing pairs from the SERVED CSS
+// (custom-property values off the live document, both themes) and asserts
+// WCAG AA. The tinted-chip recipe (`text-X` on `bg-X/10–15`), brand/status
+// text, and crit-fill labels must stay ≥4.5:1; rendered sweeps lock the
+// PUBLIC status-page pills (both themes) and the dark SEV-1 badge.
+import { expect, test, type Locator, type Page } from "@playwright/test";
+
+const AA = 4.5;
+
+// ---- WCAG 2.x math over sRGB --------------------------------------------
+type Rgb = { r: number; g: number; b: number };
+
+function hexToRgb(hex: string): Rgb {
+  const h = hex.trim().replace("#", "");
+  const v =
+    h.length === 3
+      ? h
+          .split("")
+          .map((c) => c + c)
+          .join("")
+      : h;
+  return {
+    r: parseInt(v.slice(0, 2), 16),
+    g: parseInt(v.slice(2, 4), 16),
+    b: parseInt(v.slice(4, 6), 16),
+  };
+}
+
+function luminance({ r, g, b }: Rgb): number {
+  const lin = (c: number) => {
+    const s = c / 255;
+    return s <= 0.04045 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+  };
+  return 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b);
+}
+
+function contrast(a: Rgb, b: Rgb): number {
+  const [lo, hi] = [luminance(a), luminance(b)].sort((x, y) => x - y);
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+/** `bg-X/nn` composited over an opaque base (what the browser paints). */
+function tint(hue: Rgb, alpha: number, base: Rgb): Rgb {
+  const mix = (f: number, g: number) => Math.round(alpha * f + (1 - alpha) * g);
+  return {
+    r: mix(hue.r, base.r),
+    g: mix(hue.g, base.g),
+    b: mix(hue.b, base.b),
+  };
+}
+
+// ---- served-CSS readers ---------------------------------------------------
+async function readTokens(
+  page: Page,
+  theme: "light" | "dark",
+  names: string[],
+): Promise<Record<string, Rgb>> {
+  const raw = await page.evaluate(
+    ({ t, ns }: { t: string; ns: string[] }) => {
+      document.documentElement.setAttribute("data-theme", t);
+      const cs = getComputedStyle(document.documentElement);
+      return Object.fromEntries(
+        ns.map((n) => [n, cs.getPropertyValue(n).trim()]),
+      );
+    },
+    { t: theme, ns: names },
+  );
+  const out: Record<string, Rgb> = {};
+  for (const [name, value] of Object.entries(raw)) {
+    // The dev server may serve minified hex (#fff) — accept both forms.
+    expect(value, `${name} is declared in the served CSS (${theme})`).toMatch(
+      /^#([0-9a-f]{3}|[0-9a-f]{6})$/i,
+    );
+    out[name] = hexToRgb(value);
+  }
+  return out;
+}
+
+const TOKENS = [
+  "--color-bg",
+  "--color-bg-elev",
+  "--color-brand",
+  "--color-on-brand",
+  "--color-ok",
+  "--color-warn",
+  "--color-crit",
+  "--color-nodata",
+  "--color-text-2",
+  "--color-on-crit",
+  "--color-brand-text",
+  "--color-ok-text",
+  "--color-warn-text",
+  "--color-crit-text",
+  "--color-nodata-text",
+  "--color-text-2-text",
+];
+
+test("§2 token pairs recomputed from served CSS clear WCAG AA in both themes", async ({
+  page,
+}) => {
+  await page.goto("/signin");
+  for (const theme of ["dark", "light"] as const) {
+    const t = await readTokens(page, theme, TOKENS);
+    const cases: Array<{ name: string; fg: Rgb; bg: Rgb }> = [];
+    const surfaces = ["--color-bg", "--color-bg-elev"] as const;
+
+    // Tinted-recipe pairs: the `-text` label on every alpha its hue ships
+    // with (StatusPill/LevelChip/AlertFeedRow /14, NavRail /15, ok-chips
+    // /15, CountBadge /12, WidgetTypeCell-SavedViewChip-IncidentHistory
+    // /10, QueryValue /8), over both surfaces.
+    const recipes: Array<[string, string, number[]]> = [
+      ["--color-brand-text", "--color-brand", [0.1, 0.12, 0.14, 0.15]],
+      ["--color-ok-text", "--color-ok", [0.1, 0.14, 0.15]],
+      ["--color-warn-text", "--color-warn", [0.1, 0.14]],
+      ["--color-crit-text", "--color-crit", [0.08, 0.1, 0.14, 0.15]],
+      ["--color-nodata-text", "--color-nodata", [0.14]],
+      ["--color-text-2-text", "--color-text-2", [0.14]],
+    ];
+    for (const [fg, hue, alphas] of recipes) {
+      for (const alpha of alphas) {
+        for (const surface of surfaces) {
+          cases.push({
+            name: `${fg} on ${hue}/${alpha * 100} over ${surface}`,
+            fg: t[fg],
+            bg: tint(t[hue], alpha, t[surface]),
+          });
+        }
+      }
+    }
+
+    // Plain status/brand text on the page surfaces.
+    for (const fg of [
+      "--color-brand-text",
+      "--color-ok-text",
+      "--color-warn-text",
+      "--color-crit-text",
+      "--color-nodata-text",
+      "--color-text-2-text",
+    ]) {
+      for (const surface of surfaces) {
+        cases.push({ name: `${fg} on ${surface}`, fg: t[fg], bg: t[surface] });
+      }
+    }
+
+    // Fill labels: on-crit on the crit fill (destructive Button, SEV-1,
+    // CountBadge) and the standing on-brand pairs (§2 decisions).
+    cases.push({
+      name: "--color-on-crit on --color-crit fill",
+      fg: t["--color-on-crit"],
+      bg: t["--color-crit"],
+    });
+    cases.push({
+      name: "--color-on-brand on --color-brand fill",
+      fg: t["--color-on-brand"],
+      bg: t["--color-brand"],
+    });
+    cases.push({
+      name: "--color-on-brand on --color-warn fill (SEV-2)",
+      fg: t["--color-on-brand"],
+      bg: t["--color-warn"],
+    });
+
+    for (const c of cases) {
+      const ratio = contrast(c.fg, c.bg);
+      expect
+        .soft(ratio, `${theme}: ${c.name} ≥ ${AA} (got ${ratio.toFixed(2)})`)
+        .toBeGreaterThanOrEqual(AA);
+    }
+  }
+});
+
+// ---- rendered helpers -------------------------------------------------------
+type Rendered = { label: string; ratio: number } | null;
+
+async function renderedRatio(el: Locator): Promise<Rendered> {
+  return el.evaluate((node) => {
+    type C = { r: number; g: number; b: number; a: number };
+    const parse = (s: string): C => {
+      const m = s.match(/rgba?\(([^)]+)\)/);
+      if (!m) return { r: 0, g: 0, b: 0, a: 0 };
+      const [r, g, b, a = "1"] = m[1].split(/[,/ ]+/).filter(Boolean);
+      return { r: Number(r), g: Number(g), b: Number(b), a: Number(a) };
+    };
+    const over = (top: C, base: C): C => ({
+      r: top.r * top.a + base.r * (1 - top.a),
+      g: top.g * top.a + base.g * (1 - top.a),
+      b: top.b * top.a + base.b * (1 - top.a),
+      a: 1,
+    });
+    const layers: C[] = [];
+    let n: Element | null = node;
+    let opaque = false;
+    while (n) {
+      const bg = parse(getComputedStyle(n).backgroundColor);
+      if (bg.a > 0) layers.push(bg);
+      if (bg.a >= 1) {
+        opaque = true;
+        break;
+      }
+      n = n.parentElement;
+    }
+    if (!opaque)
+      layers.push(parse(getComputedStyle(document.body).backgroundColor));
+    let backdrop = layers[layers.length - 1];
+    for (let j = layers.length - 2; j >= 0; j--) {
+      backdrop = over(layers[j], backdrop);
+    }
+    const fg = parse(getComputedStyle(node).color);
+    if (fg.a < 1) return null;
+    const lum = (c: C) => {
+      const lin = (v: number) => {
+        const s = v / 255;
+        return s <= 0.04045 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+      };
+      return 0.2126 * lin(c.r) + 0.7152 * lin(c.g) + 0.0722 * lin(c.b);
+    };
+    const [lo, hi] = [lum(fg), lum(backdrop)].sort((x, y) => x - y);
+    return {
+      label: (node.textContent ?? "").trim().slice(0, 24),
+      ratio: (hi + 0.05) / (lo + 0.05),
+    };
+  });
+}
+
+// ---- rendered surface: PUBLIC status page pills, both themes ---------------
+test("public status page pills render ≥4.5:1 in both themes (served pages)", async ({
+  page,
+}) => {
+  await page.goto("/status/upstat");
+  const pills = page.locator("span[data-status]");
+  await pills.first().waitFor({ state: "visible", timeout: 15_000 });
+
+  for (const theme of ["dark", "light"] as const) {
+    await page.evaluate(
+      (t) => document.documentElement.setAttribute("data-theme", t),
+      theme,
+    );
+    const count = await pills.count();
+    expect(count, "status page renders status pills").toBeGreaterThan(0);
+    for (let i = 0; i < count; i++) {
+      const result = await renderedRatio(pills.nth(i));
+      if (result === null) continue;
+      expect
+        .soft(
+          result.ratio,
+          `${theme}: status pill "${result.label}" renders ≥ ${AA} (got ${result.ratio.toFixed(2)})`,
+        )
+        .toBeGreaterThanOrEqual(AA);
+    }
+  }
+});
+
+// ---- rendered surface: SEV badges in dark theme (the on-crit fix) ----------
+test("incident SEV badges render ≥4.5:1 in dark theme (served pages)", async ({
+  page,
+}) => {
+  await page.goto("/signin");
+  await page.getByRole("button", { name: /continue with google/i }).click();
+  await page.waitForURL("**/dashboard**");
+  await page.goto("/dashboard/incidents");
+  await page.evaluate(() =>
+    document.documentElement.setAttribute("data-theme", "dark"),
+  );
+
+  const chips = page.locator("[data-sev]");
+  await chips.first().waitFor({ state: "visible", timeout: 15_000 });
+  const count = await chips.count();
+  expect(count, "incidents page renders SEV chips").toBeGreaterThan(0);
+
+  for (let i = 0; i < count; i++) {
+    const result = await renderedRatio(chips.nth(i));
+    if (result === null) continue;
+    expect
+      .soft(
+        result.ratio,
+        `dark: SEV chip "${result.label}" renders ≥ ${AA} (got ${result.ratio.toFixed(2)})`,
+      )
+      .toBeGreaterThanOrEqual(AA);
+  }
+});

--- a/web/src/app/dashboard/dashboards/[id]/page.tsx
+++ b/web/src/app/dashboard/dashboards/[id]/page.tsx
@@ -153,7 +153,7 @@ export default function DashboardViewPage() {
           {ctrl.savedPulse && (
             <span
               data-testid="saved-chip"
-              className="rounded-(--radius) bg-ok/15 px-2 py-0.5 text-[12px] text-ok"
+              className="rounded-(--radius) bg-ok/15 px-2 py-0.5 text-[12px] text-ok-text"
             >
               Saved
             </span>

--- a/web/src/app/dashboard/incidents/page.tsx
+++ b/web/src/app/dashboard/incidents/page.tsx
@@ -64,8 +64,8 @@ export default function IncidentsPage() {
                 <span
                   className={
                     incident.status === "resolved"
-                      ? "text-[12px] uppercase tracking-wide text-ok"
-                      : "text-[12px] uppercase tracking-wide text-warn"
+                      ? "text-[12px] uppercase tracking-wide text-ok-text"
+                      : "text-[12px] uppercase tracking-wide text-warn-text"
                   }
                 >
                   {incident.status}

--- a/web/src/app/dashboard/logs/page.tsx
+++ b/web/src/app/dashboard/logs/page.tsx
@@ -244,7 +244,7 @@ export default function LogsPage() {
                 data-testid={`logs-tab-${value}`}
                 className={
                   tab === value
-                    ? "-mb-px border-b-2 border-brand pb-2 text-[13px] font-medium text-brand"
+                    ? "-mb-px border-b-2 border-brand pb-2 text-[13px] font-medium text-brand-text"
                     : "pb-2 text-[13px] text-text-2 transition-colors duration-[var(--duration-fast)] hover:text-text"
                 }
               >

--- a/web/src/app/dashboard/monitors/[id]/page.tsx
+++ b/web/src/app/dashboard/monitors/[id]/page.tsx
@@ -52,7 +52,7 @@ export default function RuleReplayPage() {
           Rule not found.{" "}
           <Link
             href="/dashboard/monitors"
-            className="text-brand hover:underline"
+            className="text-brand-text hover:underline"
           >
             Back to monitors
           </Link>
@@ -121,7 +121,7 @@ export default function RuleReplayPage() {
               Replay — last 24h
             </h2>
             {testResult && (
-              <span className="rounded-full border border-warn px-2.5 py-0.5 text-[12px] text-warn">
+              <span className="rounded-full border border-warn px-2.5 py-0.5 text-[12px] text-warn-text">
                 would have fired ×{testResult.would_have_fired}
               </span>
             )}

--- a/web/src/app/dashboard/monitors/new/page.tsx
+++ b/web/src/app/dashboard/monitors/new/page.tsx
@@ -89,7 +89,7 @@ export default function NewMonitorPage() {
             className={clsx(
               "rounded-full border px-3 py-1.5 text-[13px] transition-colors duration-[var(--duration-fast)]",
               signal === s
-                ? "border-brand text-brand"
+                ? "border-brand text-brand-text"
                 : "border-border text-text-2 hover:text-text",
             )}
           >

--- a/web/src/app/dashboard/monitors/rule-editor.tsx
+++ b/web/src/app/dashboard/monitors/rule-editor.tsx
@@ -240,7 +240,7 @@ export function RuleEditor({
             Thresholds · evaluation window
           </legend>
           <label className="flex min-w-0 flex-col gap-1 text-[13px]">
-            <span className="text-warn">warn &gt;</span>
+            <span className="text-warn-text">warn &gt;</span>
             <Input
               mono
               value={warn}
@@ -291,7 +291,9 @@ export function RuleEditor({
                   {ch.target}
                 </span>
                 {ch.health !== "verified" && (
-                  <span className="text-[11px] text-warn">({ch.health})</span>
+                  <span className="text-[11px] text-warn-text">
+                    ({ch.health})
+                  </span>
                 )}
               </li>
             ))}

--- a/web/src/app/dashboard/page-tabs.tsx
+++ b/web/src/app/dashboard/page-tabs.tsx
@@ -21,7 +21,7 @@ export function PageTabs({ tabs, label }: { tabs: PageTab[]; label: string }) {
           className={clsx(
             "text-[13px] transition-colors duration-[var(--duration-fast)]",
             tab.active
-              ? "font-medium text-brand"
+              ? "font-medium text-brand-text"
               : "text-text-2 hover:text-text",
           )}
         >

--- a/web/src/app/dashboard/page.tsx
+++ b/web/src/app/dashboard/page.tsx
@@ -58,7 +58,7 @@ export default function DashboardHomePage() {
               <button
                 type="button"
                 onClick={() => router.push("/dashboard/dashboards")}
-                className="text-brand hover:underline"
+                className="text-brand-text hover:underline"
               >
                 create your first dashboard
               </button>
@@ -126,7 +126,7 @@ export default function DashboardHomePage() {
             <button
               type="button"
               onClick={() => router.push("/dashboard/slos")}
-              className="text-brand hover:underline"
+              className="text-brand-text hover:underline"
             >
               define your first SLO
             </button>

--- a/web/src/app/dashboard/rum/new/page.tsx
+++ b/web/src/app/dashboard/rum/new/page.tsx
@@ -91,7 +91,7 @@ export default function RumNewPropertyPage() {
                   <>
                     <span
                       data-testid="property-verified"
-                      className="inline-flex items-center gap-1.5 rounded-full bg-ok/15 px-2.5 py-1 text-[12px] text-ok"
+                      className="inline-flex items-center gap-1.5 rounded-full bg-ok/15 px-2.5 py-1 text-[12px] text-ok-text"
                     >
                       <span
                         aria-hidden="true"

--- a/web/src/app/dashboard/services/page.tsx
+++ b/web/src/app/dashboard/services/page.tsx
@@ -102,7 +102,7 @@ export default function ServiceCatalogPage() {
                     href={selected.links.repo}
                     target="_blank"
                     rel="noreferrer"
-                    className="text-brand hover:underline"
+                    className="text-brand-text hover:underline"
                   >
                     repo
                   </a>
@@ -114,7 +114,7 @@ export default function ServiceCatalogPage() {
                       href={selected.links.runbook}
                       target="_blank"
                       rel="noreferrer"
-                      className="text-brand hover:underline"
+                      className="text-brand-text hover:underline"
                     >
                       runbook
                     </a>

--- a/web/src/app/dashboard/settings/sections.tsx
+++ b/web/src/app/dashboard/settings/sections.tsx
@@ -81,7 +81,7 @@ export function OrgSection() {
       <div className="flex items-center gap-2">
         <SectionHeading id="org-heading">Organization</SectionHeading>
         {saved && (
-          <span className="rounded-(--radius) bg-ok/15 px-2 py-0.5 text-[12px] text-ok">
+          <span className="rounded-(--radius) bg-ok/15 px-2 py-0.5 text-[12px] text-ok-text">
             Saved
           </span>
         )}

--- a/web/src/app/dashboard/settings/status-page/page.tsx
+++ b/web/src/app/dashboard/settings/status-page/page.tsx
@@ -73,7 +73,7 @@ export default function StatusPageBuilderPage() {
       <header className="flex items-center gap-3">
         <h1 className="text-[20px] font-semibold">Status page — builder</h1>
         {saved && (
-          <span className="rounded-(--radius) bg-ok/15 px-2 py-0.5 text-[12px] text-ok">
+          <span className="rounded-(--radius) bg-ok/15 px-2 py-0.5 text-[12px] text-ok-text">
             Saved
           </span>
         )}

--- a/web/src/app/dashboard/shell.tsx
+++ b/web/src/app/dashboard/shell.tsx
@@ -177,7 +177,7 @@ function ShellChrome({ children }: { children: ReactNode }) {
                       setOrgOpen(false);
                       shell.newOrg();
                     }}
-                    className="w-full px-3 py-1.5 text-left text-[13px] text-brand transition-colors duration-[var(--duration-fast)] hover:bg-bg"
+                    className="w-full px-3 py-1.5 text-left text-[13px] text-brand-text transition-colors duration-[var(--duration-fast)] hover:bg-bg"
                   >
                     + New organization
                   </button>

--- a/web/src/app/dashboard/traces/explorer/page.tsx
+++ b/web/src/app/dashboard/traces/explorer/page.tsx
@@ -159,7 +159,7 @@ export default function TraceExplorerPage() {
                 </h2>
                 <Link
                   href={`/dashboard/traces/map?service=${selected.root_service}`}
-                  className="text-[12px] text-brand hover:underline"
+                  className="text-[12px] text-brand-text hover:underline"
                   data-testid="map-crosslink"
                 >
                   View {selected.root_service} in service map →

--- a/web/src/app/dashboard/traces/map/page.tsx
+++ b/web/src/app/dashboard/traces/map/page.tsx
@@ -55,7 +55,7 @@ export default function ServiceMapPage() {
             highlight: <span className="font-data text-text">{selected}</span> —{" "}
             <Link
               href={`/dashboard/traces/services/${selected}`}
-              className="text-brand hover:underline"
+              className="text-brand-text hover:underline"
             >
               open service →
             </Link>

--- a/web/src/app/dashboard/traces/page.tsx
+++ b/web/src/app/dashboard/traces/page.tsx
@@ -13,13 +13,13 @@ function ms(v: number): string {
 
 function errTint(rate: number): string {
   if (rate >= 0.04) return "text-crit";
-  if (rate >= 0.01) return "text-warn";
+  if (rate >= 0.01) return "text-warn-text";
   return "text-text-2";
 }
 
 function apdexTint(apdex: number): string {
   if (apdex < 0.8) return "text-crit";
-  if (apdex < 0.94) return "text-warn";
+  if (apdex < 0.94) return "text-warn-text";
   return "text-text-2";
 }
 

--- a/web/src/app/dashboard/uptime/SyntheticCheckBuilder.tsx
+++ b/web/src/app/dashboard/uptime/SyntheticCheckBuilder.tsx
@@ -282,7 +282,7 @@ export function SyntheticCheckBuilder({
               data-testid={`check-kind-${value}`}
               className={
                 tab === value
-                  ? "rounded-(--radius) border border-brand px-3 py-1.5 text-[13px] font-medium text-brand"
+                  ? "rounded-(--radius) border border-brand px-3 py-1.5 text-[13px] font-medium text-brand-text"
                   : "rounded-(--radius) border border-border px-3 py-1.5 text-[13px] text-text-2 transition-colors duration-[var(--duration-fast)] hover:text-text"
               }
             >

--- a/web/src/app/dashboard/uptime/[id]/page.tsx
+++ b/web/src/app/dashboard/uptime/[id]/page.tsx
@@ -181,7 +181,7 @@ export default function MonitorDetailPage() {
             </p>
             <Link
               href="/dashboard/monitors/new?signal=trace"
-              className="mt-2 inline-block text-[13px] text-brand hover:underline"
+              className="mt-2 inline-block text-[13px] text-brand-text hover:underline"
             >
               Create a latency monitor from this insight →
             </Link>

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -29,6 +29,15 @@
   --color-warn: var(--color-warn);
   --color-crit: var(--color-crit);
   --color-nodata: var(--color-nodata);
+  --color-on-crit: var(--color-on-crit);
+  /* AA text variants — readable text in a hue binds these; fills/
+     borders/dots/icons keep the base hue (design.md §2) */
+  --color-brand-text: var(--color-brand-text);
+  --color-ok-text: var(--color-ok-text);
+  --color-warn-text: var(--color-warn-text);
+  --color-crit-text: var(--color-crit-text);
+  --color-nodata-text: var(--color-nodata-text);
+  --color-text-2-text: var(--color-text-2-text);
   --color-series-1: var(--color-series-1);
   --color-series-2: var(--color-series-2);
   --color-series-3: var(--color-series-3);
@@ -191,7 +200,8 @@
      descendant (the marketing nav rode away with the scroll — caught by
      the /docs/api header e2e under CI). `clip` clips without creating a
      scroll container. */
-  html, body {
+  html,
+  body {
     overflow-x: clip;
     max-width: 100%;
   }

--- a/web/src/components/home/sections-bottom.tsx
+++ b/web/src/components/home/sections-bottom.tsx
@@ -68,7 +68,7 @@ export function SelfHostSection({ onSelfHostDocs }: SelfHostSectionProps) {
           <a
             href={SELF_HOST_DOCS_URL}
             onClick={onSelfHostDocs}
-            className="text-[13px] font-medium text-brand transition-colors duration-[var(--duration-fast)] hover:text-brand-deep"
+            className="text-[13px] font-medium text-brand-text transition-colors duration-[var(--duration-fast)] hover:text-brand-deep"
           >
             Self-host guide — step-by-step deploy docs →
           </a>
@@ -168,7 +168,7 @@ export function CloudSelfHostSection({
           {/* flex-wrap of two nowrap runs: at 390 the comment wraps as a
               whole line instead of mid-comment (CodeSnippet convention) */}
           <code className="font-data flex flex-wrap gap-x-2 text-[13px]">
-            <span className="whitespace-nowrap text-brand">
+            <span className="whitespace-nowrap text-brand-text">
               docker compose up -d
             </span>
             <span className="whitespace-nowrap text-text-2">
@@ -215,7 +215,7 @@ export function DevelopersSection({ onGithub }: DevelopersSectionProps) {
     <Section title="For developers — come build it.">
       <div className="grid items-start gap-12 lg:grid-cols-[1fr_480px]">
         <div className="min-w-0 flex flex-col gap-5">
-          <p className="font-data text-[13px] text-brand">{STACK_LINE}</p>
+          <p className="font-data text-[13px] text-brand-text">{STACK_LINE}</p>
           <p className="text-[14px] text-text-2">
             upstat is built in the open — and the interesting problems are open
             too:
@@ -234,14 +234,14 @@ export function DevelopersSection({ onGithub }: DevelopersSectionProps) {
             <a
               href={GITHUB_URL}
               onClick={onGithub}
-              className="flex items-center gap-2.5 text-[13px] text-text transition-colors duration-[var(--duration-fast)] hover:text-brand"
+              className="flex items-center gap-2.5 text-[13px] text-text transition-colors duration-[var(--duration-fast)] hover:text-brand-text"
             >
               <GithubIcon className="size-4 shrink-0" />
               github.com/cuesoftinc/upstat — good first issues welcome
             </a>
             <a
               href={`${GITHUB_URL}/blob/main/CONTRIBUTING.md`}
-              className="flex items-center gap-2.5 text-[13px] text-text transition-colors duration-[var(--duration-fast)] hover:text-brand"
+              className="flex items-center gap-2.5 text-[13px] text-text transition-colors duration-[var(--duration-fast)] hover:text-brand-text"
             >
               <FileText aria-hidden="true" className="size-4 shrink-0" />
               CONTRIBUTING.md — local setup in one script, architecture guide
@@ -249,7 +249,7 @@ export function DevelopersSection({ onGithub }: DevelopersSectionProps) {
             </a>
             <a
               href={DISCORD_URL}
-              className="flex items-center gap-2.5 text-[13px] text-text transition-colors duration-[var(--duration-fast)] hover:text-brand"
+              className="flex items-center gap-2.5 text-[13px] text-text transition-colors duration-[var(--duration-fast)] hover:text-brand-text"
             >
               {/* Discord blurple — brand-glyph color exception (design.md §8.1) */}
               <DiscordIcon className="size-4 shrink-0 text-[#5865F2]" />
@@ -259,7 +259,7 @@ export function DevelopersSection({ onGithub }: DevelopersSectionProps) {
         </div>
 
         <div className="min-w-0 rounded-(--radius) border border-border bg-bg-elev p-4">
-          <p className="font-data text-[12px] text-brand">
+          <p className="font-data text-[12px] text-brand-text">
             label: good first issue
           </p>
           {/* overflow-x-auto: pre text doesn't wrap — scroll inside the card
@@ -303,20 +303,20 @@ export function CommunitySection() {
               upstat.cuesoft.io/status/upstat — we run upstat on upstat.
             </span>
           </span>
-          <span className="shrink-0 text-[13px] font-medium text-brand">
+          <span className="shrink-0 text-[13px] font-medium text-brand-text">
             View live →
           </span>
         </Link>
         <div className="flex flex-col gap-4 lg:pt-2">
           <a
             href={ROADMAP_URL}
-            className="text-[13px] font-medium text-brand transition-colors duration-[var(--duration-fast)] hover:text-brand-deep"
+            className="text-[13px] font-medium text-brand-text transition-colors duration-[var(--duration-fast)] hover:text-brand-deep"
           >
             Public roadmap →
           </a>
           <a
             href={CUELABS_URL}
-            className="text-[13px] font-medium text-brand transition-colors duration-[var(--duration-fast)] hover:text-brand-deep"
+            className="text-[13px] font-medium text-brand-text transition-colors duration-[var(--duration-fast)] hover:text-brand-deep"
           >
             CueLABS™ — more open-source software from Cuesoft →
           </a>

--- a/web/src/components/home/sections-demo.tsx
+++ b/web/src/components/home/sections-demo.tsx
@@ -110,7 +110,7 @@ function QuadCard({ title, body, readMoreHref }: QuadCopy) {
       </div>
       <a
         href={readMoreHref}
-        className="ml-5 text-[12px] font-medium text-brand transition-colors duration-[var(--duration-fast)] hover:text-brand-deep"
+        className="ml-5 text-[12px] font-medium text-brand-text transition-colors duration-[var(--duration-fast)] hover:text-brand-deep"
       >
         Read more →
       </a>

--- a/web/src/components/home/sections-top.tsx
+++ b/web/src/components/home/sections-top.tsx
@@ -124,7 +124,7 @@ function FlowChip({
     <span
       className={
         accent
-          ? "rounded-(--radius) border border-brand px-3.5 py-2 font-data text-[12px] text-brand"
+          ? "rounded-(--radius) border border-brand px-3.5 py-2 font-data text-[12px] text-brand-text"
           : "rounded-(--radius) border border-border px-3.5 py-2 font-data text-[12px] text-text"
       }
     >
@@ -199,7 +199,7 @@ function Step({
   return (
     <div className="min-w-0 flex flex-col gap-3">
       <div className="flex items-baseline gap-2.5">
-        <span className="font-data text-[20px] font-semibold tabular-nums text-brand">
+        <span className="font-data text-[20px] font-semibold tabular-nums text-brand-text">
           {n}
         </span>
         <h3 className="text-[16px] font-semibold text-text">{title}</h3>

--- a/web/src/components/ui/AlertChannelCard.tsx
+++ b/web/src/components/ui/AlertChannelCard.tsx
@@ -88,7 +88,7 @@ export function AlertChannelCard({
         <button
           type="button"
           onClick={onVerify}
-          className="mt-0.5 shrink-0 text-[12px] font-medium text-brand hover:text-brand-deep"
+          className="mt-0.5 shrink-0 text-[12px] font-medium text-brand-text hover:text-brand-deep"
         >
           Verify
         </button>

--- a/web/src/components/ui/AlertFeedRow.tsx
+++ b/web/src/components/ui/AlertFeedRow.tsx
@@ -24,9 +24,9 @@ const SEV_CHIP: Record<
   AlertEvent["sev"],
   { label: string; className: string }
 > = {
-  sev1: { label: "SEV-1", className: "bg-crit/14 text-crit" },
-  sev2: { label: "SEV-2", className: "bg-warn/14 text-warn" },
-  resolved: { label: "OK", className: "bg-ok/14 text-ok" },
+  sev1: { label: "SEV-1", className: "bg-crit/14 text-crit-text" },
+  sev2: { label: "SEV-2", className: "bg-warn/14 text-warn-text" },
+  resolved: { label: "OK", className: "bg-ok/14 text-ok-text" },
 };
 
 export interface AlertFeedRowProps {

--- a/web/src/components/ui/Button.tsx
+++ b/web/src/components/ui/Button.tsx
@@ -14,7 +14,7 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 
 /**
  * Button — design.md §8.2. Brand fills carry `on-brand` ink; destructive
- * labels stay raw #FFFFFF per the §2 on-crit decision (documented exception).
+ * labels bind the §2 `on-crit` token (white in light, dark ink in dark).
  */
 export function Button({
   kind = "brand",
@@ -39,9 +39,9 @@ export function Button({
         kind === "quiet" &&
           "border border-border bg-transparent text-text hover:bg-bg-elev disabled:hover:bg-bg-elev",
         kind === "destructive" &&
-          // raw #FFFFFF label pending an `on-crit` token (design.md §2);
-          // hover dims the crit fill to 85% (Figma 37:25), label stays white
-          "bg-crit text-[#FFFFFF] hover:bg-crit/85 disabled:hover:bg-bg-elev",
+          // label binds `on-crit` (design.md §2 — white/light, ink/dark);
+          // hover dims the crit fill to 85% (Figma 37:25)
+          "bg-crit text-on-crit hover:bg-crit/85 disabled:hover:bg-bg-elev",
         className,
       )}
       {...rest}

--- a/web/src/components/ui/ChartTable.tsx
+++ b/web/src/components/ui/ChartTable.tsx
@@ -38,7 +38,7 @@ export function ChartTableToggle({
       onClick={onToggle}
       className={clsx(
         "rounded-(--radius) p-1 transition-colors duration-[var(--duration-fast)] ease-standard",
-        active ? "text-brand" : "text-text-2 hover:bg-bg hover:text-text",
+        active ? "text-brand-text" : "text-text-2 hover:bg-bg hover:text-text",
         className,
       )}
     >

--- a/web/src/components/ui/CodeSnippet.tsx
+++ b/web/src/components/ui/CodeSnippet.tsx
@@ -115,7 +115,10 @@ export function CodeSnippet({
         <code className="font-data text-[13px] leading-[1.6] text-text">
           {prompt
             ? tabs[active].code.split("\n").map((line) => (
-                <span key={line} className="block whitespace-nowrap text-brand">
+                <span
+                  key={line}
+                  className="block whitespace-nowrap text-brand-text"
+                >
                   <span aria-hidden="true" className="select-none">
                     {"$ "}
                   </span>

--- a/web/src/components/ui/CountBadge.tsx
+++ b/web/src/components/ui/CountBadge.tsx
@@ -21,7 +21,7 @@ export function CountBadge({
     <span
       className={clsx(
         "font-ui inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-crit",
-        "px-1 text-[10px] font-semibold tabular-nums text-[#FFFFFF]", // §2 on-crit note
+        "px-1 text-[10px] font-semibold tabular-nums text-on-crit", // §2 on-crit
         pulse && "animate-pulse motion-reduce:animate-none",
         className,
       )}
@@ -53,7 +53,7 @@ export function BufferedCountChip({
       onClick={onClick}
       className={clsx(
         "font-data inline-flex items-center gap-1 rounded-full border border-brand bg-brand/12 px-2 py-[3px]",
-        "text-[11px] font-medium text-brand",
+        "text-[11px] font-medium text-brand-text",
         "transition-colors duration-[var(--duration-fast)] ease-standard hover:bg-brand/20",
         className,
       )}

--- a/web/src/components/ui/EmptyState.tsx
+++ b/web/src/components/ui/EmptyState.tsx
@@ -116,7 +116,7 @@ export function EmptyState({
             href={docsHref}
             target="_blank"
             rel="noreferrer"
-            className="inline-flex items-center gap-1 text-[12px] text-brand hover:text-brand-deep"
+            className="inline-flex items-center gap-1 text-[12px] text-brand-text hover:text-brand-deep"
           >
             Setup docs <ExternalLink className="size-3" aria-hidden="true" />
           </a>

--- a/web/src/components/ui/ErrorGroupRow.tsx
+++ b/web/src/components/ui/ErrorGroupRow.tsx
@@ -10,7 +10,7 @@ export interface ErrorGroupRowProps {
 }
 
 const STATE_TINT: Record<ErrorGroup["state"], string> = {
-  new: "text-brand border-brand/40",
+  new: "text-brand-text border-brand/40",
   ongoing: "text-text-2 border-border",
   regressed: "text-crit border-crit/40",
 };

--- a/web/src/components/ui/FacetGroup.tsx
+++ b/web/src/components/ui/FacetGroup.tsx
@@ -91,7 +91,7 @@ export function FacetGroup({
               <button
                 type="button"
                 onClick={() => setShowAll((s) => !s)}
-                className="py-1 text-[11px] text-brand hover:text-brand-deep"
+                className="py-1 text-[11px] text-brand-text hover:text-brand-deep"
               >
                 {showAll ? "Show less" : `Show all ${values.length}`}
               </button>

--- a/web/src/components/ui/IncidentBanner.tsx
+++ b/web/src/components/ui/IncidentBanner.tsx
@@ -69,7 +69,7 @@ export function IncidentBanner({
       </span>
       {/* the whole strip is the button; the link text is the master's
           explicit affordance */}
-      <span className="shrink-0 text-[13px] font-medium text-brand">
+      <span className="shrink-0 text-[13px] font-medium text-brand-text">
         {resolved ? "Postmortem →" : "View incident →"}
       </span>
     </button>

--- a/web/src/components/ui/IncidentHistoryEntry.tsx
+++ b/web/src/components/ui/IncidentHistoryEntry.tsx
@@ -22,17 +22,17 @@ export interface IncidentHistoryEntryProps {
 }
 
 const PHASE_TINT: Record<IncidentPhase, string> = {
-  investigating: "text-crit",
-  identified: "text-warn",
-  monitoring: "text-brand",
-  resolved: "text-ok",
+  investigating: "text-crit-text",
+  identified: "text-warn-text",
+  monitoring: "text-brand-text",
+  resolved: "text-ok-text",
 };
 
 const PHASE_CHIP: Record<IncidentPhase, string> = {
-  investigating: "bg-crit/10 text-crit",
-  identified: "bg-warn/10 text-warn",
-  monitoring: "bg-brand/10 text-brand",
-  resolved: "bg-ok/10 text-ok",
+  investigating: "bg-crit/10 text-crit-text",
+  identified: "bg-warn/10 text-warn-text",
+  monitoring: "bg-brand/10 text-brand-text",
+  resolved: "bg-ok/10 text-ok-text",
 };
 
 const PHASE_DOT: Record<IncidentPhase, string> = {

--- a/web/src/components/ui/LevelChip.test.tsx
+++ b/web/src/components/ui/LevelChip.test.tsx
@@ -5,15 +5,15 @@ import { LevelChip } from "./LevelChip";
 describe("LevelChip", () => {
   it("applies the decided level mapping (INFO → brand)", () => {
     render(<LevelChip level="INFO" />);
-    expect(screen.getByText("INFO")).toHaveClass("text-brand");
+    expect(screen.getByText("INFO")).toHaveClass("text-brand-text");
   });
 
   it("keeps ERROR/WARN on crit/warn and TRACE on nodata", () => {
     const { rerender } = render(<LevelChip level="ERROR" />);
-    expect(screen.getByText("ERROR")).toHaveClass("text-crit");
+    expect(screen.getByText("ERROR")).toHaveClass("text-crit-text");
     rerender(<LevelChip level="WARN" />);
-    expect(screen.getByText("WARN")).toHaveClass("text-warn");
+    expect(screen.getByText("WARN")).toHaveClass("text-warn-text");
     rerender(<LevelChip level="TRACE" />);
-    expect(screen.getByText("TRACE")).toHaveClass("text-nodata");
+    expect(screen.getByText("TRACE")).toHaveClass("text-nodata-text");
   });
 });

--- a/web/src/components/ui/LevelChip.tsx
+++ b/web/src/components/ui/LevelChip.tsx
@@ -11,11 +11,11 @@ export interface LevelChipProps {
 // Mapping [Decided 2026-07-16]: INFO → brand · DEBUG → text-2 · TRACE →
 // nodata; ERROR/WARN keep crit/warn. 14% tint container (Figma 40:33).
 const TINT: Record<LogLevel, string> = {
-  ERROR: "text-crit bg-crit/14",
-  WARN: "text-warn bg-warn/14",
-  INFO: "text-brand bg-brand/14",
-  DEBUG: "text-text-2 bg-text-2/14",
-  TRACE: "text-nodata bg-nodata/14",
+  ERROR: "text-crit-text bg-crit/14",
+  WARN: "text-warn-text bg-warn/14",
+  INFO: "text-brand-text bg-brand/14",
+  DEBUG: "text-text-2-text bg-text-2/14",
+  TRACE: "text-nodata-text bg-nodata/14",
 };
 
 /** LevelChip — log level chip ×5, extracted from LogLine (§8.2). */

--- a/web/src/components/ui/LogLine.tsx
+++ b/web/src/components/ui/LogLine.tsx
@@ -170,7 +170,7 @@ export function LogLine({
                     if ((e.metaKey || e.ctrlKey) && onPivot)
                       onPivot(key, value);
                   }}
-                  className="truncate text-left text-text hover:text-brand"
+                  className="truncate text-left text-text hover:text-brand-text"
                 >
                   {value}
                 </button>

--- a/web/src/components/ui/MarketingNav.tsx
+++ b/web/src/components/ui/MarketingNav.tsx
@@ -141,7 +141,7 @@ function FeaturesDropdown({ href }: { href: string }) {
         onClick={() => setOpen(false)}
         className={clsx(
           "text-[13px] font-medium transition-colors duration-[var(--duration-fast)]",
-          open ? "text-brand" : "text-text-2 hover:text-text",
+          open ? "text-brand-text" : "text-text-2 hover:text-text",
         )}
       >
         Features
@@ -155,7 +155,7 @@ function FeaturesDropdown({ href }: { href: string }) {
         onClick={() => setOpen((o) => !o)}
         className={clsx(
           "rounded-(--radius) p-0.5 transition-colors duration-[var(--duration-fast)]",
-          open ? "text-brand" : "text-text-2 hover:text-text",
+          open ? "text-brand-text" : "text-text-2 hover:text-text",
         )}
       >
         <ChevronDown
@@ -189,7 +189,7 @@ function FeaturesDropdown({ href }: { href: string }) {
                         href={`/#pillar-${pillar}`}
                         data-pillar={pillar}
                         onClick={() => setOpen(false)}
-                        className="flex items-center gap-2.5 whitespace-nowrap text-[13px] font-medium text-text transition-colors duration-[var(--duration-fast)] hover:text-brand"
+                        className="flex items-center gap-2.5 whitespace-nowrap text-[13px] font-medium text-text transition-colors duration-[var(--duration-fast)] hover:text-brand-text"
                       >
                         <Icon
                           aria-hidden="true"

--- a/web/src/components/ui/NavRail.tsx
+++ b/web/src/components/ui/NavRail.tsx
@@ -61,7 +61,7 @@ export function NavRailItem({
     expanded ? "w-full gap-3 px-2.5 text-left" : "size-10 justify-center",
     "transition-colors duration-[var(--duration-fast)] ease-standard",
     active
-      ? "bg-brand/15 text-brand"
+      ? "bg-brand/15 text-brand-text"
       : "text-text-2 hover:bg-bg-elev hover:text-text",
   );
   const itemBody = (

--- a/web/src/components/ui/QueryValue.test.tsx
+++ b/web/src/components/ui/QueryValue.test.tsx
@@ -10,7 +10,7 @@ describe("QueryValue", () => {
     // Figma 70:537 — tint wash carries the threshold, the value stays neutral
     expect(screen.getByText("142 ms")).toHaveClass("text-text");
     expect(container.querySelector(".bg-warn\\/8")).not.toBeNull();
-    expect(screen.getByText("▼ 3.4%")).toHaveClass("text-warn");
+    expect(screen.getByText("▼ 3.4%")).toHaveClass("text-warn-text");
   });
 
   it("renders the sparkline variant", () => {

--- a/web/src/components/ui/QueryValue.tsx
+++ b/web/src/components/ui/QueryValue.tsx
@@ -25,9 +25,9 @@ const TINT: Record<Exclude<QueryValueThreshold, "none">, string> = {
 };
 
 const DELTA_TEXT: Record<Exclude<QueryValueThreshold, "none">, string> = {
-  ok: "text-ok",
-  warn: "text-warn",
-  crit: "text-crit",
+  ok: "text-ok-text",
+  warn: "text-warn-text",
+  crit: "text-crit-text",
 };
 
 /**
@@ -78,8 +78,8 @@ export function QueryValue({
               threshold !== "none"
                 ? DELTA_TEXT[threshold]
                 : deltaPct >= 0
-                  ? "text-ok"
-                  : "text-crit",
+                  ? "text-ok-text"
+                  : "text-crit-text",
             )}
           >
             {deltaPct >= 0 ? "▲" : "▼"} {Math.abs(deltaPct).toFixed(1)}%

--- a/web/src/components/ui/RouteTabs.tsx
+++ b/web/src/components/ui/RouteTabs.tsx
@@ -102,7 +102,7 @@ export function RouteTabs({
                 "shrink-0 whitespace-nowrap pb-2 text-[13px]",
                 "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand",
                 selected
-                  ? "-mb-px border-b-2 border-brand font-medium text-brand"
+                  ? "-mb-px border-b-2 border-brand font-medium text-brand-text"
                   : "text-text-2 transition-colors duration-[var(--duration-fast)] hover:text-text",
               )}
             >

--- a/web/src/components/ui/SLOCard.tsx
+++ b/web/src/components/ui/SLOCard.tsx
@@ -66,8 +66,8 @@ export function SLOCard({ slo, className }: SLOCardProps) {
         <span
           className={clsx(
             "text-[20px] font-semibold tabular-nums",
-            slo.state === "healthy" && "text-ok",
-            slo.state === "burning" && "text-warn",
+            slo.state === "healthy" && "text-ok-text",
+            slo.state === "burning" && "text-warn-text",
             slo.state === "exhausted" && "text-crit",
           )}
         >

--- a/web/src/components/ui/SavedViewChip.tsx
+++ b/web/src/components/ui/SavedViewChip.tsx
@@ -30,7 +30,7 @@ export function SavedViewChip({
         "font-ui inline-flex h-7 items-center gap-1.5 rounded-(--radius) border px-2 text-[12px] font-medium",
         "transition-colors duration-[var(--duration-fast)] ease-standard",
         active
-          ? "border-brand bg-brand/10 text-brand"
+          ? "border-brand bg-brand/10 text-brand-text"
           : "border-border bg-bg-elev text-text hover:border-text-2",
         className,
       )}

--- a/web/src/components/ui/ServiceCatalogRow.tsx
+++ b/web/src/components/ui/ServiceCatalogRow.tsx
@@ -79,7 +79,7 @@ export function ServiceCatalogRow({
             href={entry.links.repo}
             target="_blank"
             rel="noreferrer"
-            className="inline-flex items-center gap-0.5 text-[12px] text-text-2 hover:text-brand"
+            className="inline-flex items-center gap-0.5 text-[12px] text-text-2 hover:text-brand-text"
           >
             repo <ExternalLink className="size-3" aria-hidden="true" />
           </a>
@@ -89,7 +89,7 @@ export function ServiceCatalogRow({
             href={entry.links.runbook}
             target="_blank"
             rel="noreferrer"
-            className="inline-flex items-center gap-0.5 text-[12px] text-text-2 hover:text-brand"
+            className="inline-flex items-center gap-0.5 text-[12px] text-text-2 hover:text-brand-text"
           >
             runbook <ExternalLink className="size-3" aria-hidden="true" />
           </a>

--- a/web/src/components/ui/SevChip.tsx
+++ b/web/src/components/ui/SevChip.tsx
@@ -18,7 +18,7 @@ export function SevChip({ sev, className }: SevChipProps) {
         // never wraps or shrinks — chips stay one line in tight chrome
         // (390 banner regression fix 2026-07-20)
         "font-ui inline-flex h-5 shrink-0 items-center whitespace-nowrap rounded-(--radius) px-1.5 text-[11px] font-semibold",
-        sev === 1 && "bg-crit text-[#FFFFFF]", // raw white per the §2 on-crit note
+        sev === 1 && "bg-crit text-on-crit", // §2 on-crit: white/light, dark ink/dark
         sev === 2 && "bg-warn text-on-brand",
         sev === 3 && "bg-bg-elev text-text-2 border border-border",
         className,

--- a/web/src/components/ui/StatusPageHeader.tsx
+++ b/web/src/components/ui/StatusPageHeader.tsx
@@ -83,8 +83,8 @@ export function StatusPageHeader({
           aria-hidden="true"
           className={clsx(
             "size-5",
-            overall === "operational" && "text-ok",
-            overall === "degraded" && "text-warn",
+            overall === "operational" && "text-ok-text",
+            overall === "degraded" && "text-warn-text",
             (overall === "partial_outage" || overall === "major_outage") &&
               "text-crit",
           )}

--- a/web/src/components/ui/StatusPill.tsx
+++ b/web/src/components/ui/StatusPill.tsx
@@ -46,12 +46,12 @@ const DOT: Record<StatusPillStatus, string> = {
 };
 
 const TEXT: Record<StatusPillStatus, string> = {
-  ok: "text-ok",
-  warn: "text-warn",
-  crit: "text-crit",
-  nodata: "text-nodata",
-  paused: "text-nodata",
-  pending: "text-text-2",
+  ok: "text-ok-text",
+  warn: "text-warn-text",
+  crit: "text-crit-text",
+  nodata: "text-nodata-text",
+  paused: "text-nodata-text",
+  pending: "text-text-2-text",
 };
 
 // §5 colorblind mode: the dot-only variant is the one color-only status

--- a/web/src/components/ui/TimePicker.tsx
+++ b/web/src/components/ui/TimePicker.tsx
@@ -53,7 +53,7 @@ export function TimePicker({
           className={clsx(
             "hidden px-2 text-[12px] font-medium tabular-nums transition-colors duration-[var(--duration-fast)] ease-standard md:block",
             value === preset
-              ? "bg-bg-elev text-brand"
+              ? "bg-bg-elev text-brand-text"
               : "text-text-2 hover:text-text",
           )}
         >
@@ -77,7 +77,7 @@ export function TimePicker({
             "flex items-center gap-1 px-2 text-[12px] font-medium md:border-l md:border-border",
             "transition-colors duration-[var(--duration-fast)] ease-standard",
             value === "custom"
-              ? "bg-bg-elev text-brand"
+              ? "bg-bg-elev text-brand-text"
               : "text-text-2 hover:text-text",
           )}
         >
@@ -140,7 +140,7 @@ export function TimePicker({
           className={clsx(
             "hidden items-center gap-1.5 border-l border-border px-2 text-[12px] font-medium md:flex",
             "transition-colors duration-[var(--duration-fast)] ease-standard",
-            live ? "text-brand" : "text-text-2 hover:text-text",
+            live ? "text-brand-text" : "text-text-2 hover:text-text",
           )}
         >
           <span

--- a/web/src/components/ui/WidgetTypeCell.tsx
+++ b/web/src/components/ui/WidgetTypeCell.tsx
@@ -28,7 +28,7 @@ export function WidgetTypeCell({
         "font-ui flex w-24 flex-col items-center gap-1.5 rounded-(--radius) border p-3",
         "transition-colors duration-[var(--duration-fast)] ease-standard",
         selected
-          ? "border-brand bg-brand/10 text-brand"
+          ? "border-brand bg-brand/10 text-brand-text"
           : "border-border bg-bg-elev text-text-2 hover:border-text-2 hover:text-text",
         className,
       )}

--- a/web/src/design/tokens.css
+++ b/web/src/design/tokens.css
@@ -10,8 +10,8 @@
  * fallback only.
  *
  * No raw hex anywhere else in the app — components consume these variables
- * (documented exceptions carry a code comment, e.g. destructive-fill labels
- * stay raw #FFFFFF pending an `on-crit` token, design.md §2).
+ * (the one documented exception is the brand-mandated GoogleAuthButton
+ * chrome; destructive-fill labels bind `on-crit`, design.md §2).
  */
 
 :root {
@@ -28,6 +28,22 @@
   --color-warn: #ffb020; /* degraded / warn thresholds */
   --color-crit: #ff5c5c; /* down / alerting */
   --color-nodata: #5c6270; /* no data / muted monitors */
+  --color-on-crit: #0e1113; /* labels on crit fills — dark ink in dark theme
+    (white on #ff5c5c is 3.03), white in light (design.md §2) */
+
+  /* ---- AA text variants (design.md §2) ----
+     Readable text in a status/brand hue binds the `-text` variant;
+     fills/borders/dots/icons keep the base hue. Dark base values clear
+     4.5:1 on their /14 tints except nodata, which lightens in OKLCH
+     (L 0.496→0.643) — the others alias the base. Light values darken
+     the base (L only; C/H preserved) until ≥4.5:1 on the tinted-chip
+     recipe (`text-X` on `bg-X/10–15`) — see the light block. */
+  --color-brand-text: #00e09e;
+  --color-ok-text: #3dcc70;
+  --color-warn-text: #ffb020;
+  --color-crit-text: #ff5c5c;
+  --color-nodata-text: #868d9c; /* 4.63 on nodata/14 over bg-elev */
+  --color-text-2-text: #9ba0ac;
 
   /* ---- Series palette (8-step categorical; same both themes) ---- */
   --color-series-1: #7c6cf0;
@@ -85,6 +101,16 @@
   --color-warn: #c77d00;
   --color-crit: #d32f2f;
   --color-nodata: #9aa0aa;
+  --color-on-crit: #ffffff; /* white on #d32f2f = 4.98 */
+  /* AA text variants — every light base misses 4.5:1 on its /14 tint
+     (brand 1.57 · ok 3.10 · warn 2.84 · crit 4.03 · nodata 2.35 ·
+     text-2 4.21), so all darken in OKLCH until the recipe clears AA */
+  --color-brand-text: #097955; /* 4.61 on brand/15 over bg-elev */
+  --color-ok-text: #047634; /* 4.61 on ok/15 over bg-elev */
+  --color-warn-text: #925b03; /* 4.60 on warn/14 over bg-elev */
+  --color-crit-text: #c31a21; /* 4.54 on crit/15 over bg-elev */
+  --color-nodata-text: #646a73; /* 4.61 on nodata/14 over bg-elev */
+  --color-text-2-text: #616571; /* 4.61 on text-2/14 over bg-elev */
   /* series palette is identical in both themes (validated ≥3:1 on both bg values) */
 }
 
@@ -105,5 +131,12 @@
     --color-warn: #c77d00;
     --color-crit: #d32f2f;
     --color-nodata: #9aa0aa;
+    --color-on-crit: #ffffff;
+    --color-brand-text: #097955;
+    --color-ok-text: #047634;
+    --color-warn-text: #925b03;
+    --color-crit-text: #c31a21;
+    --color-nodata-text: #646a73;
+    --color-text-2-text: #616571;
   }
 }


### PR DESCRIPTION
## What

The `text-X on bg-X/14` tinted recipe and brand/status text fail WCAG AA in light theme; the PUBLIC status page pins `data-theme="light"` in its layout, so its pills failed under **both** app themes; and the dark SEV-1 badge shipped white on `#FF5C5C` at 3.03 (2026-07-21 fleet audit, adjudicated canon fix). §2 gains paired `-text` variants — light bases darkened in OKLCH (L only, C/H preserved) until ≥4.5:1 on the tinted recipe over `bg-elev` — plus the previously-"pending" `on-crit` token. **Readable text binds the variant; fills/borders/dots/icons keep the base hue.** Dark is visually unchanged except the nodata `-text` (the one dark AA failure) and the SEV-1/destructive labels.

## Token values

| Token | Light | Dark |
|---|---|---|
| `--color-brand-text` | `#097955` | `#00E09E` (base — already AA) |
| `--color-ok-text` | `#047634` | `#3DCC70` (base — already AA) |
| `--color-warn-text` | `#925B03` | `#FFB020` (base — already AA) |
| `--color-crit-text` | `#C31A21` | `#FF5C5C` (base — already AA, 4.71) |
| `--color-nodata-text` | `#646A73` | `#868D9C` (lightened — dark failed too) |
| `--color-text-2-text` | `#616571` | `#9BA0AC` (base — already AA) |
| `--color-on-crit` | `#FFFFFF` (4.98 on crit) | `#0E1113` (6.26 on crit; white was 3.03) |

## Before → after (worst context per pair)

| Pair | Before | After |
|---|---|---|
| light: brand as text on `bg` (links/nav/tabs — the ×14–29/route volume) | **1.73** | **5.42** |
| light: brand on `brand/15` active-nav tint over `bg-elev` | **1.47** | **4.61** |
| light: ok on `ok/14` StatusPill tint (status page pins light → "both themes") | **2.94** | **4.61** |
| light: warn on `warn/14` tint | **2.69** | **4.60** |
| light: crit on `crit/15` tint | **3.76** | **4.54** |
| light: nodata on `nodata/14` tint | **2.22** | **4.61** |
| dark: nodata on `nodata/14` tint | **2.52** | **4.63** |
| light: text-2 on `text-2/14` pending-pill tint | **3.98** | **4.61** |
| dark: SEV-1 label on `crit` fill | **3.03** | **6.26** |

## Code

- `StatusPill` (ok/warn/crit/nodata/paused/pending — **passes in BOTH themes**, incl. the pinned-light public status page), `LevelChip` ×5, `AlertFeedRow` sev chips, `IncidentHistoryEntry` (both maps), `NavRail` active, `CountBadge`/`BufferedCountChip`, `SavedViewChip`, `WidgetTypeCell`, page/route/log tabs, ok/15 chips (settings, status-page, rum, dashboards), `QueryValue`, `SLOCard`, `StatusPageHeader`, `IncidentBanner`, `TimePicker`, `ChartTable`, `MarketingNav`, `ErrorGroupRow`, rule-editor/monitor warn text, brand links + marketing home copy → `-text` variants
- `SevChip` SEV-1, `CountBadge`, destructive `Button` swap raw `#FFFFFF` → `text-on-crit`; `GoogleAuthButton` stays raw (brand-mandated)
- Kept on base hue deliberately: icons/glyphs (BrandMark, checkmarks, favorite star, toast icons), dots, borders, fills, plain crit copy (already AA both themes), `hover:text-brand-deep` transient hovers

## Docs

`docs/design.md` §2 gains the `on-crit` row and `brand-text` + status `-text` rows; the `on-brand` row, §8.2 Button row, and `docs/web-implementation.md` token notes now describe `on-crit` as it ships (current-system voice).

## Lock

`web/e2e/contrast-tokens.spec.ts`:
1. recomputes every recipe pair + fill-label pair (`on-crit`/crit, `on-brand`/brand, SEV-2 warn) from the **served CSS** in both themes, asserting ≥4.5:1
2. sweeps the rendered PUBLIC `/status/upstat` pills under both app themes (walk-up backdrop compositing)
3. sweeps the rendered SEV badges on `/dashboard/incidents` in dark

## Gate

prettier ✓ eslint ✓ boundaries ✓ typecheck ✓ vitest ✓ build ✓ Playwright 72/72 ✓ (PW_PORT=4433, serial per repo config)

🤖 Generated with [Claude Code](https://claude.com/claude-code)