### PR TITLE
docs: changelog catch-up — routed settings tabs, self-host Helm tabs, SEO, a11y

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- Settings goes route-backed tabs: General | Members | Keys & properties |
+  Integrations | Data & privacy | Appearance | Usage — seven deep-linkable
+  tabs (#188).
+- Self-host install snippet goes tabbed: Docker Compose and Helm (#184).
+- SEO plumbing: sitemap, `robots.txt`, canonical URLs, an Open Graph card, and
+  a real brand favicon in place of the placeholder (#195).
+
+### Changed
+- Dead-code and env-plumbing cleanup: removed dead exports, scaffold assets,
+  an unused dependency, and the dead `NEXT_PUBLIC_BASE_URL` env plumbing
+  (docs now name the real var); piped Playwright's `webServer` output so CI
+  server deaths are diagnosable (#190, #191, #193).
+
+### Fixed
+- Figma↔code convergence pass: home content, charts, pills sweep, `NavRail`,
+  brand mark, banner, `FacetGroup` header, landing font-smoothing/type lock,
+  `TimePicker` panel anatomy, monitors editor panel whitespace, the `?run=`
+  lock, and `IncidentBanner` chrome-strip placement (#180, #181, #182, #185,
+  #186, #192).
+- Self-host checklist now names the shipping database (MongoDB) instead of
+  the earlier target (#189).
+- Accessibility: pinch-zoom restored, nav-rail links corrected, and command
+  palette dismissal/focus restore fixed (#194).
+
+### Added
 - Full observability web application (monitors, incidents, logs, metrics, RUM,
   and public status pages) built from the shared component registry over a
   mock CRUD API, with multi-organization onboarding.


### PR DESCRIPTION
## Summary
- Catches up CHANGELOG.md's `[Unreleased]` section with every PR merged since the last convergence pass (#179–#195).
- New Added/Changed/Fixed batch covering: route-backed settings tabs (seven deep-linkable tabs), tabbed self-host install snippet, SEO plumbing, Figma↔code convergence fixes (home content, charts, NavRail, brand mark, banner, TimePicker, monitors editor), a self-host checklist correction (names MongoDB), accessibility fixes (pinch-zoom, nav-rail links, focus restore), and dead-code/env-plumbing cleanup.
- Docs-only design-ratification PRs (no shipped change) were intentionally left out, consistent with the file's existing convention.

## Test plan
- [x] Diff reviewed: additive only, nothing removed from CHANGELOG.md
- [x] No code/build changes — docs only