### PR TITLE
fix(web): signin gains the sibling-parity legal consent line

### DIFF
--- a/docs/web-implementation.md
+++ b/docs/web-implementation.md
@@ -684,7 +684,7 @@ order per pages.md Part B.
 | pages.md | Route | Screen |
 | --- | --- | --- |
 | Part A (A1–A16) | `/` | Public home page |
-| flows/auth.md · design.md §8.1 Stage 4 | `/signin` | Single auth screen — GoogleAuthButton + legal links (X-1; the only auth route — stale `/login` links 404 on the branded page (stub removed 2026-07-19); there is no `/signup`) |
+| flows/auth.md · design.md §8.1 Stage 4 | `/signin` | Single auth screen — GoogleAuthButton + legal consent line (Terms/Privacy open the canonical https://terms.cuesoft.io / https://privacy.cuesoft.io in a new tab; X-1; the only auth route — stale `/login` links 404 on the branded page (stub removed 2026-07-19); there is no `/signup`) |
 | X-2 | `/docs/api` | Public API reference — Scalar embed rendering `docs/api/openapi.yaml` (served at `/docs/api/openapi.yaml`); marketing nav chrome, minimal legal strip **[Ratified 2026-07-20]** |
 | B1 | `/dashboard` | Home — org health: incidents banner (MI-14), triggered monitors, SLO burn (MI-15), watched dashboards |
 | B1 first-run | `/dashboard/onboarding` | create-org (name + IANA timezone, X-10) → send-your-first-data (ingestion key + snippet + MI-16 waiting-for-data; resolves to `/dashboard` on first datapoint) |

--- a/web/e2e/signin.spec.ts
+++ b/web/e2e/signin.spec.ts
@@ -33,6 +33,24 @@ test("signin → dashboard home via the single Google CTA", async ({ page }) => 
   ).toBeVisible();
 });
 
+test("legal consent line links the canonical Cuesoft policies", async ({
+  page,
+}) => {
+  await page.goto("/signin");
+
+  const screen = page.getByTestId("signin-screen");
+  await expect(
+    screen.getByText(/By continuing you agree to the/),
+  ).toBeVisible();
+  await expect(screen.getByRole("link", { name: "Terms" })).toHaveAttribute(
+    "href",
+    "https://terms.cuesoft.io",
+  );
+  await expect(
+    screen.getByRole("link", { name: "Privacy Policy" }),
+  ).toHaveAttribute("href", "https://privacy.cuesoft.io");
+});
+
 test("/login 404s on the branded page (redirect stub removed 2026-07-19)", async ({
   page,
 }) => {

--- a/web/src/app/signin/page.tsx
+++ b/web/src/app/signin/page.tsx
@@ -43,6 +43,30 @@ export default function SignInPage() {
             Sign-in failed. Please try again.
           </p>
         )}
+
+        {/* Legal consent line (sibling parity: apparule/expendit signin) —
+            links open the canonical Cuesoft policies in a new tab. */}
+        <p className="text-[13px] leading-[1.45] text-text-2">
+          By continuing you agree to the{" "}
+          <a
+            href="https://terms.cuesoft.io"
+            target="_blank"
+            rel="noreferrer"
+            className="underline underline-offset-2 transition-colors duration-[var(--duration-fast)] hover:text-text"
+          >
+            Terms
+          </a>{" "}
+          and{" "}
+          <a
+            href="https://privacy.cuesoft.io"
+            target="_blank"
+            rel="noreferrer"
+            className="underline underline-offset-2 transition-colors duration-[var(--duration-fast)] hover:text-text"
+          >
+            Privacy Policy
+          </a>
+          .
+        </p>
       </main>
     </div>
   );


### PR DESCRIPTION
## Summary
- `/signin` had no legal consent line — parity drift vs apparule/expendit, and `docs/web-implementation.md` already promised "GoogleAuthButton + legal links". Adds the fleet-common line beneath the CTA/error slot: *"By continuing you agree to the Terms and Privacy Policy."* on the signin type scale (`text-[13px] leading-[1.45] text-text-2`).
- Both links open the canonical **https://terms.cuesoft.io** and **https://privacy.cuesoft.io** in a new tab (`target="_blank" rel="noreferrer"` — the repo's external-link idiom).
- LOCK: `web/e2e/signin.spec.ts` now asserts the consent line renders and both legal links carry exactly the canonical hrefs.
- Docs: `/signin` route-map row updated to describe the consent line (current-system voice).

## Test plan
- CI e2e: new "legal consent line links the canonical Cuesoft policies" test in the signin spec; the existing single-button X-1 assertion is unaffected (links are anchors, not buttons).

🤖 Generated with [Claude Code](https://claude.com/claude-code)