### PR TITLE
perf(web): CLS + TBT — pre-paint rail width, reserved widget frames, deferred demo panels

### DIFF
--- a/docs/web-implementation.md
+++ b/docs/web-implementation.md
@@ -888,3 +888,45 @@ products; per-product values only):
   canonical on `/`, og:image resolves 200 at 1200×630, twitter card, and
   the served favicon's sha256 equals upstat's mark while differing from
   both siblings'.
+
+## 11. Performance budget (as-built, 2026-07-21)
+
+Two budgets, both e2e-locked: **CLS < 0.1** on home and every dashboard
+route, and **interactive-fast above the fold** on the marketing home
+(mobile TBT). Three mechanisms carry them:
+
+- **Pre-paint chrome resolution** — anything that changes the app frame's
+  geometry resolves before first paint, never after. The NavRail's
+  expansion (persisted `nav.rail.expanded`, ≥1280px default) is applied by
+  `navRailInitScript` (root layout, beside the theme/colorvision scripts):
+  it sets `data-nav-expanded` on `<html>`, and the rail's width binds
+  `--nav-rail-w` off that attribute. The width `transition` therefore only
+  ever animates user toggles — a first paint is already final-width. The
+  rail's internal state resolves in a layout effect (same-paint with the
+  hydration commit).
+- **Reserved loading frames** — every §8.1 loading frame holds exactly the
+  footprint of the widget it becomes. The rendered sizes live as
+  `--widget-h-*` tokens in `globals.css` (value tile, list rows, SLO/rule/
+  channel cards, the B8 rule-editor panel, saved-view chip row, facet
+  group, MI-14 banner slot), consumed as `h-(--widget-h-*)` /
+  `min-h-(--widget-h-*)` — no per-page magic numbers. `Skeleton` gains a
+  `frame` kind (bordered shimmer block, height from the token) for these;
+  `TimeseriesPanel` reserves one legend row while loading; the shell holds
+  the IncidentBanner's slot while incidents load. If a widget's
+  construction changes, re-measure and update the token.
+- **Visibility-gated demo panels** — the home page's below-the-fold demo
+  visuals (timeseries SVGs, 90-day uptime strips, snippet blocks) mount
+  through `DeferredPanel` (components/ui): prerender and first client
+  render emit a height-reserving placeholder; the subtree mounts via
+  IntersectionObserver 600px before it scrolls into view. Marketing copy
+  stays outside the wrappers (SEO), and the hero's panels stay eager —
+  only illustrative markup defers. Environments without
+  IntersectionObserver mount immediately.
+
+**Lock** — `web/e2e/layout-stability.spec.ts` computes web-vitals-style
+CLS (layout-shift entries, session-windowed) on `/`, `/dashboard`,
+`/dashboard/monitors` and `/dashboard/metrics` in TEST_MODE and asserts
+< 0.1 per route. Reference numbers (local prod build, Lighthouse mobile,
+median of 3 — devtools throttling; lantern is insensitive on localhost):
+home TBT 7ms / CLS 0.033; layout-shift probe CLS 0.017 (/dashboard),
+0.017 (monitors), 0.025 (metrics).

--- a/web/e2e/dashboard.spec.ts
+++ b/web/e2e/dashboard.spec.ts
@@ -354,7 +354,10 @@ test("full journey: onboarding → B1 → dashboards → explorer → logs → t
       async () =>
         page.getByRole("list", { name: "Log lines" }).locator("li").count(),
       {
-        timeout: 10_000,
+        // 30s, not 10: under dev-server compile contention the first tail
+        // batches can take >10s to land (pre-existing flake documented by
+        // the 2026-07-21 a11y lane) — the tail itself streams every ~2s
+        timeout: 30_000,
       },
     )
     .toBeGreaterThan(tailCount);

--- a/web/e2e/layout-stability.spec.ts
+++ b/web/e2e/layout-stability.spec.ts
@@ -1,0 +1,132 @@
+import { expect, test, type Page } from "@playwright/test";
+
+/**
+ * Layout-stability LOCK (perf pass 2026-07-21). The audited dashboards
+ * shipped CLS 0.23–0.31: the NavRail's 56→240px width entrance slid every
+ * route's content column, the MI-14 IncidentBanner mounted above <main>
+ * after first paint, and §8.1 loading frames didn't reserve their hydrated
+ * sizes. All three are fixed (navRailInitScript pre-paint width, banner
+ * slot reserve, `--widget-h-*` skeleton frames); this spec pins the
+ * budget: web-vitals-style CLS < 0.1 on home and the audited dashboards.
+ *
+ * CLS is computed the way Chrome reports it — layout-shift entries
+ * without recent input, grouped into session windows (≤5s span, ≤1s
+ * gaps), taking the worst window.
+ */
+
+const BUDGET = 0.1;
+
+interface ShiftEntry {
+  value: number;
+  ts: number;
+  sources: string[];
+}
+
+declare global {
+  interface Window {
+    __shifts?: ShiftEntry[];
+  }
+}
+
+test.beforeEach(async ({ page, request }) => {
+  // hermetic seed — earlier specs mutate the shared narrative
+  await request.post("/api/mock/v1/reset");
+  await page.addInitScript(() => {
+    window.__shifts = [];
+    new PerformanceObserver((list) => {
+      for (const entry of list.getEntries()) {
+        const shift = entry as PerformanceEntry & {
+          value: number;
+          hadRecentInput: boolean;
+          sources?: { node: Node | null }[];
+        };
+        if (shift.hadRecentInput) continue;
+        window.__shifts?.push({
+          value: shift.value,
+          ts: entry.startTime,
+          sources: (shift.sources ?? []).map((source) => {
+            const node = source.node;
+            const el =
+              node && node.nodeType === 1
+                ? (node as Element)
+                : (node?.parentElement ?? null);
+            if (!el) return node?.nodeName ?? "?";
+            const testId = el.getAttribute("data-testid");
+            return `${el.tagName.toLowerCase()}${el.id ? `#${el.id}` : ""}${
+              testId ? `[${testId}]` : ""
+            }`;
+          }),
+        });
+      }
+    }).observe({ type: "layout-shift", buffered: true });
+  });
+});
+
+/** Worst session window (5s span / 1s gap) — the CWV CLS definition. */
+async function windowedCls(page: Page): Promise<{
+  cls: number;
+  worst: ShiftEntry[];
+}> {
+  return page.evaluate(() => {
+    const shifts = (window.__shifts ?? []).sort((a, b) => a.ts - b.ts);
+    let max = 0;
+    let current = 0;
+    let windowStart = 0;
+    let last = 0;
+    for (const s of shifts) {
+      if (current > 0 && s.ts - last <= 1000 && s.ts - windowStart <= 5000) {
+        current += s.value;
+      } else {
+        current = s.value;
+        windowStart = s.ts;
+      }
+      last = s.ts;
+      if (current > max) max = current;
+    }
+    return {
+      cls: max,
+      worst: shifts.sort((a, b) => b.value - a.value).slice(0, 5),
+    };
+  });
+}
+
+async function signIn(page: Page) {
+  await page.goto("/signin");
+  await page.getByRole("button", { name: /continue with google/i }).click();
+  await page.waitForURL("**/dashboard**");
+}
+
+async function assertStable(page: Page, route: string, settle: string) {
+  await page.goto(route);
+  await expect(page.getByTestId(settle)).toBeVisible();
+  // hold past hydration + data swaps — late shifts are the regression class
+  await page.waitForTimeout(3_000);
+  const { cls, worst } = await windowedCls(page);
+  expect(
+    cls,
+    `${route} CLS ${cls.toFixed(3)} must stay under ${BUDGET}; worst shifts: ${JSON.stringify(worst)}`,
+  ).toBeLessThan(BUDGET);
+}
+
+test("home stays layout-stable on load (CLS < 0.1)", async ({ page }) => {
+  await page.goto("/");
+  await expect(
+    page.getByRole("heading", { level: 1, name: /All your telemetry\./ }),
+  ).toBeVisible();
+  await page.waitForTimeout(3_000);
+  const { cls, worst } = await windowedCls(page);
+  expect(
+    cls,
+    `home CLS ${cls.toFixed(3)}; worst shifts: ${JSON.stringify(worst)}`,
+  ).toBeLessThan(BUDGET);
+});
+
+test("audited dashboards stay layout-stable on load (CLS < 0.1)", async ({
+  page,
+}) => {
+  test.setTimeout(90_000);
+  await signIn(page);
+  await assertStable(page, "/dashboard", "dashboard-home");
+  await assertStable(page, "/dashboard/monitors", "monitors-page");
+  await assertStable(page, "/dashboard/metrics", "metrics-explorer");
+});

--- a/web/src/app/dashboard/metrics/page.tsx
+++ b/web/src/app/dashboard/metrics/page.tsx
@@ -102,8 +102,12 @@ export default function MetricsExplorerPage() {
         </div>
       </header>
 
-      {/* saved views morph the QueryBar into named chips (MI-18) */}
-      {(ctrl.views.data ?? []).length > 0 && (
+      {/* saved views morph the QueryBar into named chips (MI-18); while
+          loading, hold the chip row's slot — the row materializing pushed
+          the whole explorer down a beat after paint (CLS) */}
+      {ctrl.views.loading ? (
+        <div className="h-(--widget-h-chip-row)" aria-hidden="true" />
+      ) : (ctrl.views.data ?? []).length > 0 ? (
         <ul
           aria-label="Saved views"
           className="flex flex-wrap items-center gap-2"
@@ -119,7 +123,7 @@ export default function MetricsExplorerPage() {
             </li>
           ))}
         </ul>
-      )}
+      ) : null}
 
       <QueryBar
         pills={ctrl.queryState.pills}
@@ -143,12 +147,18 @@ export default function MetricsExplorerPage() {
       <div className="flex min-h-0 flex-1 flex-col gap-5 lg:flex-row">
         {/* FacetSidebar (MI-6) */}
         <aside aria-label="Facets" className="w-full shrink-0 lg:w-52">
+          {/* min-h holds the seeded 8-row group while services load — the
+              facet list growing in pushed the env group + stacked-mobile
+              chart down after paint (CLS) */}
           <FacetGroup
             name="service"
             values={serviceFacets}
             selected={selectedServices}
             onToggle={(value) => ctrl.pivot("service", value)}
             topN={8}
+            className={
+              services.loading ? "min-h-(--widget-h-facets)" : undefined
+            }
           />
           <FacetGroup
             name="env"

--- a/web/src/app/dashboard/monitors/page.tsx
+++ b/web/src/app/dashboard/monitors/page.tsx
@@ -137,9 +137,15 @@ export default function MonitorsPage() {
               </div>
             </header>
             {ctrl.rules.loading ? (
-              <div className="flex flex-col gap-2">
-                {Array.from({ length: 4 }, (_, i) => (
-                  <Skeleton key={i} kind="panel-axis" style={{ height: 88 }} />
+              // frames reserve the hydrated AlertRuleCard footprints (CLS);
+              // count/gap mirror the seeded list construction
+              <div className="flex flex-col gap-3">
+                {Array.from({ length: 5 }, (_, i) => (
+                  <Skeleton
+                    key={i}
+                    kind="frame"
+                    className="h-(--widget-h-rule)"
+                  />
                 ))}
               </div>
             ) : rules.length === 0 ? (
@@ -200,7 +206,15 @@ export default function MonitorsPage() {
               Notification channels
             </h2>
             {ctrl.channels.loading ? (
-              <Skeleton kind="line" />
+              <div className="flex flex-col gap-3">
+                {Array.from({ length: 3 }, (_, i) => (
+                  <Skeleton
+                    key={i}
+                    kind="frame"
+                    className="h-(--widget-h-channel)"
+                  />
+                ))}
+              </div>
             ) : (
               <ul className="flex flex-col gap-3" aria-label="Channels">
                 {(ctrl.channels.data ?? []).map((channel) => (
@@ -228,7 +242,15 @@ export default function MonitorsPage() {
               Triggered
             </h2>
             {ctrl.feed.loading ? (
-              <Skeleton kind="line" />
+              <div className="flex flex-col">
+                {Array.from({ length: 6 }, (_, i) => (
+                  <Skeleton
+                    key={i}
+                    kind="frame"
+                    className="h-(--widget-h-feed-row) rounded-none border-x-0 border-t-0"
+                  />
+                ))}
+              </div>
             ) : (ctrl.feed.data ?? []).length === 0 ? (
               <p className="text-[13px] text-text-2">
                 Quiet — nothing has triggered.
@@ -259,9 +281,20 @@ export default function MonitorsPage() {
           // self-start: the frame (130:2621) shows the editor panel at
           // content height while the rules column runs on below it — the
           // default grid stretch left ~650px of empty panel under the form
-          className="min-w-0 self-start rounded-(--radius) border border-border bg-bg-elev p-5"
+          className={clsx(
+            "min-w-0 self-start rounded-(--radius) border border-border bg-bg-elev p-5",
+            // the editor auto-selects rules[0] once loaded — while loading,
+            // reserve the form's footprint so the panel doesn't grow into
+            // place (CLS); loaded content stands at this height on its own
+            ctrl.rules.loading && "min-h-(--widget-h-editor)",
+          )}
         >
-          {selected ? (
+          {ctrl.rules.loading ? (
+            <div className="flex flex-col gap-4" aria-hidden="true">
+              <Skeleton kind="line" className="w-64" />
+              <Skeleton kind="panel-axis" style={{ height: 200 }} />
+            </div>
+          ) : selected ? (
             <>
               <h2
                 id="editor-heading"

--- a/web/src/app/dashboard/page.tsx
+++ b/web/src/app/dashboard/page.tsx
@@ -29,7 +29,8 @@ export default function DashboardHomePage() {
       >
         {tiles.loading || !tiles.data
           ? Array.from({ length: 4 }, (_, i) => (
-              <Skeleton key={i} kind="value" />
+              // frame reserves the hydrated QueryValue footprint (CLS)
+              <Skeleton key={i} kind="frame" className="h-(--widget-h-value)" />
             ))
           : tiles.data.map((tile) => (
               <QueryValue
@@ -51,7 +52,16 @@ export default function DashboardHomePage() {
             Watched dashboards
           </h2>
           {dashboards.loading ? (
-            <Skeleton kind="line" />
+            // one frame per seeded row height — the list swaps in place
+            <div className="flex flex-col">
+              {Array.from({ length: 3 }, (_, i) => (
+                <Skeleton
+                  key={i}
+                  kind="frame"
+                  className="h-(--widget-h-row) rounded-none border-x-0 border-t-0"
+                />
+              ))}
+            </div>
           ) : watched.length === 0 ? (
             <p className="text-[13px] leading-[1.45] text-text-2">
               No dashboards yet —{" "}
@@ -89,7 +99,15 @@ export default function DashboardHomePage() {
             Triggered monitors
           </h2>
           {feed.loading ? (
-            <Skeleton kind="line" />
+            <div className="flex flex-col">
+              {Array.from({ length: 6 }, (_, i) => (
+                <Skeleton
+                  key={i}
+                  kind="frame"
+                  className="h-(--widget-h-feed-row) rounded-none border-x-0 border-t-0"
+                />
+              ))}
+            </div>
           ) : (feed.data ?? []).length === 0 ? (
             <p className="text-[13px] leading-[1.45] text-text-2">
               Quiet — nothing has triggered.
@@ -117,7 +135,11 @@ export default function DashboardHomePage() {
         {slos.loading ? (
           <div className="grid gap-4 md:grid-cols-3">
             {Array.from({ length: 3 }, (_, i) => (
-              <Skeleton key={i} kind="value" />
+              <Skeleton
+                key={i}
+                kind="frame"
+                className="h-(--widget-h-slo) max-w-64"
+              />
             ))}
           </div>
         ) : (slos.data ?? []).length === 0 ? (

--- a/web/src/app/dashboard/shell.tsx
+++ b/web/src/app/dashboard/shell.tsx
@@ -199,8 +199,16 @@ function ShellChrome({ children }: { children: ReactNode }) {
           )}
         </div>
 
-        {/* MI-14: persistent banner while a sev1/2 incident is open */}
-        {banner && (
+        {/* MI-14: persistent banner while a sev1/2 incident is open. While
+            incidents load, hold the banner's slot — the banner mounting
+            above <main> pushed every route's content down a beat after
+            first paint (CLS perf pass 2026-07-21) */}
+        {shell.incidents.loading ? (
+          <div
+            aria-hidden="true"
+            className="h-(--widget-h-banner) shrink-0 border-b border-border"
+          />
+        ) : banner ? (
           <IncidentBanner
             sev={Math.min(banner.sev, 3) as Sev}
             title={`${banner.key} — ${banner.title}`}
@@ -208,7 +216,7 @@ function ShellChrome({ children }: { children: ReactNode }) {
             responders={[banner.roles.commander, ...banner.roles.responders]}
             onClick={() => router.push(`/dashboard/incidents/${banner.id}`)}
           />
-        )}
+        ) : null}
 
         <main id="main" className="min-w-0 flex-1 overflow-y-auto">
           {/* Suspense above every page: screens read useSearchParams (deep

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -99,6 +99,37 @@
   }
 }
 
+/*
+ * Widget-frame reserve heights (perf pass 2026-07-21, CLS < 0.1 budget):
+ * every §8.1 loading frame reserves its hydrated size so the skeleton →
+ * data swap never moves layout. Values are the RENDERED sizes of the
+ * seeded widgets (desktop, TEST_MODE prod build) — re-derive by measuring
+ * if a widget's construction changes. Consumed as `min-h-(--widget-h-*)` /
+ * `h-(--widget-h-*)`; no per-page magic numbers.
+ */
+:root {
+  /* NavRail width — resolved PRE-PAINT by navRailInitScript (NavRail.tsx):
+     html[data-nav-expanded] flips it, so the app frame never paints
+     collapsed and then slides open (the 56→240px entrance moved every
+     dashboard's content column — the fleet's worst CLS source). */
+  --nav-rail-w: 56px;
+
+  --widget-h-value: 117px; /* QueryValue stat tile (label + 28 value + spark) */
+  --widget-h-row: 40px; /* DashboardListRow */
+  --widget-h-feed-row: 32px; /* AlertFeedRow */
+  --widget-h-slo: 119px; /* SLOCard */
+  --widget-h-rule: 101px; /* AlertRuleCard */
+  --widget-h-channel: 67px; /* AlertChannelCard */
+  --widget-h-editor: 503px; /* B8 rule-editor panel (form + inline replay) */
+  --widget-h-chip-row: 28px; /* SavedViewChip row */
+  --widget-h-facets: 195px; /* FacetGroup, 8 rows + show-all affordance */
+  --widget-h-banner: 39px; /* IncidentBanner (shell MI-14 slot) */
+}
+
+html[data-nav-expanded] {
+  --nav-rail-w: 240px;
+}
+
 /* Component-library keyframes (design.md §4 MIs; consumers pair these
    with motion-reduce fallbacks). */
 @keyframes breathe {

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -5,6 +5,7 @@ import {
   colorVisionInitScript,
 } from "@/design/ColorVisionProvider";
 import { ThemeProvider, themeInitScript } from "@/design/ThemeProvider";
+import { navRailInitScript } from "@/components/ui/NavRail";
 import "./globals.css";
 
 // Design-system fonts (design.md §2): Inter for UI, JetBrains Mono for
@@ -52,11 +53,13 @@ export default function RootLayout({
       suppressHydrationWarning
     >
       <body>
-        {/* pre-paint: applies the persisted `upstat.theme` override and the
-            `upstat.colorvision` mode before first paint — static literal
-            scripts (theme-parity canon; design.md §5 colorblind mode) */}
+        {/* pre-paint: applies the persisted `upstat.theme` override, the
+            `upstat.colorvision` mode and the rail expansion width before
+            first paint — static literal scripts (theme-parity canon;
+            design.md §5 colorblind mode; CLS perf pass 2026-07-21) */}
         <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
         <script dangerouslySetInnerHTML={{ __html: colorVisionInitScript }} />
+        <script dangerouslySetInnerHTML={{ __html: navRailInitScript }} />
         <ThemeProvider>
           <ColorVisionProvider>{children}</ColorVisionProvider>
         </ThemeProvider>

--- a/web/src/components/home/sections-demo.tsx
+++ b/web/src/components/home/sections-demo.tsx
@@ -8,6 +8,7 @@
 import Link from "next/link";
 import type { AlertRule, Series } from "@/models";
 import { AlertRuleCard } from "@/components/ui/AlertRuleCard";
+import { DeferredPanel } from "@/components/ui/DeferredPanel";
 import {
   IncidentHistoryEntry,
   type IncidentHistoryUpdate,
@@ -42,22 +43,28 @@ export function DemoBandSection({
   return (
     <Section id="demo" title="It looks like this — with your data.">
       <div className="grid items-start gap-12 lg:grid-cols-[1fr_480px]">
-        <TimeseriesPanel
-          title="p95 latency — api-common"
-          titleAs="p"
-          unit="ms"
-          query={query}
-          series={series}
-          height={190}
-          className="min-w-0"
-        />
-        <div className="min-w-0 flex flex-col gap-6">
-          <UptimeCard
-            name={heartbeat.name}
-            days={heartbeat.days}
-            uptimePct={heartbeat.uptimePct}
-            p95Ms={heartbeat.p95Ms}
+        {/* demo visuals mount on approach (TBT); the copy and QueryValue
+            tiles stay eager — see DeferredPanel */}
+        <DeferredPanel minHeight={308} className="min-w-0">
+          <TimeseriesPanel
+            title="p95 latency — api-common"
+            titleAs="p"
+            unit="ms"
+            query={query}
+            series={series}
+            height={190}
+            className="min-w-0"
           />
+        </DeferredPanel>
+        <div className="min-w-0 flex flex-col gap-6">
+          <DeferredPanel minHeight={124}>
+            <UptimeCard
+              name={heartbeat.name}
+              days={heartbeat.days}
+              uptimePct={heartbeat.uptimePct}
+              p95Ms={heartbeat.p95Ms}
+            />
+          </DeferredPanel>
           <div className="flex flex-wrap gap-6">
             <QueryValue
               label="availability · api-common"
@@ -141,27 +148,32 @@ export function UseCasesSection({
             body="11 widget types on one grid — timeseries, heatmaps, top lists, log streams, even markdown. Hover anywhere and every panel's crosshair lands on the same moment. Drag, resize, ship."
             readMoreHref="#demo"
           />
-          <TimeseriesPanel
-            title="p95 latency — api-common"
-            titleAs="p"
-            unit="ms"
-            query={query}
-            series={series}
-            height={140}
-            className="min-w-0"
-          />
+          <DeferredPanel minHeight={248} className="min-w-0">
+            <TimeseriesPanel
+              title="p95 latency — api-common"
+              titleAs="p"
+              unit="ms"
+              query={query}
+              series={series}
+              height={140}
+              className="min-w-0"
+            />
+          </DeferredPanel>
         </div>
 
         {/* 2 — alerting → incidents (visual left, copy right) */}
         <div className="grid items-center gap-12 md:grid-cols-[1fr_480px]">
-          <div className="min-w-0 flex flex-col gap-4 md:order-1">
+          <DeferredPanel
+            minHeight={202}
+            className="min-w-0 flex flex-col gap-4 md:order-1"
+          >
             <AlertRuleCard rule={alertRule} />
             <IncidentHistoryEntry
               updates={[incidentUpdate]}
               variant="timeline"
               className="border-b-0 py-0"
             />
-          </div>
+          </DeferredPanel>
           <div className="md:order-2">
             <QuadCard
               title="From alert to postmortem"
@@ -178,7 +190,10 @@ export function UseCasesSection({
             body="Publish uptime and incident history to a page you control at your own slug. Subscribers get updates as your responders post them — the same timeline, no PR filter."
             readMoreHref="#status"
           />
-          <div className="min-w-0 flex flex-col gap-3">
+          <DeferredPanel
+            minHeight={132}
+            className="min-w-0 flex flex-col gap-3"
+          >
             <StatusPageHeader
               overall="operational"
               lastUpdated={statusUpdatedAt}
@@ -192,7 +207,7 @@ export function UseCasesSection({
               uptimePct={statusRow.uptimePct}
               layout="inline"
             />
-          </div>
+          </DeferredPanel>
         </div>
 
         {/* 4 — cookieless RUM (visual left, copy right) */}
@@ -248,7 +263,9 @@ export function StatusEmbedSection({
           updatedFormat="relative"
           updatedPlacement="banner"
         />
-        <div className="flex flex-col gap-3">
+        {/* the two 90-bar strips mount on approach (TBT); the header and
+            the status link above/below stay eager for the e2e/SEO copy */}
+        <DeferredPanel minHeight={140} className="flex flex-col gap-3">
           {rows.map((row) => (
             <StatusPageComponentRow
               key={row.name}
@@ -259,7 +276,7 @@ export function StatusEmbedSection({
               layout="inline"
             />
           ))}
-        </div>
+        </DeferredPanel>
       </div>
       {/* the REAL status page is the in-app B7 route — the imagined
           status.upstat.cuesoft.io host was a dead link (sweep 2026-07-19) */}

--- a/web/src/components/home/sections-top.tsx
+++ b/web/src/components/home/sections-top.tsx
@@ -9,6 +9,7 @@ import type { ApiKey, Series } from "@/models";
 import { APIKeyRow } from "@/components/ui/APIKeyRow";
 import { Button } from "@/components/ui/Button";
 import { CodeSnippet } from "@/components/ui/CodeSnippet";
+import { DeferredPanel } from "@/components/ui/DeferredPanel";
 import { MARKETING_PILLARS, PillarCard } from "@/components/ui/PillarCard";
 import { TimeseriesPanel } from "@/components/ui/TimeseriesPanel";
 import { UptimeCard } from "@/components/ui/UptimeCard";
@@ -140,7 +141,11 @@ export function OtelSection() {
       sub="Point your existing OTel SDKs at one endpoint — gRPC 4317 / HTTP 4318. Nothing proprietary in your code."
     >
       <div className="grid items-center gap-12 lg:grid-cols-[1fr_480px]">
-        <CodeSnippet tabs={OTEL_SNIPPETS} />
+        {/* below-the-fold demo visuals mount on approach (TBT); reserves
+            are the rendered desktop sizes — see DeferredPanel */}
+        <DeferredPanel minHeight={176}>
+          <CodeSnippet tabs={OTEL_SNIPPETS} />
+        </DeferredPanel>
         <div className="flex flex-col gap-5">
           <div
             className="flex flex-wrap items-center gap-3"
@@ -220,7 +225,9 @@ export function HowItWorksSection({ series }: HowItWorksSectionProps) {
           title="Point your SDK at us"
           body="One endpoint — gRPC 4317 / HTTP 4318. No agents to babysit."
         >
-          <CodeSnippet tabs={OTEL_SNIPPETS} />
+          <DeferredPanel minHeight={176}>
+            <CodeSnippet tabs={OTEL_SNIPPETS} />
+          </DeferredPanel>
         </Step>
         <Step
           n={2}
@@ -228,22 +235,24 @@ export function HowItWorksSection({ series }: HowItWorksSectionProps) {
           body="Scoped ingestion tokens — rotate with zero downtime."
         >
           {/* the key row keeps its natural width; scrolls inside at 375w */}
-          <div className="overflow-x-auto">
+          <DeferredPanel minHeight={48} className="overflow-x-auto">
             <APIKeyRow apiKey={DEMO_KEY} />
-          </div>
+          </DeferredPanel>
         </Step>
         <Step
           n={3}
           title="See everything"
           body="Dashboards, traces, logs and alerts light up as data lands."
         >
-          <TimeseriesPanel
-            title="p95 latency — api-common"
-            titleAs="p"
-            unit="ms"
-            series={series}
-            height={130}
-          />
+          <DeferredPanel minHeight={220}>
+            <TimeseriesPanel
+              title="p95 latency — api-common"
+              titleAs="p"
+              unit="ms"
+              series={series}
+              height={130}
+            />
+          </DeferredPanel>
         </Step>
       </div>
     </Section>

--- a/web/src/components/ui/DeferredPanel.test.tsx
+++ b/web/src/components/ui/DeferredPanel.test.tsx
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { act, render, screen } from "@testing-library/react";
+import { DeferredPanel } from "./DeferredPanel";
+
+/** Controllable IntersectionObserver stub (jsdom has none). */
+class ObserverStub {
+  static instances: ObserverStub[] = [];
+  callback: IntersectionObserverCallback;
+  observed: Element[] = [];
+  constructor(cb: IntersectionObserverCallback) {
+    this.callback = cb;
+    ObserverStub.instances.push(this);
+  }
+  observe(el: Element) {
+    this.observed.push(el);
+  }
+  disconnect() {}
+  intersect() {
+    this.callback(
+      [{ isIntersecting: true } as IntersectionObserverEntry],
+      this as unknown as IntersectionObserver,
+    );
+  }
+}
+
+afterEach(() => {
+  ObserverStub.instances = [];
+  vi.unstubAllGlobals();
+});
+
+describe("DeferredPanel", () => {
+  it("reserves min-height and defers children until intersection", () => {
+    vi.stubGlobal("IntersectionObserver", ObserverStub);
+    const { container } = render(
+      <DeferredPanel minHeight={220}>
+        <p>demo panel</p>
+      </DeferredPanel>,
+    );
+    const wrapper = container.firstElementChild as HTMLElement;
+    expect(wrapper).toHaveAttribute("data-deferred", "pending");
+    expect(wrapper.style.minHeight).toBe("220px");
+    expect(screen.queryByText("demo panel")).toBeNull();
+
+    act(() => ObserverStub.instances[0].intersect());
+    expect(screen.getByText("demo panel")).toBeInTheDocument();
+    expect(wrapper).toHaveAttribute("data-deferred", "mounted");
+    // the reserve hands over to the real content's own height
+    expect(wrapper.style.minHeight).toBe("");
+  });
+
+  it("mounts immediately where IntersectionObserver is unavailable", () => {
+    render(
+      <DeferredPanel minHeight={100}>
+        <p>fallback content</p>
+      </DeferredPanel>,
+    );
+    expect(screen.getByText("fallback content")).toBeInTheDocument();
+  });
+});

--- a/web/src/components/ui/DeferredPanel.tsx
+++ b/web/src/components/ui/DeferredPanel.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import {
+  startTransition,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+
+export interface DeferredPanelProps {
+  /**
+   * Reserved footprint until the panel mounts (number = px). Mounting
+   * happens `rootMargin` before the panel scrolls into view, so the
+   * reserve only needs to hold the page's scroll geometry — off-viewport
+   * swaps contribute nothing to CLS.
+   */
+  minHeight: number | string;
+  /** How far outside the viewport to start mounting. */
+  rootMargin?: string;
+  children: ReactNode;
+  className?: string;
+}
+
+/**
+ * DeferredPanel — visibility-gated mount for below-the-fold demo panels
+ * (perf pass 2026-07-21). The home page hydrated every demo panel eagerly —
+ * five 90-day uptime strips (90 tooltip'd bars each), four timeseries SVGs
+ * and two snippet blocks executed inside the load window (live mobile TBT
+ * 772ms). Prerender and first client render emit only a height-reserving
+ * placeholder; the real subtree mounts when it approaches the viewport.
+ * Environments without IntersectionObserver mount immediately.
+ *
+ * Marketing-copy sections stay OUTSIDE these wrappers — deferral is for
+ * illustrative panels whose markup carries no SEO weight.
+ */
+export function DeferredPanel({
+  minHeight,
+  rootMargin = "600px 0px",
+  children,
+  className,
+}: DeferredPanelProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    if (mounted) return;
+    const el = ref.current;
+    if (!el || typeof IntersectionObserver === "undefined") {
+      setMounted(true);
+      return;
+    }
+    const io = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) {
+          // transition: a fast scroll can trip several observers at once —
+          // the heavy subtree mounts must stay interruptible so they never
+          // starve a router navigation (the home CTA handoff)
+          startTransition(() => setMounted(true));
+        }
+      },
+      { rootMargin },
+    );
+    io.observe(el);
+    return () => io.disconnect();
+  }, [mounted, rootMargin]);
+
+  return (
+    <div
+      ref={ref}
+      data-deferred={mounted ? "mounted" : "pending"}
+      className={className}
+      style={mounted ? undefined : { minHeight }}
+    >
+      {mounted ? children : null}
+    </div>
+  );
+}

--- a/web/src/components/ui/NavRail.tsx
+++ b/web/src/components/ui/NavRail.tsx
@@ -20,7 +20,7 @@ import {
 } from "lucide-react";
 import * as Dialog from "@radix-ui/react-dialog";
 import Link from "next/link";
-import { useEffect, useState } from "react";
+import { useLayoutEffect, useState, useSyncExternalStore } from "react";
 import { useMediaQuery } from "@/controllers/use-media-query";
 import { Avatar } from "./Avatar";
 import { BrandMark } from "./BrandMark";
@@ -170,44 +170,93 @@ const EXPANDED_STORAGE_KEY = "nav.rail.expanded";
 const EXPAND_DEFAULT_QUERY = "(min-width: 1280px)";
 
 /**
+ * Pre-paint rail width (CLS): resolves the persisted/viewport-default
+ * expansion BEFORE first paint and sets `data-nav-expanded` on <html> —
+ * the rail's width binds `--nav-rail-w` (globals.css) off that attribute,
+ * so the app frame never paints collapsed and then slides open (the
+ * 56→240px width entrance moved every dashboard's whole content column;
+ * 2026-07-21 perf audit). Same static-literal pattern as themeInitScript.
+ * React re-syncs the attribute after hydration (toggle/resize).
+ */
+export const navRailInitScript =
+  '(function(){try{var s=localStorage.getItem("nav.rail.expanded");var x=s===null?window.matchMedia("(min-width: 1280px)").matches:s==="1";if(x&&window.matchMedia("(min-width: 768px)").matches){document.documentElement.setAttribute("data-nav-expanded","");}}catch(e){}})();';
+
+// -- external expansion store (ThemeProvider pattern: localStorage-backed,
+//    read via useSyncExternalStore — no state syncing through effects; the
+//    hydration consistency check re-renders BEFORE paint, so the resolved
+//    rail never paints a collapsed frame first) --
+
+const railListeners = new Set<() => void>();
+/** In-memory fallback when storage is unavailable (private mode). */
+let railFallback: boolean | null = null;
+let railViewportListenerAttached = false;
+
+function onRailViewportChange(): void {
+  railEmit();
+}
+
+function ensureRailViewportListener(): void {
+  if (railViewportListenerAttached || typeof window === "undefined") return;
+  try {
+    window
+      .matchMedia(EXPAND_DEFAULT_QUERY)
+      .addEventListener("change", onRailViewportChange);
+    railViewportListenerAttached = true;
+  } catch {
+    /* matchMedia unavailable — the default just won't track live */
+  }
+}
+
+function railSubscribe(listener: () => void): () => void {
+  ensureRailViewportListener();
+  railListeners.add(listener);
+  return () => {
+    railListeners.delete(listener);
+  };
+}
+
+function railEmit(): void {
+  for (const listener of railListeners) listener();
+}
+
+function readRailExpanded(): boolean {
+  try {
+    const stored = window.localStorage.getItem(EXPANDED_STORAGE_KEY);
+    if (stored !== null) return stored === "1";
+  } catch {
+    /* storage unavailable — fall through */
+  }
+  if (railFallback !== null) return railFallback;
+  try {
+    return window.matchMedia(EXPAND_DEFAULT_QUERY).matches;
+  } catch {
+    return false;
+  }
+}
+
+function toggleRailExpanded(): void {
+  const next = !readRailExpanded();
+  try {
+    window.localStorage.setItem(EXPANDED_STORAGE_KEY, next ? "1" : "0");
+  } catch {
+    railFallback = next; // non-persistent environments still toggle
+  }
+  railEmit();
+}
+
+/**
  * Rail expansion state — persisted per user (localStorage), defaulting by
- * viewport. Resolved after mount: SSR renders collapsed, so hydration
- * stays deterministic.
+ * viewport. SSR snapshots collapsed (hydration stays deterministic); the
+ * client snapshot resolves in the hydration commit. The WIDTH is resolved
+ * even earlier, by navRailInitScript (pre-paint).
  */
 function useRailExpanded(): [boolean, () => void] {
-  const [expanded, setExpanded] = useState(false);
-
-  // Deferred a tick (use-request pattern): setState stays out of the
-  // synchronous effect body.
-  useEffect(() => {
-    const t = window.setTimeout(() => {
-      try {
-        const stored = window.localStorage.getItem(EXPANDED_STORAGE_KEY);
-        if (stored !== null) {
-          setExpanded(stored === "1");
-          return;
-        }
-      } catch {
-        /* storage unavailable (private mode) — fall through to viewport */
-      }
-      setExpanded(window.matchMedia(EXPAND_DEFAULT_QUERY).matches);
-    }, 0);
-    return () => window.clearTimeout(t);
-  }, []);
-
-  const toggle = () => {
-    setExpanded((prev) => {
-      const next = !prev;
-      try {
-        window.localStorage.setItem(EXPANDED_STORAGE_KEY, next ? "1" : "0");
-      } catch {
-        /* non-persistent environments still toggle in-memory */
-      }
-      return next;
-    });
-  };
-
-  return [expanded, toggle];
+  const expanded = useSyncExternalStore(
+    railSubscribe,
+    readRailExpanded,
+    () => false,
+  );
+  return [expanded, toggleRailExpanded];
 }
 
 export interface NavRailProps {
@@ -363,6 +412,15 @@ export function NavRail({
   const inlineExpanded = expanded && !isMobile;
   const open = isMobile && drawerOpen;
 
+  // keep the pre-paint width attribute (navRailInitScript) in sync with
+  // the hydrated state — toggles and viewport flips flow through here
+  useLayoutEffect(() => {
+    document.documentElement.toggleAttribute(
+      "data-nav-expanded",
+      inlineExpanded,
+    );
+  }, [inlineExpanded]);
+
   const select = (key: string) => {
     setDrawerOpen(false);
     onNavigate?.(key);
@@ -377,7 +435,11 @@ export function NavRail({
           "sticky top-0 z-[var(--z-sticky)] flex h-dvh flex-col gap-1",
           "border-r border-border bg-bg py-2",
           "transition-[width] duration-[var(--duration-base)] ease-standard motion-reduce:transition-none",
-          inlineExpanded ? "w-60 items-stretch px-1.5" : "w-14 items-center",
+          // width rides --nav-rail-w (html[data-nav-expanded], set pre-paint
+          // by navRailInitScript) so the first paint is already final-width;
+          // user toggles still animate via the transition above
+          "w-(--nav-rail-w)",
+          inlineExpanded ? "items-stretch px-1.5" : "items-center",
           className,
         )}
       >

--- a/web/src/components/ui/Skeleton.tsx
+++ b/web/src/components/ui/Skeleton.tsx
@@ -2,7 +2,7 @@
 
 import { clsx } from "clsx";
 
-export type SkeletonKind = "line" | "value" | "panel-axis";
+export type SkeletonKind = "line" | "value" | "panel-axis" | "frame";
 
 export interface SkeletonProps {
   /** §8.2b: kind line / value / panel-axis. */
@@ -17,6 +17,23 @@ export interface SkeletonProps {
  */
 export function Skeleton({ kind = "line", className, style }: SkeletonProps) {
   const shimmer = "animate-pulse motion-reduce:animate-none bg-bg-elev";
+  if (kind === "frame") {
+    // widget-frame placeholder — no intrinsic height; callers bind a
+    // `--widget-h-*` reserve token (globals.css) so the loading frame
+    // holds exactly the hydrated widget's footprint (CLS budget)
+    return (
+      <div
+        data-kind={kind}
+        aria-hidden="true"
+        style={style}
+        className={clsx(
+          "w-full rounded-(--radius) border border-border",
+          shimmer,
+          className,
+        )}
+      />
+    );
+  }
   if (kind === "panel-axis") {
     // axis-first loading: hairline axes + shimmering plot region
     return (

--- a/web/src/components/ui/TimeseriesPanel.tsx
+++ b/web/src/components/ui/TimeseriesPanel.tsx
@@ -576,6 +576,11 @@ export function TimeseriesPanel({
         </div>
       )}
 
+      {/* loading holds one legend-row of space — the legend materializing
+          under the plot nudged everything below the panel (CLS) */}
+      {withLegend && loading && (
+        <footer aria-hidden="true" className="min-h-3.5" />
+      )}
       {withLegend && !empty && !loading && (
         <footer className="flex flex-wrap gap-2">
           {series.map((s, i) => (


### PR DESCRIPTION
## What

Perf fixes adjudicated from the 2026-07-21 audit (upstat ledger, CLS/TBT rows) + one test-hygiene item.

### CLS — dashboards shipped 0.23–0.31
Three root causes, three mechanisms (budget: **CLS < 0.1**):

1. **NavRail width entrance** (the dominant source — it slid every route's whole content column 56→240px over a 200ms transition after first paint). `navRailInitScript` now resolves the persisted/viewport-default expansion **before first paint** (theme-script pattern) via `data-nav-expanded` on `<html>` + `--nav-rail-w`; expansion state moved to the ThemeProvider `useSyncExternalStore` store pattern so internals resolve in the hydration commit. User toggles still animate.
2. **Loading frames didn't reserve their hydrated sizes.** Rendered widget sizes now live as `--widget-h-*` tokens in `globals.css` (value tile, list/feed rows, SLO/rule/channel cards, B8 editor panel, saved-view chip row, facet group, banner slot), consumed via the new `Skeleton kind="frame"` — no per-page magic numbers. `TimeseriesPanel` reserves one legend row while loading.
3. **IncidentBanner mounted above `<main>` after paint** — the shell now holds its slot while incidents load.

### TBT — home hydrated the whole demo eagerly (live mobile TBT 772ms)
New `DeferredPanel` (components/ui): below-the-fold demo visuals (4 timeseries SVGs, 4 of 5 uptime strips = 360 tooltip'd bars, 2 snippet blocks) render a height-reserving placeholder at prerender/first render and mount via IntersectionObserver 600px ahead of the viewport, inside a `startTransition` so mount storms never starve router navigations. Marketing copy stays eager (SEO); hero panels stay eager; seeded-demo determinism and e2e selectors unchanged.

### Test hygiene
`dashboard.spec.ts` live-tail growth poll 10s → 30s (pre-existing flake under dev-server compile contention, documented by the a11y lane).

### Lock
`e2e/layout-stability.spec.ts` — web-vitals-style CLS (session-windowed layout-shift entries) on `/`, `/dashboard`, `/dashboard/monitors`, `/dashboard/metrics` in TEST_MODE, asserting < 0.1 per route. Docs: `web-implementation.md` §11 (perf budget, current-system voice).

## Before / after

Local TEST_MODE prod build. Lighthouse can't carry the per-tab TEST_MODE session, so dashboards use the audit's own instrument (layout-shift PerformanceObserver probe, authed, median of 3); home is Lighthouse mobile (median of 3). Lantern is insensitive on localhost — both throttling methods reported.

| Surface | Metric | Before | After |
|---|---|---|---|
| `/` (LH mobile, **devtools** throttling) | TBT | **109 ms** | **7 ms** |
| `/` (LH mobile, devtools) | CLS | 0.043 | 0.033 |
| `/` (LH mobile, devtools) | Perf score | 0.98 | 1.00 |
| `/` (LH mobile, lantern) | TBT | 40 ms | 11 ms |
| `/` (LH mobile, lantern) | CLS / Perf | 0.005 / 0.94 | 0.005 / 0.94 |
| `/dashboard` (probe, desktop) | CLS | **0.319** | **0.017** |
| `/dashboard/monitors` (probe) | CLS | **0.675** | **0.017** |
| `/dashboard/metrics` (probe) | CLS | **0.276** | **0.025** |

(Localhost on an M-series host can't reproduce the live 772ms TBT absolute — the relative collapse is the signal; the deferral removes the same script-eval the live audit blamed.)

## Gates

prettier ✓ · eslint ✓ · boundaries ✓ (381 files) · typecheck ✓ · vitest 103 files / 363 ✓ · build ✓ · Playwright **78/78** ✓ (PW_PORT=4437; includes the new layout-stability lock)

Remaining home CLS (~0.03) is the hero crosshair tooltip moving via `left` — cosmetic, under budget; noted for a future pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)