### PR TITLE
fix(web): a11y closeout — footer target size, table header, skip link (P15), ⌘K (P12), TEST_MODE key (P16)

### DIFF
--- a/web/e2e/focus-restore.spec.ts
+++ b/web/e2e/focus-restore.spec.ts
@@ -34,6 +34,25 @@ test("palette: Escape works from an option and focus returns to the trigger", as
   await expect(trigger).toBeFocused();
 });
 
+test("palette: ⌘K toggles it (fleet-standard invocation, P12)", async ({
+  page,
+}) => {
+  await signIn(page);
+  const anchor = page.getByTestId("rail-toggle");
+  await anchor.focus();
+  await expect(anchor).toBeFocused();
+
+  await page.keyboard.press("ControlOrMeta+k");
+  const palette = page.getByRole("dialog", { name: "Command palette" });
+  await expect(palette).toBeVisible();
+
+  // Second ⌘K toggles it closed (expendit parity) — even from the search
+  // input — and focus returns to the pre-open element (P4).
+  await page.keyboard.press("ControlOrMeta+k");
+  await expect(palette).toBeHidden();
+  await expect(anchor).toBeFocused();
+});
+
 test('palette: "/" opens it and Escape from the input restores focus too', async ({
   page,
 }) => {

--- a/web/e2e/skip-link.spec.ts
+++ b/web/e2e/skip-link.spec.ts
@@ -1,0 +1,27 @@
+// Skip link — fleet canon (P15, a11y audit 2026-07-21): the rail + chrome
+// are 9+ tab stops before <main> on every dashboard page. The first Tab on
+// a fresh page must land on "Skip to content", and activating it must move
+// focus to the #main landmark (tabIndex={-1}) — not just scroll.
+import { expect, test, type Page } from "@playwright/test";
+
+async function signIn(page: Page) {
+  await page.goto("/signin");
+  await page.getByRole("button", { name: /continue with google/i }).click();
+  await page.waitForURL("**/dashboard**");
+  await expect(page.getByTestId("dashboard-home")).toBeVisible();
+}
+
+test("first Tab lands on the skip link; activating it focuses #main", async ({
+  page,
+}) => {
+  await signIn(page);
+  // Anchor focus at the document start — body is the post-navigation state.
+  await page.locator("body").focus();
+
+  await page.keyboard.press("Tab");
+  const skip = page.getByRole("link", { name: "Skip to content" });
+  await expect(skip).toBeFocused();
+
+  await page.keyboard.press("Enter");
+  await expect(page.locator("main#main")).toBeFocused();
+});

--- a/web/src/app/dashboard/shell.tsx
+++ b/web/src/app/dashboard/shell.tsx
@@ -17,6 +17,7 @@ import { IncidentBanner } from "@/components/ui/IncidentBanner";
 import { NavRail, NAV_PILLARS } from "@/components/ui/NavRail";
 import { NotificationPopover } from "@/components/ui/AlertFeedRow";
 import { ShortcutCheatsheet } from "@/components/ui/ShortcutCheatsheet";
+import { SkipLink } from "@/components/ui/SkipLink";
 import { TimePicker, type TimePreset } from "@/components/ui/TimePicker";
 import { TopBar } from "@/components/ui/TopBar";
 import { ZoomStackChip } from "@/components/ui/ZoomStackChip";
@@ -118,6 +119,9 @@ function ShellChrome({ children }: { children: ReactNode }) {
     // (the logs live-tail list, MI-4 pause-on-scroll) get a real overflow
     // boundary instead of growing the body.
     <div className="font-ui flex h-dvh bg-bg text-text">
+      {/* Fleet canon P15: first focusable on every dashboard page — the
+          rail + chrome are 9+ tab stops before <main> without it. */}
+      <SkipLink />
       {/* Rail items are real <a> links (a11y audit: middle-click/new-tab,
           AT link navigation); the g-chords keep router.push (keyboard.ts). */}
       <NavRail
@@ -218,7 +222,13 @@ function ShellChrome({ children }: { children: ReactNode }) {
           />
         ) : null}
 
-        <main id="main" className="min-w-0 flex-1 overflow-y-auto">
+        {/* tabIndex={-1}: the SkipLink target must take programmatic focus
+            so activation actually moves the keyboard user (P15). */}
+        <main
+          id="main"
+          tabIndex={-1}
+          className="min-w-0 flex-1 overflow-y-auto"
+        >
           {/* Suspense above every page: screens read useSearchParams (deep
               links, ?edit=1, ?service=…) and static prerender requires a
               boundary (missing-suspense-with-csr-bailout). */}

--- a/web/src/auth/test-mode.ts
+++ b/web/src/auth/test-mode.ts
@@ -6,7 +6,9 @@ const TEST_USER: AuthUser = {
   email: "ibukun@cuesoft.io",
 };
 
-const STORAGE_KEY = "upstat_test_session";
+// Fleet canon (P16): TEST_MODE session keys are `<product>.test-session`;
+// upstat keeps sessionStorage (already the dictated storage).
+const STORAGE_KEY = "upstat.test-session";
 
 /**
  * TEST_MODE auth (`NEXT_PUBLIC_TEST_MODE=1`): no Firebase, no network —

--- a/web/src/components/ui/CloudVsSelfHostTable.test.tsx
+++ b/web/src/components/ui/CloudVsSelfHostTable.test.tsx
@@ -34,4 +34,11 @@ describe("CloudVsSelfHostTable — landing instance overrides (Figma 135:688)", 
       screen.getByRole("button", { name: "Deploy with compose" }),
     ).toBeInTheDocument();
   });
+
+  it("keeps an sr-only Feature header when the visible label is empty", () => {
+    render(<CloudVsSelfHostTable featureHeader="" />);
+    expect(
+      screen.getByRole("columnheader", { name: "Feature" }),
+    ).toBeInTheDocument();
+  });
 });

--- a/web/src/components/ui/CloudVsSelfHostTable.tsx
+++ b/web/src/components/ui/CloudVsSelfHostTable.tsx
@@ -15,7 +15,9 @@ export interface CloudVsSelfHostTableProps {
   onTryCloud?: () => void;
   onSelfHost?: () => void;
   /** Header/CTA overrides — the landing v2 instance (Figma 135:688) uses
-   *  an empty feature header, "Upstat Cloud", and "Deploy with compose". */
+   *  an empty feature header, "Upstat Cloud", and "Deploy with compose".
+   *  An empty featureHeader stays visually blank but keeps an sr-only
+   *  "Feature" label so the column header is never empty for AT. */
   featureHeader?: string;
   cloudHeader?: string;
   selfHostHeader?: string;
@@ -64,7 +66,9 @@ export function CloudVsSelfHostTable({
             scope="col"
             className="p-3 text-left text-[13px] font-semibold text-text"
           >
-            {featureHeader}
+            {/* axe empty-table-header (a11y audit 2026-07-21): the landing
+                instance passes "" — keep the visual blank, name the column */}
+            {featureHeader || <span className="sr-only">Feature</span>}
           </th>
           <th
             scope="col"

--- a/web/src/components/ui/MarketingFooter.tsx
+++ b/web/src/components/ui/MarketingFooter.tsx
@@ -113,16 +113,20 @@ export function MarketingFooter({
           <nav
             key={col.heading}
             aria-label={col.heading}
-            className="flex flex-col gap-1.5"
+            className="flex flex-col"
           >
-            <span className="text-[12px] font-semibold uppercase tracking-wide text-text-2">
+            <span className="pb-0.5 text-[12px] font-semibold uppercase tracking-wide text-text-2">
               {col.heading}
             </span>
+            {/* WCAG 2.5.8 target size (a11y audit ×15): each link is a
+                ≥24px flex row — min-h-6 supplies the hit area and the old
+                gap-1.5 rhythm is absorbed into the rows' inner padding, so
+                the rendered text keeps its size and alignment. */}
             {col.links.map((link) => (
               <a
                 key={link.label}
                 href={link.href}
-                className="text-[13px] text-text-2 transition-colors duration-[var(--duration-fast)] hover:text-text"
+                className="flex min-h-6 items-center text-[13px] text-text-2 transition-colors duration-[var(--duration-fast)] hover:text-text"
               >
                 {link.label}
               </a>

--- a/web/src/components/ui/ShortcutCheatsheet.tsx
+++ b/web/src/components/ui/ShortcutCheatsheet.tsx
@@ -21,6 +21,7 @@ const DEFAULT_SHORTCUTS: ShortcutEntry[] = [
   { keys: "g d", label: "Go to dashboards" },
   { keys: "g l", label: "Go to logs" },
   { keys: "g m", label: "Go to monitors" },
+  { keys: "⌘K", label: "Search" },
   { keys: "/", label: "Search" },
   { keys: "e", label: "Toggle dashboard edit mode" },
   { keys: "j", label: "Next log line" },

--- a/web/src/components/ui/SkipLink.tsx
+++ b/web/src/components/ui/SkipLink.tsx
@@ -1,0 +1,15 @@
+/**
+ * SkipLink — fleet canon (P15): the first focusable element in the shell,
+ * visually hidden until keyboard focus, jumps past the chrome to the
+ * `#main` landmark (which carries tabIndex={-1} so focus follows).
+ */
+export function SkipLink() {
+  return (
+    <a
+      href="#main"
+      className="sr-only focus:not-sr-only focus:fixed focus:left-2 focus:top-2 focus:z-[var(--z-overlay)] focus:rounded-(--radius) focus:border focus:border-border focus:bg-bg-elev focus:px-3 focus:py-2 focus:text-[13px] focus:font-medium focus:text-text"
+    >
+      Skip to content
+    </a>
+  );
+}

--- a/web/src/components/ui/TopBar.tsx
+++ b/web/src/components/ui/TopBar.tsx
@@ -22,8 +22,8 @@ export interface TopBarProps {
 }
 
 /**
- * TopBar — §2 layout: org/env switcher · global time picker · search (/) ·
- * bell.
+ * TopBar — §2 layout: org/env switcher · global time picker · search
+ * (⌘K, also "/") · bell.
  *
  * Mobile (<md, 390 support): the fixed-width utility cluster (~770px) used
  * to overflow the clipped document — right-side taps side-scrolled the
@@ -79,8 +79,10 @@ export function TopBar({
       >
         <Search aria-hidden="true" className="size-3.5 shrink-0" />
         <span className="hidden flex-1 text-left md:block">Search</span>
+        {/* fleet-standard invocation hint (P12) — "/" still works and is
+            listed in the ? cheatsheet */}
         <span className="hidden md:inline-flex">
-          <KbdChip keys="/" />
+          <KbdChip keys="⌘K" />
         </span>
       </button>
 

--- a/web/src/controllers/keyboard.ts
+++ b/web/src/controllers/keyboard.ts
@@ -2,8 +2,10 @@
 
 /**
  * MI-17 keyboard map — `g d` dashboards, `g l` logs, `g m` monitors,
- * `/` search, `?` overlay cheatsheet. Sequences time out after 800ms;
- * shortcuts never fire while typing in an input/textarea/select.
+ * ⌘K/Ctrl+K or `/` search, `?` overlay cheatsheet. Sequences time out
+ * after 800ms; shortcuts never fire while typing in an
+ * input/textarea/select — except ⌘K, which toggles the palette from
+ * anywhere (fleet standard P12, expendit parity).
  */
 
 import { useRouter } from "next/navigation";
@@ -32,6 +34,7 @@ export const SHORTCUTS: ShortcutEntry[] = [
   { keys: "g h", label: "Go to home" },
   { keys: "g t", label: "Go to traces" },
   { keys: "g i", label: "Go to incidents" },
+  { keys: "⌘K", label: "Search" },
   { keys: "/", label: "Search" },
   { keys: "e", label: "Toggle dashboard edit mode" },
   { keys: "?", label: "This cheatsheet" },
@@ -70,6 +73,15 @@ export function useKeyboardMap(): KeyboardMapState {
 
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
+      // Fleet-standard palette invocation (P12): ⌘K/Ctrl+K toggles the
+      // palette alongside "/" (the log-search idiom stays). Handled ahead
+      // of the modifier and typing-target guards — like expendit's, it
+      // works from anywhere, inputs included.
+      if (e.key.toLowerCase() === "k" && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        setPaletteOpen((v) => !v);
+        return;
+      }
       if (e.metaKey || e.ctrlKey || e.altKey) return;
       if (isTypingTarget(e.target)) return;
 


### PR DESCRIPTION
Closes the remaining upstat gaps in the 2026-07-21 a11y/perf audit ledger (web-program closeout).

## What

| # | Ledger item | Fix |
|---|---|---|
| 1 | Footer target-size ×15 (axe `target-size`, 166×16px) | `MarketingFooter` column links are now ≥24px `min-h-6` flex rows; the old `gap-1.5` rhythm is absorbed into the rows' inner padding — text size/alignment unchanged (WCAG 2.5.8) |
| 2 | Comparison-table empty `<th>` (axe `empty-table-header`) | `CloudVsSelfHostTable` renders an sr-only "Feature" label when `featureHeader=""` — landing stays visually blank, AT gets a column name (+ unit test) |
| 3 | **P15 skip link (fleet canon)** | New token-only `components/ui/SkipLink.tsx` (first focusable, hidden until focus, `href="#main"`); shell `<main id="main">` takes `tabIndex={-1}` so activation moves focus. e2e: first Tab lands on it, Enter focuses `#main` |
| 4 | **P12 palette invocation (fleet standard)** | ⌘K/Ctrl+K toggles the CommandPalette alongside the existing `/` log-search idiom (expendit parity — works from inputs too). TopBar hint chip shows ⌘K; `?` cheatsheet lists both. e2e: ⌘K opens, second ⌘K closes + restores focus |
| 5 | **P16 TEST_MODE key (dictated canon)** | `upstat_test_session` → `upstat.test-session` (sessionStorage stays); grep-swept — no other reader existed (e2e signs in via `/signin`) |

## Verification

- `grep -rn upstat_test_session web/` → 0 hits post-rename
- New/updated e2e: `web/e2e/skip-link.spec.ts`, `web/e2e/focus-restore.spec.ts` (⌘K toggle) — run by the `web-e2e` CI job
- New unit test: sr-only feature-column header (`CloudVsSelfHostTable.test.tsx`)
- Rebased on `main` @ 1ccfb90 (post docs-lane #203)

🤖 Generated with [Claude Code](https://claude.com/claude-code)