### PR TITLE
docs: changelog — a11y closeout entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   demo panels mount on intersection) both land inside budget (#201).
 
 ### Fixed
+- Accessibility closeout: footer links meet the 24px target-size minimum,
+  the cloud-vs-self-host comparison table names its feature column for
+  assistive tech, a skip-to-content link fronts the app shell, and the
+  command palette opens on ⌘K as well as "/" (#204).
 - Contrast-token canon: AA-compliant `-text` variants for the tinted-chip
   recipe, plus a new `on-crit` token (#196).
 - Signin gains the sibling-parity legal consent line (#200).

--- a/web/e2e/wave-b.spec.ts
+++ b/web/e2e/wave-b.spec.ts
@@ -146,7 +146,9 @@ test("B7: status-page builder edits reflect on the public page", async ({
     .getByRole("button", { name: "Reorder Web frontend" })
     .press("ArrowDown");
   await page.getByTestId("save-status-page").click();
-  await expect(page.getByText("Saved")).toBeVisible();
+  // exact: the settings copy ("Saved changes publish immediately…")
+  // substring-matches a bare "Saved" and trips strict mode.
+  await expect(page.getByText("Saved", { exact: true })).toBeVisible();
 
   // public-URL preview links the slugged public construction
   await expect(page.getByTestId("open-public-page")).toHaveAttribute(


### PR DESCRIPTION
Adds the #204 closeout entry (footer target sizes, named comparison column, skip link, ⌘K palette).

🤖 Generated with [Claude Code](https://claude.com/claude-code)