### PR TITLE
chore(web): deferral-register sweep — CLS tooltip, Radix overlay closeout, manifest, SkipLink parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Changed
+- The command palette and the keyboard-shortcut overlay ride the same dialog
+  primitive as the rest of the overlay set — focus is trapped while they are
+  open; dismissal and focus-restore behavior are unchanged (#206).
+- The demo chart's crosshair tooltip follows the hero loop without shifting
+  layout — home CLS lands at ~0 (#206).
+- The skip-to-content link converges on the fleet-canonical implementation
+  (#206).
 - `/docs/api`'s Scalar reference now loads on user intent instead of shipping
   eagerly with the route (#198).
 - Tree-shape parity: env reads route through typed `config/env.ts`
@@ -27,6 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Signin gains the sibling-parity legal consent line (#200).
 
 ### Added
+- Web app manifest at `/manifest.webmanifest`: install identity — product
+  name, theme colors, and icons (#206).
 - Settings goes route-backed tabs: General | Members | Keys & properties |
   Integrations | Data & privacy | Appearance | Usage — seven deep-linkable
   tabs (#188).

--- a/docs/web-implementation.md
+++ b/docs/web-implementation.md
@@ -616,13 +616,52 @@ clipboard payload, caption persistence and the 1440/390 container fit.
   when `hrefFor` is set (the link navigates). The `g …` chords keep their
   programmatic `router.push` (keyboard.ts). Unit: `NavRail.test.tsx`
   link-mode lock; e2e: `navrail.spec.ts` navigates by link role + href.
-- **Palette dismissal + focus restore (fleet P4).** `CommandPalette`
-  handles Escape on the dialog container (it was input-only — after Tab
-  to an option the palette was un-dismissable), is announced
-  `aria-modal`, and snapshots the opener on open / refocuses it on close.
-  Unit: `CommandPalette.test.tsx`;
+- **Palette dismissal + focus restore (fleet P4).** `CommandPalette` is
+  a Radix Dialog (deferral sweep below): Escape dismisses from anywhere
+  inside it, it is announced `aria-modal` (set explicitly — Radix hides
+  the outside tree instead of announcing modality), and it snapshots the
+  opener on open / synchronously refocuses it on close (Radix's own
+  restore runs a tick later than the lock asserts, so the hand-back
+  stays component-owned). Unit: `CommandPalette.test.tsx`;
   e2e: `focus-restore.spec.ts` (open → Tab inside → Escape → trigger
   refocused, plus the "/" hotkey path).
+
+**Deferral sweep as-built (2026-07-21).** Register closeout, one pass:
+
+- **Overlay canon closed (SKILL.md canonical-libraries).** Every
+  behavior-bearing overlay rides a `@radix-ui` primitive: the W2 set
+  (Modal/Sheet, Tooltip, Select, Switch, Checkbox, the NavRail mobile
+  drawer, NotificationPopover, IncidentComposer autocomplete) plus
+  CommandPalette and ShortcutCheatsheet on `@radix-ui/react-dialog`
+  (the Modal.tsx pattern — Content nested in Overlay, rendered chrome
+  unchanged; focus trap and scrim/Escape dismissal from the primitive).
+  `@floating-ui/*` has zero imports repo-wide (dependency pruned in the
+  code-quality pass; the lockfile entries are Radix-internal). The
+  bespoke layers that remain are positioning-/layout-class, not
+  behavior primitives, and stay bespoke per the floating-layers canon's
+  measure-and-clamp clause: TimePicker's absolute-range panel (designed
+  responsive dual rendering — `<md` fixed full-width sheet under the
+  bar, `md+` right-anchored panel; Escape + in-viewport geometry locked
+  in `dashboard.spec.ts`), QueryBar's suggestion listbox (combobox
+  anchored full-width to its own input; the input keeps focus),
+  SpanDrawer (in-flow detail panel, `<lg` sheet), and Toast (status
+  region — no focus/dismiss semantics).
+- **Crosshair tooltip moves by transform only (CLS).** The
+  TimeseriesPanel plot wrapper is an inline-size container and the
+  crosshair tooltip positions via `translateX(calc(<x>cqw ± own-width
+  flip))` — never `left` — so the hero's 8s crosshair loop produces
+  zero layout-shift entries. Home layout-stability probe (prod build):
+  0.0108 → 0.0001, the tooltip gone from the shift sources.
+- **Web app manifest.** `src/app/manifest.ts` (App Router convention,
+  served at `/manifest.webmanifest`, linked from every route): identity
+  from the root layout metadata ("Upstat" / "All your telemetry. One
+  open platform."), colors from the dark-primary tokens
+  (`--color-bg`), the §10 favicon/apple-icon set. Locked in
+  `e2e/seo.spec.ts` (§10).
+- **SkipLink byte-parity.** `components/ui/SkipLink.tsx` is the
+  byte-identical fleet canonical (sha256 `907bb788…`, default export);
+  the dashboard shell consumes the default export. P15 behavior and the
+  `skip-link.spec.ts` lock are unchanged.
 
 ## 3. Token mapping — design.md §2 → `web/src/design/tokens.css`
 
@@ -904,11 +943,16 @@ products; per-product values only):
   by `web/scripts/generate-brand-assets.mjs` (byte-identical across repos,
   config keyed by package name; Inter via `INTER_WOFF2` or the official
   distribution).
+- **Web manifest** — `src/app/manifest.ts` (App Router convention):
+  name/short_name/description mirror the root metadata, theme/background
+  are the dark-primary `--color-bg`, icons are the favicon + apple-icon
+  set above.
 - **Lock** — `web/e2e/seo.spec.ts` (byte-identical across repos) asserts
   sitemap 200 + exact route set, robots policy + sitemap reference,
-  canonical on `/`, og:image resolves 200 at 1200×630, twitter card, and
+  canonical on `/`, og:image resolves 200 at 1200×630, twitter card,
   the served favicon's sha256 equals upstat's mark while differing from
-  both siblings'.
+  both siblings', and the manifest is linked, resolves, names the
+  product, and every declared icon resolves.
 
 ## 11. Performance budget (as-built, 2026-07-21)
 
@@ -947,7 +991,8 @@ route, and **interactive-fast above the fold** on the marketing home
 **Lock** — `web/e2e/layout-stability.spec.ts` computes web-vitals-style
 CLS (layout-shift entries, session-windowed) on `/`, `/dashboard`,
 `/dashboard/monitors` and `/dashboard/metrics` in TEST_MODE and asserts
-< 0.1 per route. Reference numbers (local prod build, Lighthouse mobile,
-median of 3 — devtools throttling; lantern is insensitive on localhost):
-home TBT 7ms / CLS 0.033; layout-shift probe CLS 0.017 (/dashboard),
-0.017 (monitors), 0.025 (metrics).
+< 0.1 per route. Reference numbers (local prod build; TBT via Lighthouse
+mobile, median of 3 — devtools throttling; lantern is insensitive on
+localhost): home TBT 7ms; layout-shift probe CLS 0.0001 (home — the
+crosshair tooltip moves by transform, deferral sweep above), 0.017
+(/dashboard), 0.017 (monitors), 0.025 (metrics).

--- a/web/e2e/seo.spec.ts
+++ b/web/e2e/seo.spec.ts
@@ -5,7 +5,7 @@ import { expect, test } from "@playwright/test";
 
 /**
  * SEO plumbing lock (fleet, 2026-07-21): sitemap + robots + canonical +
- * og/twitter card + product-branded icons.
+ * og/twitter card + product-branded icons + web manifest.
  *
  * This spec is BYTE-IDENTICAL across apparule/expendit/upstat (tooling
  * canon) — per-product expectations live in the config below keyed by
@@ -151,4 +151,32 @@ test("icons are product-branded and distinct from the sibling products", async (
   const appleRes = await request.get(appleUrl.pathname + appleUrl.search);
   expect(appleRes.status()).toBe(200);
   expect(appleRes.headers()["content-type"]).toContain("image/png");
+});
+
+test("web manifest is linked, resolves, and carries the product identity", async ({
+  page,
+  request,
+}) => {
+  // Linked from the page (App Router `manifest` file convention).
+  await page.goto("/");
+  const href = await page.locator('link[rel="manifest"]').getAttribute("href");
+  expect(href).toBeTruthy();
+  const manifestUrl = new URL(href!, product.base);
+  const res = await request.get(manifestUrl.pathname + manifestUrl.search);
+  expect(res.status()).toBe(200);
+  const manifest = JSON.parse(await res.text()) as {
+    name?: string;
+    icons?: { src: string }[];
+  };
+
+  // The manifest name carries the product (`package.json` name)…
+  expect(manifest.name?.toLowerCase()).toContain(pkgName.toLowerCase());
+
+  // …and every declared icon actually resolves.
+  expect(manifest.icons?.length ?? 0).toBeGreaterThan(0);
+  for (const icon of manifest.icons ?? []) {
+    const iconUrl = new URL(icon.src, product.base);
+    const iconRes = await request.get(iconUrl.pathname + iconUrl.search);
+    expect(iconRes.status(), icon.src).toBe(200);
+  }
 });

--- a/web/src/app/dashboard/shell.tsx
+++ b/web/src/app/dashboard/shell.tsx
@@ -17,7 +17,7 @@ import { IncidentBanner } from "@/components/ui/IncidentBanner";
 import { NavRail, NAV_PILLARS } from "@/components/ui/NavRail";
 import { NotificationPopover } from "@/components/ui/AlertFeedRow";
 import { ShortcutCheatsheet } from "@/components/ui/ShortcutCheatsheet";
-import { SkipLink } from "@/components/ui/SkipLink";
+import SkipLink from "@/components/ui/SkipLink";
 import { TimePicker, type TimePreset } from "@/components/ui/TimePicker";
 import { TopBar } from "@/components/ui/TopBar";
 import { ZoomStackChip } from "@/components/ui/ZoomStackChip";

--- a/web/src/app/manifest.ts
+++ b/web/src/app/manifest.ts
@@ -1,0 +1,34 @@
+import type { MetadataRoute } from "next";
+
+/**
+ * Web app manifest (App Router file convention — served at
+ * /manifest.webmanifest and linked from every route's <head>).
+ * Identity mirrors the root layout metadata; colors are the dark-primary
+ * design tokens (tokens.css :root, design.md §2) — the manifest is static
+ * server output, so the values are inlined rather than var()-bound.
+ * Locked in e2e/seo.spec.ts (fleet-shared): 200 + product name + icons
+ * resolve.
+ */
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: "Upstat",
+    short_name: "Upstat",
+    description: "All your telemetry. One open platform.",
+    start_url: "/",
+    display: "standalone",
+    background_color: "#0e1113", // --color-bg (dark canvas)
+    theme_color: "#0e1113", // --color-bg — browser chrome matches the canvas
+    icons: [
+      {
+        src: "/favicon.ico",
+        sizes: "16x16 32x32 48x48 256x256",
+        type: "image/x-icon",
+      },
+      {
+        src: "/apple-icon.png",
+        sizes: "180x180",
+        type: "image/png",
+      },
+    ],
+  };
+}

--- a/web/src/components/ui/CommandPalette.tsx
+++ b/web/src/components/ui/CommandPalette.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import * as Dialog from "@radix-ui/react-dialog";
 import { clsx } from "clsx";
 import { Search } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
@@ -22,7 +23,14 @@ export interface CommandPaletteProps {
   className?: string;
 }
 
-/** CommandPalette / SearchOverlay — §8.2b: empty / results / no-results. */
+/**
+ * CommandPalette / SearchOverlay — §8.2b: empty / results / no-results.
+ * Radix-Dialog convergence (deferral sweep 2026-07-21): the dialog
+ * behavior — focus trap, Escape-anywhere, outside-dismiss, and the P4
+ * focus restore back to the pre-open element — rides
+ * `@radix-ui/react-dialog`; the rendered chrome is the QA'd markup
+ * unchanged.
+ */
 export function CommandPalette({
   open,
   onClose,
@@ -33,10 +41,11 @@ export function CommandPalette({
   const [query, setQuery] = useState("");
   const [active, setActive] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
-  // Focus restore (2026-07-21 a11y audit, fleet P4): the palette opens
-  // programmatically ("/" or the TopBar search button), so closing must
-  // hand focus back to whatever element had it before the input grabbed
-  // focus — previously it fell to <body>.
+  // Focus restore (fleet P4): the palette opens programmatically ("/",
+  // ⌘K or the TopBar search button), so closing must hand focus back to
+  // whatever element had it before the input grabbed focus. The P4 lock
+  // asserts the restore the moment the palette is gone — Radix's own
+  // restore runs a tick later — so the snapshot/restore pair stays ours.
   const returnFocusRef = useRef<HTMLElement | null>(null);
 
   const results = useMemo(
@@ -59,114 +68,116 @@ export function CommandPalette({
     }
   }
 
-  // Opening snapshots the opener before the input grabs focus; closing
-  // sends focus back once the palette's DOM is gone.
+  // Closing sends focus back synchronously once the palette's DOM is gone.
   useEffect(() => {
-    if (open) {
-      returnFocusRef.current =
-        document.activeElement instanceof HTMLElement
-          ? document.activeElement
-          : null;
-      inputRef.current?.focus();
-    } else {
-      const opener = returnFocusRef.current;
-      returnFocusRef.current = null;
-      if (opener?.isConnected) opener.focus();
-    }
+    if (open) return;
+    const opener = returnFocusRef.current;
+    returnFocusRef.current = null;
+    if (opener?.isConnected) opener.focus();
   }, [open]);
 
-  if (!open) return null;
-
   return (
-    <div
-      role="presentation"
-      onClick={onClose}
-      className="fixed inset-0 z-[var(--z-overlay)] flex items-start justify-center bg-bg/70 pt-[15vh]"
-    >
-      <div
-        role="dialog"
-        aria-modal="true"
-        aria-label="Command palette"
-        onClick={(e) => e.stopPropagation()}
-        // Escape dismisses from ANYWHERE inside the dialog (2026-07-21
-        // a11y audit: it was bound on the search input only, so after Tab
-        // moved focus to an option Escape did nothing).
-        onKeyDown={(e) => {
-          if (e.key === "Escape") onClose();
-        }}
-        className={clsx(
-          "font-ui w-[560px] overflow-hidden rounded-(--radius) border border-border bg-bg-elev shadow-xl",
-          className,
-        )}
-      >
-        <div className="flex items-center gap-2 border-b border-border px-3">
-          <Search aria-hidden="true" className="size-4 text-text-2" />
-          <input
-            ref={inputRef}
-            value={query}
-            onChange={(e) => {
-              setQuery(e.target.value);
-              setActive(0);
+    <Dialog.Root open={open} onOpenChange={(next) => !next && onClose()}>
+      <Dialog.Portal>
+        {/* Content nests inside Overlay so the scrim + flex-positioning
+            layer stays byte-identical (the Modal.tsx convergence pattern). */}
+        <Dialog.Overlay className="fixed inset-0 z-[var(--z-overlay)] flex items-start justify-center bg-bg/70 pt-[15vh]">
+          <Dialog.Content
+            aria-describedby={undefined}
+            // Radix hides the outside tree via aria-hidden but leaves
+            // aria-modal off; the a11y locks assert the attribute.
+            aria-modal="true"
+            // Opening snapshots the opener BEFORE the input grabs focus
+            // (this fires while the pre-open element still has it).
+            onOpenAutoFocus={(e) => {
+              e.preventDefault();
+              returnFocusRef.current =
+                document.activeElement instanceof HTMLElement
+                  ? document.activeElement
+                  : null;
+              inputRef.current?.focus();
             }}
-            onKeyDown={(e) => {
-              if (e.key === "ArrowDown") {
-                e.preventDefault();
-                setActive((a) => Math.min(a + 1, results.length - 1));
-              }
-              if (e.key === "ArrowUp") {
-                e.preventDefault();
-                setActive((a) => Math.max(a - 1, 0));
-              }
-              if (e.key === "Enter" && results[active]) {
-                onSelect?.(results[active]);
-                onClose();
-              }
-            }}
-            placeholder="Search dashboards, monitors, services…"
-            aria-label="Search"
-            className="h-11 flex-1 bg-transparent text-[14px] text-text placeholder:text-text-2 focus:outline-none"
-          />
-        </div>
-        <ul
-          role="listbox"
-          aria-label="Results"
-          className="max-h-72 overflow-y-auto py-1"
-        >
-          {results.length === 0 && (
-            <li className="px-3 py-6 text-center text-[13px] text-text-2">
-              No results for “{query}”
-            </li>
-          )}
-          {results.map((item, i) => {
-            const Icon = item.icon;
-            return (
-              <li key={item.id} role="presentation">
-                <button
-                  type="button"
-                  role="option"
-                  aria-selected={i === active}
-                  onClick={() => {
-                    onSelect?.(item);
+            // The synchronous restore above owns focus hand-back.
+            onCloseAutoFocus={(e) => e.preventDefault()}
+            className={clsx(
+              "font-ui w-[560px] overflow-hidden rounded-(--radius) border border-border bg-bg-elev shadow-xl",
+              className,
+            )}
+          >
+            <Dialog.Title className="sr-only">Command palette</Dialog.Title>
+            <div className="flex items-center gap-2 border-b border-border px-3">
+              <Search aria-hidden="true" className="size-4 text-text-2" />
+              <input
+                ref={inputRef}
+                value={query}
+                onChange={(e) => {
+                  setQuery(e.target.value);
+                  setActive(0);
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === "ArrowDown") {
+                    e.preventDefault();
+                    setActive((a) => Math.min(a + 1, results.length - 1));
+                  }
+                  if (e.key === "ArrowUp") {
+                    e.preventDefault();
+                    setActive((a) => Math.max(a - 1, 0));
+                  }
+                  if (e.key === "Enter" && results[active]) {
+                    onSelect?.(results[active]);
                     onClose();
-                  }}
-                  onMouseEnter={() => setActive(i)}
-                  className={clsx(
-                    "flex w-full items-center gap-2 px-3 py-2 text-left text-[13px] text-text",
-                    "transition-colors duration-[var(--duration-fast)]",
-                    i === active && "bg-bg",
-                  )}
-                >
-                  {Icon && (
-                    <Icon aria-hidden="true" className="size-4 text-text-2" />
-                  )}
-                  <span className="flex-1 truncate">{item.label}</span>
-                  {item.kbd && <KbdChip keys={item.kbd} />}
-                </button>
-              </li>
-            );
-          })}
-        </ul>
-      </div>
-    </div>
+                  }
+                }}
+                placeholder="Search dashboards, monitors, services…"
+                aria-label="Search"
+                className="h-11 flex-1 bg-transparent text-[14px] text-text placeholder:text-text-2 focus:outline-none"
+              />
+            </div>
+            <ul
+              role="listbox"
+              aria-label="Results"
+              className="max-h-72 overflow-y-auto py-1"
+            >
+              {results.length === 0 && (
+                <li className="px-3 py-6 text-center text-[13px] text-text-2">
+                  No results for “{query}”
+                </li>
+              )}
+              {results.map((item, i) => {
+                const Icon = item.icon;
+                return (
+                  <li key={item.id} role="presentation">
+                    <button
+                      type="button"
+                      role="option"
+                      aria-selected={i === active}
+                      onClick={() => {
+                        onSelect?.(item);
+                        onClose();
+                      }}
+                      onMouseEnter={() => setActive(i)}
+                      className={clsx(
+                        "flex w-full items-center gap-2 px-3 py-2 text-left text-[13px] text-text",
+                        "transition-colors duration-[var(--duration-fast)]",
+                        i === active && "bg-bg",
+                      )}
+                    >
+                      {Icon && (
+                        <Icon
+                          aria-hidden="true"
+                          className="size-4 text-text-2"
+                        />
+                      )}
+                      <span className="flex-1 truncate">{item.label}</span>
+                      {item.kbd && <KbdChip keys={item.kbd} />}
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          </Dialog.Content>
+        </Dialog.Overlay>
+      </Dialog.Portal>
+    </Dialog.Root>
   );
 }

--- a/web/src/components/ui/ShortcutCheatsheet.tsx
+++ b/web/src/components/ui/ShortcutCheatsheet.tsx
@@ -1,7 +1,7 @@
 "use client";
 
+import * as Dialog from "@radix-ui/react-dialog";
 import { clsx } from "clsx";
-import { useEffect } from "react";
 import { KbdChip } from "./KbdChip";
 
 export interface ShortcutEntry {
@@ -29,60 +29,55 @@ const DEFAULT_SHORTCUTS: ShortcutEntry[] = [
   { keys: "?", label: "This cheatsheet" },
 ];
 
-/** ShortcutCheatsheet — `?` overlay, 2-col grid (MI-17, §8.2b). */
+/**
+ * ShortcutCheatsheet — `?` overlay, 2-col grid (MI-17, §8.2b).
+ * Radix-Dialog convergence (deferral sweep 2026-07-21): dismissal
+ * (Escape-anywhere per MI-17, scrim click), focus trap and focus restore
+ * ride `@radix-ui/react-dialog`; the rendered chrome is unchanged.
+ */
 export function ShortcutCheatsheet({
   open,
   onClose,
   shortcuts = DEFAULT_SHORTCUTS,
   className,
 }: ShortcutCheatsheetProps) {
-  // ESC dismisses the overlay (MI-17 — the `?` sheet trapped keyboard
-  // users behind a click-only backdrop; system-QA finding 2026-07-19)
-  useEffect(() => {
-    if (!open) return;
-    const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose?.();
-    };
-    window.addEventListener("keydown", onKeyDown);
-    return () => window.removeEventListener("keydown", onKeyDown);
-  }, [open, onClose]);
-
-  if (!open) return null;
   return (
-    <div
-      className="fixed inset-0 z-[var(--z-overlay)] flex items-center justify-center bg-bg/70"
-      onClick={onClose}
-      role="presentation"
-    >
-      <div
-        role="dialog"
-        aria-label="Keyboard shortcuts"
-        onClick={(e) => e.stopPropagation()}
-        className={clsx(
-          "font-ui w-[480px] rounded-(--radius) border border-border bg-bg-elev p-4 shadow-xl",
-          className,
-        )}
-      >
-        <h2 className="mb-3 text-[16px] font-semibold text-text">
-          Keyboard shortcuts
-        </h2>
-        {/* semantic: shortcut map is a definition list (label → keys) */}
-        <dl className="grid grid-cols-2 gap-x-6 gap-y-2">
-          {shortcuts.map((s) => (
-            <div
-              key={s.keys}
-              className="flex items-center justify-between gap-2"
-            >
-              <dt className="text-[13px] leading-[1.45] text-text-2">
-                {s.label}
-              </dt>
-              <dd className="m-0">
-                <KbdChip keys={s.keys} />
-              </dd>
-            </div>
-          ))}
-        </dl>
-      </div>
-    </div>
+    <Dialog.Root open={open} onOpenChange={(next) => !next && onClose?.()}>
+      <Dialog.Portal>
+        {/* Content nests inside Overlay so the scrim + flex-centering
+            layer stays byte-identical (the Modal.tsx convergence pattern). */}
+        <Dialog.Overlay className="fixed inset-0 z-[var(--z-overlay)] flex items-center justify-center bg-bg/70">
+          <Dialog.Content
+            aria-describedby={undefined}
+            className={clsx(
+              "font-ui w-[480px] rounded-(--radius) border border-border bg-bg-elev p-4 shadow-xl",
+              className,
+            )}
+          >
+            <Dialog.Title asChild>
+              <h2 className="mb-3 text-[16px] font-semibold text-text">
+                Keyboard shortcuts
+              </h2>
+            </Dialog.Title>
+            {/* semantic: shortcut map is a definition list (label → keys) */}
+            <dl className="grid grid-cols-2 gap-x-6 gap-y-2">
+              {shortcuts.map((s) => (
+                <div
+                  key={s.keys}
+                  className="flex items-center justify-between gap-2"
+                >
+                  <dt className="text-[13px] leading-[1.45] text-text-2">
+                    {s.label}
+                  </dt>
+                  <dd className="m-0">
+                    <KbdChip keys={s.keys} />
+                  </dd>
+                </div>
+              ))}
+            </dl>
+          </Dialog.Content>
+        </Dialog.Overlay>
+      </Dialog.Portal>
+    </Dialog.Root>
   );
 }

--- a/web/src/components/ui/SkipLink.tsx
+++ b/web/src/components/ui/SkipLink.tsx
@@ -1,15 +1,17 @@
-/**
- * SkipLink — fleet canon (P15): the first focusable element in the shell,
- * visually hidden until keyboard focus, jumps past the chrome to the
- * `#main` landmark (which carries tabIndex={-1} so focus follows).
- */
-export function SkipLink() {
-  return (
-    <a
-      href="#main"
-      className="sr-only focus:not-sr-only focus:fixed focus:left-2 focus:top-2 focus:z-[var(--z-overlay)] focus:rounded-(--radius) focus:border focus:border-border focus:bg-bg-elev focus:px-3 focus:py-2 focus:text-[13px] focus:font-medium focus:text-text"
-    >
-      Skip to content
-    </a>
-  );
-}
+// SkipLink — fleet canon (SKILL.md a11y closeout canons, 2026-07-21).
+// First focusable on every route; visually hidden until keyboard focus;
+// the pill appearing on :focus IS the focus indication. Byte-identical
+// across products (shared-files canon) — utility names only, no
+// product-specific tokens.
+import React from "react";
+
+const SkipLink: React.FC = () => (
+  <a
+    href="#main"
+    className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-50 focus:block focus:rounded-md focus:border focus:border-border focus:bg-bg-elev focus:px-4 focus:py-2 focus:text-[13px] focus:font-medium focus:text-text"
+  >
+    Skip to content
+  </a>
+);
+
+export default SkipLink;

--- a/web/src/components/ui/TimeseriesPanel.tsx
+++ b/web/src/components/ui/TimeseriesPanel.tsx
@@ -200,6 +200,15 @@ export function TimeseriesPanel({
   const n = visible[0]?.points.length ?? 0;
   const cursorIndex =
     cursorFrac !== null && n > 0 ? Math.round(cursorFrac * (n - 1)) : null;
+  // Crosshair x as a percentage of the rendered plot width — fed to the
+  // tooltip as `cqw` units (the plot wrapper is an inline-size container)
+  // so the tooltip moves via transform only. Moving it via `left` made
+  // every hero-loop step a layout shift: the tooltip was the whole of the
+  // home page's CLS (layout-stability probe, deferral sweep 2026-07-21).
+  const cursorPct =
+    cursorIndex !== null
+      ? ((PAD_L + (cursorIndex / Math.max(n - 1, 1)) * innerW) / PLOT_W) * 100
+      : 0;
 
   const fracAt = (clientX: number): number | null => {
     const rect = svgRef.current?.getBoundingClientRect();
@@ -333,7 +342,7 @@ export function TimeseriesPanel({
           className="border-0 bg-transparent p-0"
         />
       ) : (
-        <div className="relative min-w-0">
+        <div className="@container relative min-w-0">
           <svg
             ref={svgRef}
             viewBox={`0 0 ${PLOT_W} ${plotH}`}
@@ -529,20 +538,23 @@ export function TimeseriesPanel({
           {/* crosshair tooltip — FLOATING at the crosshair inside the plot,
               led by the timestamp (master 50:407 crosshair variant:
               "14:32:00 · p50 84 ms · …"); flips sides past plot center so
-              it never leaves the panel */}
+              it never leaves the panel. Positioned by transform ONLY
+              (`cqw` of the @container plot wrapper + own-width flip) —
+              transform moves are composited and never count as layout
+              shifts, where the previous `left` moves put the tooltip on
+              every hero-loop frame's CLS. */}
           {cursorIndex !== null && visible[0]?.points[cursorIndex] && (
             <div
               data-testid="crosshair-tooltip"
               className={clsx(
-                "font-data pointer-events-none absolute top-2 z-10 flex flex-col gap-0.5",
+                "font-data pointer-events-none absolute left-0 top-2 z-10 flex flex-col gap-0.5",
                 "rounded-(--radius) border border-border bg-bg-elev/95 px-2 py-1.5 text-[11px] tabular-nums shadow-lg",
               )}
               style={{
-                left: `${((PAD_L + (cursorIndex / Math.max(n - 1, 1)) * innerW) / PLOT_W) * 100}%`,
                 transform:
                   cursorIndex / Math.max(n - 1, 1) > 0.55
-                    ? "translateX(calc(-100% - 8px))"
-                    : "translateX(8px)",
+                    ? `translateX(calc(${cursorPct}cqw - 100% - 8px))`
+                    : `translateX(calc(${cursorPct}cqw + 8px))`,
               }}
             >
               <span className="text-text-2">


### PR DESCRIPTION
Closes upstat's four deferral-register items in one lean lane.

## 1. Hero crosshair tooltip CLS
The demo chart's crosshair tooltip moved via `left`, so every step of the home hero's 8s loop was a layout shift. The plot wrapper becomes an inline-size container and the tooltip positions by **transform only** (`cqw` + own-width flip).

| probe (prod build, session-windowed) | before | after |
|---|---|---|
| home CLS | **0.0108** (every shift `div[crosshair-tooltip]`) | **0.0001** (tooltip absent from sources) |

## 2. Radix overlay closeout (the codified deviation)
`@floating-ui` enumeration in `web/src/components/ui`: **zero imports** (the W2 convergence + dependency prune already landed). What remained hand-rolled and behavior-bearing — **CommandPalette** and **ShortcutCheatsheet** — now ride `@radix-ui/react-dialog` (Modal.tsx pattern, chrome unchanged). The palette keeps its own opener snapshot + synchronous focus restore (Radix restores a tick later than the P4 lock asserts) and sets `aria-modal` explicitly. Adjudicated bespoke (positioning-/layout-class per the floating-layers canon): TimePicker range panel (responsive sheet/anchored dual rendering, e2e-locked geometry), QueryBar suggestion listbox (combobox, input keeps focus), SpanDrawer (in-flow panel + `<lg` sheet), Toast (status region). Every focus-restore / Escape-anywhere lock passes unchanged. web-implementation.md now describes the current system.

## 3. Web manifest
`src/app/manifest.ts` (App Router convention): identity from root metadata, dark-primary token colors, existing icon set. `e2e/seo.spec.ts` (fleet-shared bytes) gains a generic lock: manifest linked + 200, name carries the package product name, all icons resolve.

## 4. SkipLink byte-parity
`components/ui/SkipLink.tsx` = fleet canonical byte-for-byte (sha256 `907bb788aa625c9963cf26fe8ffe18dcb455c5c09b7a79a4456d32100942a426`); shell adapted to the default export; P15 lock unchanged.

## Gates
prettier ✓ · eslint ✓ · boundaries ✓ · typecheck ✓ · vitest 364/364 ✓ · build (TEST_MODE) ✓ · Playwright 85/85 on :4443 against `next start` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)