### PR TITLE
fix(web): session-restore gate — dashboard gate, /signin reverse guard, failed-restore net

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,7 +125,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   session read reads as signed out instead of throwing past the seam; the
   provider contract (return `null`, never throw) is documented on
   `AuthProvider.currentUser()`, and the e2e cold-start pair locks both
-  directions.
+  directions (#208).
 - Accessibility closeout: footer links meet the 24px target-size minimum,
   the cloud-vs-self-host comparison table names its feature column for
   assistive tech, a skip-to-content link fronts the app shell, and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Session-restore gate hardening (flows/auth.md §2, ratified 2026-07-22):
+  the dashboard now sits behind a session gate — nothing app-side paints
+  until the restored session settles, and a signed-out visitor is replaced
+  to `/signin` — while `/signin` gains the reverse guard (a signed-in
+  visitor is replaced to `/dashboard` and never sees the CTA). A failed
+  session read reads as signed out instead of throwing past the seam; the
+  provider contract (return `null`, never throw) is documented on
+  `AuthProvider.currentUser()`, and the e2e cold-start pair locks both
+  directions.
 - Accessibility closeout: footer links meet the 24px target-size minimum,
   the cloud-vs-self-host comparison table names its feature column for
   assistive tech, a skip-to-content link fronts the app shell, and the

--- a/docs/flows/auth.md
+++ b/docs/flows/auth.md
@@ -19,7 +19,18 @@ returns `PERMISSION_DENIED provider_not_allowed` for non-Google tokens.
 
 Firebase SDK session; gRPC-Web carries `authorization: Bearer <ID token>`
 metadata (interceptor swaps local-JWT verification for Firebase);
-`upstat_token`/`upstat_user` cookies retire. Boundary inventory:
+`upstat_token`/`upstat_user` cookies retire.
+
+**Session restore [Decided 2026-07-22, platform-neutral]**: restore
+resolves **before either surface routes** — the web resolves the
+provider's restored session before dashboard routes render (the
+`DashboardShell` gate), and the mobile on-call companion, when its phase
+opens, runs the same silent restore behind its boot gate. A failed
+restore reads as **signed out** (never an error interstitial) —
+providers resolve `null` and never throw past the seam; a signed-in user
+never sees the auth screen (`/signin` carries the reverse guard).
+
+Boundary inventory:
 
 | Caller | Mechanism |
 | --- | --- |

--- a/docs/web-implementation.md
+++ b/docs/web-implementation.md
@@ -720,6 +720,19 @@ standard]** — `/` home · `/signin` the only auth route · all app surfaces
 under `/dashboard/<area>`, canonical across the CueLABS™ products. Rail
 order per pages.md Part B.
 
+**Session gate (flows/auth.md §2, ratified 2026-07-22).** Restore
+resolves before either surface routes: `DashboardShell` holds rendering
+behind `useRequireAuth` (nothing dashboard-side paints until the session
+read settles — an aria-busy hold, then signed-out visitors replace to
+`/signin`), and `/signin` carries the reverse guard — `SignInGate` wraps
+the screen content (`useRedirectAuthed`; metadata stays on the signin
+layout) so a signed-in visitor is replaced to `/dashboard` and never
+sees the CTA. A failed restore reads as signed out: providers return
+`null`, never throw (the `AuthProvider.currentUser()` contract), and the
+controllers catch as a second net. Locked by the e2e cold-start pair in
+`signin.spec.ts`. The public `/status/{slug}` entry point stays outside
+the gate by construction (it never mounts the shell).
+
 | pages.md | Route | Screen |
 | --- | --- | --- |
 | Part A (A1–A16) | `/` | Public home page |

--- a/web/e2e/completeness.spec.ts
+++ b/web/e2e/completeness.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
 
 /**
  * Demo-completeness features (PR3): portable dashboard JSON import (B2 /
@@ -10,6 +10,15 @@ import { expect, test } from "@playwright/test";
 test.beforeEach(async ({ request }) => {
   await request.post("/api/mock/v1/reset");
 });
+
+// The dashboard is session-gated (flows/auth.md §2) — establish the
+// TEST_MODE session before navigating (suite-standard helper).
+async function signIn(page: Page) {
+  await page.goto("/signin");
+  await page.getByRole("button", { name: /continue with google/i }).click();
+  await page.waitForURL("**/dashboard**");
+  await expect(page.getByTestId("dashboard-home")).toBeVisible();
+}
 
 const PORTABLE = JSON.stringify({
   version: 1,
@@ -36,6 +45,7 @@ const PORTABLE = JSON.stringify({
 test("dashboards: import a portable JSON definition → lands on the new dashboard", async ({
   page,
 }) => {
+  await signIn(page);
   await page.goto("/dashboard/dashboards");
   await page.getByTestId("import-dashboard").click();
   await page.getByTestId("import-json").fill(PORTABLE);
@@ -54,6 +64,7 @@ test("dashboards: import a portable JSON definition → lands on the new dashboa
 test("dashboards: malformed import errors readably, nothing created", async ({
   page,
 }) => {
+  await signIn(page);
   await page.goto("/dashboard/dashboards");
   await page.getByTestId("import-dashboard").click();
   await page.getByTestId("import-json").fill('{"version": 3}');
@@ -62,6 +73,7 @@ test("dashboards: malformed import errors readably, nothing created", async ({
 });
 
 test("RUM: devices and countries breakdowns render (B6)", async ({ page }) => {
+  await signIn(page);
   await page.goto("/dashboard/rum");
   await expect(page.getByRole("heading", { name: "Devices" })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Countries" })).toBeVisible();
@@ -73,6 +85,7 @@ test("RUM: devices and countries breakdowns render (B6)", async ({ page }) => {
 test("traces: the hero span's logs-in-span tab carries correlated lines (B5)", async ({
   page,
 }) => {
+  await signIn(page);
   await page.goto("/dashboard/traces/explorer");
   // the hero trace is the seeded POST /v1/events run; selecting it fires
   // the correlated-logs fetch — wait for it before reading tab counts
@@ -108,6 +121,7 @@ test("traces: the hero span's logs-in-span tab carries correlated lines (B5)", a
 test("monitors: an active alert row opens declare-incident prefilled (B9)", async ({
   page,
 }) => {
+  await signIn(page);
   await page.goto("/dashboard/monitors");
   await page
     .getByRole("list", { name: "Triggered feed" })
@@ -148,6 +162,7 @@ test("nav: Features and Platform anchor different landing sections", async ({
 test("logs: j/k walk the log lines with focus; Enter expands (§5)", async ({
   page,
 }) => {
+  await signIn(page);
   await page.goto("/dashboard/logs");
   // live tail is off by default (?live=1 enables it) — the row window is
   // the static base query, so focus targets stay stable

--- a/web/e2e/mobile-responsive.spec.ts
+++ b/web/e2e/mobile-responsive.spec.ts
@@ -139,7 +139,23 @@ function auditOverflow(): OverflowReport {
   return out;
 }
 
+// The dashboard is session-gated (flows/auth.md §2); the public routes
+// (`/`, `/signin`, `/status/*`) are audited signed OUT — a /signin visit
+// with a session would reverse-guard to /dashboard — so the session is
+// established lazily: one sign-in beat before a test's first gated route
+// (ROUTES orders public first, so the signed-out sweep stays intact).
+const sessioned = new WeakSet<Page>();
+
+async function ensureSession(page: Page, route: string) {
+  if (!route.startsWith("/dashboard") || sessioned.has(page)) return;
+  await page.goto("/signin");
+  await page.getByRole("button", { name: /continue with google/i }).click();
+  await page.waitForURL("**/dashboard**");
+  sessioned.add(page);
+}
+
 async function open(page: Page, route: string) {
+  await ensureSession(page, route);
   await page.goto(route, { waitUntil: "domcontentloaded" });
   // charts/lists render client-side from the mock — give them a beat
   await page.waitForTimeout(1_200);

--- a/web/e2e/signin.spec.ts
+++ b/web/e2e/signin.spec.ts
@@ -51,6 +51,42 @@ test("legal consent line links the canonical Cuesoft policies", async ({
   ).toHaveAttribute("href", "https://privacy.cuesoft.io");
 });
 
+/**
+ * Cold-start matrix (flows/auth.md §2, ratified 2026-07-22): restore
+ * resolves before either surface routes, and each surface guards its
+ * wrong-state visitor.
+ */
+test("cold start signed out: /dashboard replaces to /signin with no dashboard paint", async ({
+  page,
+}) => {
+  await page.goto("/dashboard");
+  await page.waitForURL("**/signin");
+  await expect(page.getByTestId("signin-screen")).toBeVisible();
+  // The dashboard never painted content for the signed-out visitor.
+  await expect(page.getByTestId("dashboard-home")).toHaveCount(0);
+});
+
+test("reverse guard: a signed-in visit to /signin is replaced to /dashboard", async ({
+  page,
+}) => {
+  await page.goto("/signin");
+  await page
+    .getByTestId("signin-screen")
+    .getByRole("button", { name: /continue with google/i })
+    .click();
+  await page.waitForURL("**/dashboard");
+
+  // Same tab (the TEST_MODE session is sessionStorage-held, per-tab):
+  // /signin is not a reachable surface while signed in — the SignInGate
+  // replaces to the app and the CTA never paints.
+  await page.goto("/signin");
+  await page.waitForURL("**/dashboard");
+  await expect(page.getByTestId("dashboard-home")).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: /continue with google/i }),
+  ).toHaveCount(0);
+});
+
 test("/login 404s on the branded page (redirect stub removed 2026-07-19)", async ({
   page,
 }) => {

--- a/web/src/app/dashboard/shell.tsx
+++ b/web/src/app/dashboard/shell.tsx
@@ -21,6 +21,7 @@ import SkipLink from "@/components/ui/SkipLink";
 import { TimePicker, type TimePreset } from "@/components/ui/TimePicker";
 import { TopBar } from "@/components/ui/TopBar";
 import { ZoomStackChip } from "@/components/ui/ZoomStackChip";
+import { useRequireAuth } from "@/controllers/auth";
 import {
   ageLabel,
   useCurrentUserName,
@@ -257,6 +258,24 @@ function ShellChrome({ children }: { children: ReactNode }) {
 }
 
 export function DashboardShell({ children }: { children: ReactNode }) {
+  const { user, checked } = useRequireAuth();
+
+  // Session gate (flows/auth.md §2, ratified 2026-07-22): nothing
+  // dashboard-side paints until the session read settles; a signed-out
+  // visitor is replaced to /signin (useRequireAuth) and never sees the
+  // app chrome. Covers both the in-flight read and the replace beat.
+  if (!checked || !user) {
+    return (
+      <div
+        aria-busy="true"
+        data-testid="dashboard-gate"
+        className="flex min-h-screen items-center justify-center bg-bg"
+      >
+        <span className="sr-only">Loading…</span>
+      </div>
+    );
+  }
+
   return (
     <TimeRangeProvider>
       <ShellChrome>{children}</ShellChrome>

--- a/web/src/app/signin/SignInGate.test.tsx
+++ b/web/src/app/signin/SignInGate.test.tsx
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { SignInGate } from "./SignInGate";
+
+const replace = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace, push: vi.fn(), prefetch: vi.fn() }),
+}));
+
+// Fleet P16 session shape: `upstat.test-session`, sessionStorage, JSON user.
+const SESSION = JSON.stringify({
+  id: "usr_ibukun",
+  name: "Ibukun",
+  email: "ibukun@cuesoft.io",
+});
+
+describe("SignInGate (flows/auth.md §2 — the /signin reverse guard)", () => {
+  beforeEach(() => {
+    replace.mockClear();
+    window.sessionStorage.clear();
+  });
+
+  it("holds an aria-busy gate on first paint while the session read is in flight", () => {
+    render(
+      <SignInGate>
+        <p>cta</p>
+      </SignInGate>,
+    );
+    // Synchronous first paint — the deferred read hasn't run yet: never
+    // the CTA.
+    expect(screen.getByTestId("signin-gate")).toBeInTheDocument();
+    expect(screen.queryByText("cta")).not.toBeInTheDocument();
+  });
+
+  it("renders the screen for a signed-out visitor", async () => {
+    render(
+      <SignInGate>
+        <p>cta</p>
+      </SignInGate>,
+    );
+    expect(await screen.findByText("cta")).toBeInTheDocument();
+    expect(screen.queryByTestId("signin-gate")).not.toBeInTheDocument();
+    expect(replace).not.toHaveBeenCalled();
+  });
+
+  it("replaces a signed-in visitor to /dashboard without ever painting the CTA", async () => {
+    window.sessionStorage.setItem("upstat.test-session", SESSION);
+    render(
+      <SignInGate>
+        <p>cta</p>
+      </SignInGate>,
+    );
+    await waitFor(() => expect(replace).toHaveBeenCalledWith("/dashboard"));
+    expect(screen.queryByText("cta")).not.toBeInTheDocument();
+    expect(screen.getByTestId("signin-gate")).toBeInTheDocument();
+  });
+});

--- a/web/src/app/signin/SignInGate.tsx
+++ b/web/src/app/signin/SignInGate.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+/**
+ * SignInGate — the /signin reverse guard (flows/auth.md §2, ratified
+ * 2026-07-22: restore resolves before either surface routes; a signed-in
+ * user never sees the auth screen). Wraps the screen content (metadata
+ * stays on the signin layout): signed in → replace to /dashboard
+ * (useRedirectAuthed), session read in flight → an aria-busy hold
+ * (per-tab sessionStorage, one deferred tick — a negligible beat); only
+ * signed out renders the CTA. DashboardShell holds the mirror-image gate
+ * (useRequireAuth).
+ */
+
+import type { ReactNode } from "react";
+import { useRedirectAuthed } from "@/controllers/auth";
+
+export function SignInGate({ children }: { children: ReactNode }) {
+  const { user, checked } = useRedirectAuthed();
+
+  if (!checked || user) {
+    // Covers both the in-flight read and the signed-in replace-in-progress.
+    return (
+      <div
+        aria-busy="true"
+        data-testid="signin-gate"
+        className="flex min-h-screen items-center justify-center bg-bg"
+      >
+        <span className="sr-only">Loading…</span>
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/web/src/app/signin/page.tsx
+++ b/web/src/app/signin/page.tsx
@@ -3,6 +3,7 @@
 import { useAuthController } from "@/controllers/auth";
 import { BrandMark } from "@/components/ui/BrandMark";
 import { GoogleAuthButton } from "@/components/ui/GoogleAuthButton";
+import { SignInGate } from "./SignInGate";
 
 /**
  * /signin — the single auth screen (X-1: Google sign-in only, product-wide;
@@ -10,64 +11,68 @@ import { GoogleAuthButton } from "@/components/ui/GoogleAuthButton";
  * /login or /signup exists, and stale links 404 on the branded page
  * [Directive 2026-07-19]). One CTA, nothing else. Composition per the X-1
  * canon frame (124:6): centered bolt + wordmark over "Sign in to your
- * organization" over the Google CTA.
+ * organization" over the Google CTA. SignInGate is the flows/auth.md §2
+ * reverse guard: a signed-in visitor is replaced to /dashboard and never
+ * sees this screen.
  */
 export default function SignInPage() {
   const { signInWithGoogle, loading, error } = useAuthController();
 
   return (
-    <div
-      data-testid="signin-screen"
-      className="font-ui flex min-h-screen items-center justify-center bg-bg px-[var(--space-4)] text-text"
-    >
-      <main className="flex w-full max-w-[360px] flex-col items-center gap-[var(--space-6)] text-center">
-        <header className="flex flex-col items-center gap-[var(--space-3)]">
-          <BrandMark
-            wordmark
-            className="gap-2.5 text-[26px]"
-            glyphClassName="size-7"
+    <SignInGate>
+      <div
+        data-testid="signin-screen"
+        className="font-ui flex min-h-screen items-center justify-center bg-bg px-[var(--space-4)] text-text"
+      >
+        <main className="flex w-full max-w-[360px] flex-col items-center gap-[var(--space-6)] text-center">
+          <header className="flex flex-col items-center gap-[var(--space-3)]">
+            <BrandMark
+              wordmark
+              className="gap-2.5 text-[26px]"
+              glyphClassName="size-7"
+            />
+            <h1 className="text-[14px] font-normal leading-[1.45] text-text-2">
+              Sign in to your organization
+            </h1>
+          </header>
+
+          <GoogleAuthButton
+            onClick={() => void signInWithGoogle()}
+            loading={loading}
+            className="w-full max-w-[280px]"
           />
-          <h1 className="text-[14px] font-normal leading-[1.45] text-text-2">
-            Sign in to your organization
-          </h1>
-        </header>
 
-        <GoogleAuthButton
-          onClick={() => void signInWithGoogle()}
-          loading={loading}
-          className="w-full max-w-[280px]"
-        />
+          {error && (
+            <p role="alert" className="text-[13px] leading-[1.45] text-crit">
+              Sign-in failed. Please try again.
+            </p>
+          )}
 
-        {error && (
-          <p role="alert" className="text-[13px] leading-[1.45] text-crit">
-            Sign-in failed. Please try again.
+          {/* Legal consent line (sibling parity: apparule/expendit signin) —
+              links open the canonical Cuesoft policies in a new tab. */}
+          <p className="text-[13px] leading-[1.45] text-text-2">
+            By continuing you agree to the{" "}
+            <a
+              href="https://terms.cuesoft.io"
+              target="_blank"
+              rel="noreferrer"
+              className="underline underline-offset-2 transition-colors duration-[var(--duration-fast)] hover:text-text"
+            >
+              Terms
+            </a>{" "}
+            and{" "}
+            <a
+              href="https://privacy.cuesoft.io"
+              target="_blank"
+              rel="noreferrer"
+              className="underline underline-offset-2 transition-colors duration-[var(--duration-fast)] hover:text-text"
+            >
+              Privacy Policy
+            </a>
+            .
           </p>
-        )}
-
-        {/* Legal consent line (sibling parity: apparule/expendit signin) —
-            links open the canonical Cuesoft policies in a new tab. */}
-        <p className="text-[13px] leading-[1.45] text-text-2">
-          By continuing you agree to the{" "}
-          <a
-            href="https://terms.cuesoft.io"
-            target="_blank"
-            rel="noreferrer"
-            className="underline underline-offset-2 transition-colors duration-[var(--duration-fast)] hover:text-text"
-          >
-            Terms
-          </a>{" "}
-          and{" "}
-          <a
-            href="https://privacy.cuesoft.io"
-            target="_blank"
-            rel="noreferrer"
-            className="underline underline-offset-2 transition-colors duration-[var(--duration-fast)] hover:text-text"
-          >
-            Privacy Policy
-          </a>
-          .
-        </p>
-      </main>
-    </div>
+        </main>
+      </div>
+    </SignInGate>
   );
 }

--- a/web/src/auth/provider.ts
+++ b/web/src/auth/provider.ts
@@ -16,6 +16,14 @@ export interface AuthProvider {
   /** The one sign-in path this product has (X-1). Resolves once a session exists. */
   signInWithGoogle(): Promise<AuthUser>;
   signOut(): Promise<void>;
+  /**
+   * Synchronous snapshot of the current session (null = signed out).
+   * Contract (flows/auth.md §2, ratified 2026-07-22): a failed session
+   * read reads as **signed out** — implementations return `null` on any
+   * failure and MUST NOT throw; the controllers still catch as a second
+   * net so a misbehaving provider can never strand a guard at its
+   * loading state.
+   */
   currentUser(): AuthUser | null;
   /** Bearer token for repository calls; null when signed out. */
   idToken(): Promise<string | null>;

--- a/web/src/auth/test-mode.test.ts
+++ b/web/src/auth/test-mode.test.ts
@@ -15,6 +15,12 @@ describe("TestModeAuthProvider", () => {
     expect(await provider.idToken()).toBe("test-mode-token");
   });
 
+  it("reads a corrupted session as signed out (flows/auth.md §2: null, never throw)", () => {
+    window.sessionStorage.setItem("upstat.test-session", "{not json");
+    const provider = new TestModeAuthProvider();
+    expect(provider.currentUser()).toBeNull();
+  });
+
   it("clears the session on signOut", async () => {
     const provider = new TestModeAuthProvider();
     await provider.signInWithGoogle();

--- a/web/src/auth/test-mode.ts
+++ b/web/src/auth/test-mode.ts
@@ -32,7 +32,14 @@ export class TestModeAuthProvider implements AuthProvider {
   currentUser(): AuthUser | null {
     if (typeof window === "undefined") return null;
     const raw = window.sessionStorage.getItem(STORAGE_KEY);
-    return raw ? (JSON.parse(raw) as AuthUser) : null;
+    if (!raw) return null;
+    try {
+      return JSON.parse(raw) as AuthUser;
+    } catch {
+      // flows/auth.md §2: a corrupted session reads as signed out — the
+      // provider contract (provider.ts) is null, never throw.
+      return null;
+    }
   }
 
   async idToken(): Promise<string | null> {

--- a/web/src/controllers/auth.test.tsx
+++ b/web/src/controllers/auth.test.tsx
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+import type { AuthUser } from "@/auth/provider";
+import { useRedirectAuthed, useRequireAuth } from "./auth";
+
+const replace = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace, push: vi.fn(), prefetch: vi.fn() }),
+}));
+
+// A provider that violates its own contract (auth/provider.ts: return
+// null, never throw) — the controllers' second net must map it to signed
+// out (flows/auth.md §2), never a stranded loading state.
+vi.mock("@/auth", () => ({
+  getAuthProvider: () => {
+    throw new Error("restore exploded");
+  },
+}));
+
+describe("session-read failure net (flows/auth.md §2)", () => {
+  beforeEach(() => {
+    replace.mockClear();
+  });
+
+  it("useRequireAuth: a throwing provider reads as signed out → /signin", async () => {
+    let state: { user: AuthUser | null; checked: boolean } = {
+      user: null,
+      checked: false,
+    };
+    const Probe = () => {
+      state = useRequireAuth();
+      return null;
+    };
+    render(<Probe />);
+    await waitFor(() => expect(state.checked).toBe(true));
+    expect(state.user).toBeNull();
+    expect(replace).toHaveBeenCalledWith("/signin");
+  });
+
+  it("useRedirectAuthed: a throwing provider reads as signed out → the CTA renders", async () => {
+    let state: { user: AuthUser | null; checked: boolean } = {
+      user: null,
+      checked: false,
+    };
+    const Probe = () => {
+      state = useRedirectAuthed();
+      return null;
+    };
+    render(<Probe />);
+    await waitFor(() => expect(state.checked).toBe(true));
+    expect(state.user).toBeNull();
+    expect(replace).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/controllers/auth.ts
+++ b/web/src/controllers/auth.ts
@@ -1,8 +1,8 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import { getAuthProvider } from "@/auth";
+import { getAuthProvider, type AuthUser } from "@/auth";
 
 /**
  * Auth controller — the single Google CTA flow (X-1, flows/auth.md).
@@ -32,4 +32,73 @@ export function useAuthController() {
   }, [router]);
 
   return { signInWithGoogle, signOut, loading, error };
+}
+
+/**
+ * Session read with the flows/auth.md §2 failure net: a failed restore
+ * reads as **signed out** — a throwing provider can never strand a guard
+ * at its loading state. Providers already contract to return null
+ * (auth/provider.ts); this is the second net.
+ */
+function readSession(): AuthUser | null {
+  try {
+    return getAuthProvider().currentUser();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Dashboard-side session gate (flows/auth.md §2, ratified 2026-07-22):
+ * nothing under /dashboard paints until the session read settles — a
+ * signed-out visitor is replaced to /signin. Deferred a tick (shell.ts
+ * pattern): the session lives in per-tab sessionStorage, so
+ * SSR/hydration must render without it; `checked` distinguishes "still
+ * reading" from "signed out" so the shell can hold its loading state.
+ */
+export function useRequireAuth(): { user: AuthUser | null; checked: boolean } {
+  const router = useRouter();
+  const [state, setState] = useState<{
+    user: AuthUser | null;
+    checked: boolean;
+  }>({ user: null, checked: false });
+
+  useEffect(() => {
+    const t = window.setTimeout(() => {
+      const user = readSession();
+      setState({ user, checked: true });
+      if (!user) router.replace("/signin");
+    }, 0);
+    return () => window.clearTimeout(t);
+  }, [router]);
+
+  return state;
+}
+
+/**
+ * Reverse guard for /signin (flows/auth.md §2, ratified 2026-07-22): a
+ * signed-in user never sees the auth screen — the gate replaces to
+ * /dashboard. A failed read is signed out (readSession), which lands on
+ * the sign-in screen itself.
+ */
+export function useRedirectAuthed(): {
+  user: AuthUser | null;
+  checked: boolean;
+} {
+  const router = useRouter();
+  const [state, setState] = useState<{
+    user: AuthUser | null;
+    checked: boolean;
+  }>({ user: null, checked: false });
+
+  useEffect(() => {
+    const t = window.setTimeout(() => {
+      const user = readSession();
+      setState({ user, checked: true });
+      if (user) router.replace("/dashboard");
+    }, 0);
+    return () => window.clearTimeout(t);
+  }, [router]);
+
+  return state;
 }


### PR DESCRIPTION
## Summary

Canon sweep from apparule (org parity canon #4 + flows/auth.md §2, ratified 2026-07-22): tri-state session restore resolves **before either surface routes**; a failed restore reads as **signed out**; a signed-in user never sees the auth screen.

**Audit found**
- **No dashboard-side gate at all** — `DashboardShell` painted the full app chrome for signed-out visitors; nothing redirected to `/signin`.
- `/signin` had **no reverse guard** — a signed-in visitor saw the CTA.
- `TestModeAuthProvider.currentUser()` **threw on a corrupted session** (raw `JSON.parse`), and the provider contract was undocumented; no consumer had a failure net.

**Fixes**
- `DashboardShell` session gate via the new `useRequireAuth` controller: aria-busy hold until the read settles; signed-out → `router.replace("/signin")`; nothing app-side paints meanwhile. The public `/status/{slug}` entry stays outside the gate by construction.
- `SignInGate` client wrapper on `/signin` (metadata stays on the signin layout): signed in → `router.replace("/dashboard")` via `useRedirectAuthed`; read-in-flight → the same hold; signed out → the CTA.
- Provider stops throwing (corrupted session → `null`), `readSession` try/catch second net in the controllers, contract documented on `AuthProvider.currentUser()` (return `null`, never throw).
- e2e cold-start pair locks both directions (signed-out `/dashboard` → `/signin` with no dashboard paint; signed-in `/signin` → `/dashboard`); unit locks for the gate, the net, and the corrupted-session read. The completeness suite and the responsive sweeps now establish the TEST_MODE session before gated routes (public routes stay audited signed out).
- Docs: flows/auth.md §2 platform-neutral ruling; web-implementation.md §4 session-gate note; CHANGELOG (Fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)