### PR TITLE
fix(web): SkipLink mounts at the root layout — every route, per fleet canon P15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Skip-to-content now mounts once from the root layout instead of only the
+  dashboard shell, so marketing routes (`/`, `/signin`, `/docs/api`, public
+  status pages, the 404) get the fleet-canonical (P15) first-focusable link
+  too — every route's `<main>` carries the matching `id="main"` +
+  `tabIndex={-1}` target, and the e2e coverage now locks the flow on a
+  marketing route in addition to the dashboard.
 - Docs currency pass: corrected the dark/light design-token inversion, the
   redis and Aiven-Postgres-vs-current-state mismatches, Resend→Brevo (X-7),
   and the mock-CRUD-vs-gRPC-Web control-plane framing across the README and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,7 +140,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   status pages, the 404) get the fleet-canonical (P15) first-focusable link
   too — every route's `<main>` carries the matching `id="main"` +
   `tabIndex={-1}` target, and the e2e coverage now locks the flow on a
-  marketing route in addition to the dashboard.
+  marketing route in addition to the dashboard (#211).
 - Docs currency pass: corrected the dark/light design-token inversion, the
   redis and Aiven-Postgres-vs-current-state mismatches, Resend→Brevo (X-7),
   and the mock-CRUD-vs-gRPC-Web control-plane framing across the README and

--- a/web/e2e/skip-link.spec.ts
+++ b/web/e2e/skip-link.spec.ts
@@ -1,7 +1,9 @@
-// Skip link — fleet canon (P15, a11y audit 2026-07-21): the rail + chrome
-// are 9+ tab stops before <main> on every dashboard page. The first Tab on
-// a fresh page must land on "Skip to content", and activating it must move
-// focus to the #main landmark (tabIndex={-1}) — not just scroll.
+// Skip link — fleet canon (P15, a11y audit 2026-07-21): first focusable on
+// EVERY route, mounted once from the root layout — not just the dashboard
+// shell (the rail + chrome there are 9+ tab stops before <main>). The first
+// Tab on a fresh page load must land on "Skip to content", and activating it
+// must move focus to the route's #main landmark (tabIndex={-1}) — not just
+// scroll.
 import { expect, test, type Page } from "@playwright/test";
 
 async function signIn(page: Page) {
@@ -11,10 +13,7 @@ async function signIn(page: Page) {
   await expect(page.getByTestId("dashboard-home")).toBeVisible();
 }
 
-test("first Tab lands on the skip link; activating it focuses #main", async ({
-  page,
-}) => {
-  await signIn(page);
+async function expectSkipLinkFlow(page: Page) {
   // Anchor focus at the document start — body is the post-navigation state.
   await page.locator("body").focus();
 
@@ -24,4 +23,29 @@ test("first Tab lands on the skip link; activating it focuses #main", async ({
 
   await page.keyboard.press("Enter");
   await expect(page.locator("main#main")).toBeFocused();
+}
+
+test("home: first Tab lands on the skip link; activating it focuses #main", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await expectSkipLinkFlow(page);
+});
+
+test("signin: first Tab lands on the skip link; activating it focuses #main", async ({
+  page,
+}) => {
+  await page.goto("/signin");
+  await expectSkipLinkFlow(page);
+});
+
+test("dashboard: first Tab lands on the skip link; activating it focuses #main", async ({
+  page,
+}) => {
+  await signIn(page);
+  // Fresh document load: the signin click leaves the browser's
+  // sequential-focus start point on a disconnected node after the
+  // client-side redirect — the skip link contract is about page loads.
+  await page.goto("/dashboard");
+  await expectSkipLinkFlow(page);
 });

--- a/web/src/app/dashboard/shell.tsx
+++ b/web/src/app/dashboard/shell.tsx
@@ -17,7 +17,6 @@ import { IncidentBanner } from "@/components/ui/IncidentBanner";
 import { NavRail, NAV_PILLARS } from "@/components/ui/NavRail";
 import { NotificationPopover } from "@/components/ui/AlertFeedRow";
 import { ShortcutCheatsheet } from "@/components/ui/ShortcutCheatsheet";
-import SkipLink from "@/components/ui/SkipLink";
 import { TimePicker, type TimePreset } from "@/components/ui/TimePicker";
 import { TopBar } from "@/components/ui/TopBar";
 import { ZoomStackChip } from "@/components/ui/ZoomStackChip";
@@ -120,9 +119,6 @@ function ShellChrome({ children }: { children: ReactNode }) {
     // (the logs live-tail list, MI-4 pause-on-scroll) get a real overflow
     // boundary instead of growing the body.
     <div className="font-ui flex h-dvh bg-bg text-text">
-      {/* Fleet canon P15: first focusable on every dashboard page — the
-          rail + chrome are 9+ tab stops before <main> without it. */}
-      <SkipLink />
       {/* Rail items are real <a> links (a11y audit: middle-click/new-tab,
           AT link navigation); the g-chords keep router.push (keyboard.ts). */}
       <NavRail

--- a/web/src/app/dev/components/gallery.tsx
+++ b/web/src/app/dev/components/gallery.tsx
@@ -1589,8 +1589,9 @@ export function ComponentGallery() {
       {/* Semantic landmark: the gallery body is the page's single <main>
           (live-QA sweep: this page had zero). Component instances inside
           keep their own semantics — StatusPageHeader demos legitimately
-          render <h1>, so this dev-only page has extra h1s by design. */}
-      <main>
+          render <h1>, so this dev-only page has extra h1s by design.
+          id + tabIndex: the SkipLink (root layout, P15) targets #main. */}
+      <main id="main" tabIndex={-1}>
         <GalleryAll />
 
         <div data-theme="light">

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -6,6 +6,7 @@ import {
 } from "@/design/ColorVisionProvider";
 import { ThemeProvider, themeInitScript } from "@/design/ThemeProvider";
 import { navRailInitScript } from "@/components/ui/NavRail";
+import SkipLink from "@/components/ui/SkipLink";
 import "./globals.css";
 
 // Design-system fonts (design.md §2): Inter for UI, JetBrains Mono for
@@ -53,6 +54,9 @@ export default function RootLayout({
       suppressHydrationWarning
     >
       <body>
+        {/* P15 fleet canon: first focusable on every route; targets the
+            route's single <main id="main">. */}
+        <SkipLink />
         {/* pre-paint: applies the persisted `upstat.theme` override, the
             `upstat.colorvision` mode and the rail expansion width before
             first paint — static literal scripts (theme-parity canon;

--- a/web/src/app/not-found.tsx
+++ b/web/src/app/not-found.tsx
@@ -5,7 +5,13 @@ import Link from "next/link";
  */
 export default function NotFound() {
   return (
-    <div className="font-ui flex min-h-screen flex-col items-center justify-center gap-4 bg-bg px-6 text-text">
+    // id + tabIndex: the SkipLink (root layout, P15) targets #main and
+    // moves programmatic focus there — not just a scroll jump.
+    <main
+      id="main"
+      tabIndex={-1}
+      className="font-ui flex min-h-screen flex-col items-center justify-center gap-4 bg-bg px-6 text-text"
+    >
       <p className="font-data text-[13px] text-text-2">404</p>
       <h1 className="text-[24px] font-semibold">
         This page doesn&apos;t exist.
@@ -20,6 +26,6 @@ export default function NotFound() {
       >
         Go to the dashboard
       </Link>
-    </div>
+    </main>
   );
 }

--- a/web/src/app/signin/page.tsx
+++ b/web/src/app/signin/page.tsx
@@ -24,7 +24,13 @@ export default function SignInPage() {
         data-testid="signin-screen"
         className="font-ui flex min-h-screen items-center justify-center bg-bg px-[var(--space-4)] text-text"
       >
-        <main className="flex w-full max-w-[360px] flex-col items-center gap-[var(--space-6)] text-center">
+        {/* id + tabIndex: the SkipLink (root layout, P15) targets #main and
+            moves programmatic focus there — not just a scroll jump. */}
+        <main
+          id="main"
+          tabIndex={-1}
+          className="flex w-full max-w-[360px] flex-col items-center gap-[var(--space-6)] text-center"
+        >
           <header className="flex flex-col items-center gap-[var(--space-3)]">
             <BrandMark
               wordmark

--- a/web/src/app/status/[slug]/page.tsx
+++ b/web/src/app/status/[slug]/page.tsx
@@ -22,7 +22,11 @@ export default function StatusPage() {
 
   if (loading) {
     return (
-      <main className="mx-auto flex w-full max-w-[960px] flex-col gap-4 px-6 py-10">
+      <main
+        id="main"
+        tabIndex={-1}
+        className="mx-auto flex w-full max-w-[960px] flex-col gap-4 px-6 py-10"
+      >
         <Skeleton kind="line" className="w-64" />
         <Skeleton kind="panel-axis" style={{ height: 220 }} />
       </main>
@@ -33,7 +37,11 @@ export default function StatusPage() {
     // branded 404 treatment (the app-wide not-found pattern) — public
     // surface, so the CTA points home, not into the auth-gated dashboard
     return (
-      <main className="font-ui flex min-h-screen flex-col items-center justify-center gap-4 bg-bg px-6 text-text">
+      <main
+        id="main"
+        tabIndex={-1}
+        className="font-ui flex min-h-screen flex-col items-center justify-center gap-4 bg-bg px-6 text-text"
+      >
         <p className="font-data text-[13px] text-text-2">404</p>
         <h1 className="text-[24px] font-semibold">Status page not found</h1>
         <p className="max-w-[420px] text-center text-[13px] leading-[1.45] text-text-2">
@@ -54,6 +62,8 @@ export default function StatusPage() {
 
   return (
     <main
+      id="main"
+      tabIndex={-1}
       data-testid="status-page"
       className="mx-auto flex w-full max-w-[960px] flex-col gap-6 px-6 py-10"
     >

--- a/web/src/components/docs/DocsApiView.tsx
+++ b/web/src/components/docs/DocsApiView.tsx
@@ -29,7 +29,11 @@ export function DocsApiView() {
           offsets its sticky sidebar/mobile bar below the nav and shrinks
           its viewport math to match (one coherent scroll). `isolate` opens
           a stacking context so no Scalar z-index can paint over the nav. */}
-      <main className="isolate flex-1 [--scalar-custom-header-height:57px]">
+      <main
+        id="main"
+        tabIndex={-1}
+        className="isolate flex-1 [--scalar-custom-header-height:57px]"
+      >
         <ScalarApiReferenceLazy />
       </main>
       {/* Minimal footer strip — verbatim legal line only (parity canon). */}

--- a/web/src/components/home/HomeView.tsx
+++ b/web/src/components/home/HomeView.tsx
@@ -52,7 +52,9 @@ export function HomeView() {
         onTryCloud={onTryCloud}
       />
 
-      <main>
+      {/* id + tabIndex: the SkipLink (root layout, P15) targets #main and
+          moves programmatic focus there — not just a scroll jump. */}
+      <main id="main" tabIndex={-1}>
         <HeroSection
           series={demo.latencySeries}
           query={demo.latencyQuery}


### PR DESCRIPTION
## Summary

- Fleet canon P15 (and this repo's own `SkipLink.tsx` header comment) says the skip link is the first focusable on every route. Upstat only mounted it in `web/src/app/dashboard/shell.tsx`, so marketing routes (`/`, `/signin`, `/docs/api`, public status pages, the 404) never got one, and several routes' `<main>` lacked the `id="main"` / `tabIndex={-1}` target the link points to.
- `SkipLink` now mounts once from `web/src/app/layout.tsx` (first focusable, mirroring apparule/expendit's root-layout placement byte-for-byte in intent) and the now-duplicate mount in `dashboard/shell.tsx` is removed — one skip link per page.
- Added the `id="main"` + `tabIndex={-1}` target to every route's single `<main>` that was missing it: marketing home (`HomeView.tsx`), `/signin`, `/docs/api` (`DocsApiView.tsx`), the public status page (all three render branches), the 404 page, and the dev-only component gallery. `dashboard/shell.tsx`'s `<main>` already had the correct target.
- `SkipLink.tsx` itself is untouched — still byte-identical to the fleet-shared component (sha-locked per canon).
- Extended `web/e2e/skip-link.spec.ts` to cover a marketing route (home) in addition to signin and dashboard, following the `expectSkipLinkFlow` pattern from expendit's sibling spec — including its fix for the client-side-redirect "disconnected focus node" issue (an extra `page.goto` after sign-in before asserting Tab order).

## Test plan

- [x] `cd web && npm run lint` — clean (prettier, eslint, check:boundaries)
- [x] `cd web && npm run typecheck` — clean
- [x] `cd web && npm test` — 105 test files / 370 tests passed
- [x] `cd web && npx playwright test e2e/skip-link.spec.ts` against a production build (`next build && next start`, matching CI's build mode) — 3/3 passed (home, signin, dashboard)
- [ ] Full e2e suite left to CI per host constraints (not run locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)